### PR TITLE
extractor: Ensure use of absolute path

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -97,6 +97,8 @@ class TempDirExtractorContext(BaseExtractor):
 
     def extract(self, filename):
         """ Run the extractor """
+        # Resolve path in case of cwd change
+        filename = os.path.abspath(filename)
         for extractor in self.file_extractors:
             for extention in self.file_extractors[extractor]:
                 if filename[::-1].startswith(extention[::-1]):


### PR DESCRIPTION
* Some extraction methods change cwd. Paths therefore must be
  resolved to absolute paths.

Fixes: #3

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>