### PR TITLE
extract: improve .deb extraction

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -2,6 +2,7 @@
 Extraction of archives
 '''
 import os
+import glob
 import shutil
 import tempfile
 import itertools
@@ -67,17 +68,12 @@ class BaseExtractor(object):
     @classmethod
     def extract_file_deb(cls, filename, extraction_path):
         """ Extract debian packages """
-        if subprocess.call(["ar", "x", filename], cwd=extraction_path) != 0:
-            return 1
-        for filename in os.listdir(extraction_path):
-            if '.tar' in filename:
-                result = subprocess.call(
-                    ["tar", "-C", extraction_path, "-zxf",
-                     os.path.join(extraction_path, filename)])
-                os.unlink(os.path.join(extraction_path, filename))
-                if result != 0:
-                    return result
-        return 0
+        result = subprocess.call(["ar", "x", filename], cwd=extraction_path)
+        if result != 0:
+            return result
+        datafile = glob.glob(os.path.join(extraction_path, "data.tar.*"))[0]
+        result = subprocess.call(["tar", "-C", extraction_path, "-axf", datafile])
+        return result
 
     @classmethod
     def extract_file_cab(cls, filename, extraction_path):


### PR DESCRIPTION
A Debian package is an 'ar' archive with two files:
- control.tar.gz (metadata)
- data.tar.* (content)

Because cve-bin-tool only cares about the content it can skip iterating the
unpacked archives and go straight to data.tar. This file may be compressed with
a number of compressors so don't hardcode gzip, use glob to find the filename
and let tar determine how to unpack it.

Fixes #2

Signed-off-by: Ross Burton <ross.burton@intel.com>