### PR TITLE
cil: Error if required binaries are not in path

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -22,7 +22,7 @@ import argparse
 import pkg_resources
 from collections import namedtuple
 
-from .util import DirWalk
+from .util import DirWalk, inpath
 from .extractor import Extractor
 from .NVDAutoUpdate import get_cvelist, NVDSQLite
 from .log import LOGGER
@@ -226,6 +226,14 @@ def main(argv=sys.argv, outfile=sys.stdout):
     if not os.path.isfile(args.directory) and not os.path.isdir(args.directory):
         print("Error: directory/file invalid")
         print(usage)
+        return 0
+
+    if not inpath('file'):
+        print("Error: need `file` binary in path")
+        return 0
+
+    if not inpath('strings'):
+        print("Error: need `strings` binary in path")
         return 0
 
     exclude_folders = ['.git']

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -6,6 +6,10 @@ import shutil
 import fnmatch
 import collections
 
+def inpath(binary):
+    return any(list(map(lambda dirname: os.path.isfile(os.path.join(dirname,
+        binary)), os.environ.get('PATH', '').split(':'))))
+
 class DirWalk():
     """
     for filename in DirWalk('*.c').walk(roots):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,0 +1,11 @@
+"""
+CVE-bin-tool util tests
+"""
+import unittest
+
+from cve_bin_tool.util import inpath
+
+class TestUtil(unittest.TestCase):
+
+    def test_inpath(self):
+        self.assertTrue(inpath('python'))


### PR DESCRIPTION
* Check for file and strings binaries and error out before scanning if
  not present.

Signed-off-by: John Andersen <john.s.andersen@intel.com>