### PR TITLE
find one not mapping curl CVE

### DIFF
--- a/test/binaries/test-curl-7.34.0.c
+++ b/test/binaries/test-curl-7.34.0.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+int main() {
+  printf("This program is designed to test the cve-bin-tool checker.");
+  printf("It outputs a few strings normally associated with libcurl 7.34.0.");
+  printf("They appear below this line.");
+  printf("------------------");
+  printf("An unknown option was passed in to libcurl");
+  printf("CLIENT libcurl 7.34.0");
+
+  return 0;
+}

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -84,18 +84,19 @@ class TestScanner(unittest.TestCase):
             self.assertNotIn(ensure_out, cves[package][version])
 
     def test_curl_7_34_0(self):
-	"""Scanning test-curl-7.34.0.out"""
+        """Scanning test-curl-7.34.0.out"""
         self._binary_test(
-	  'test-curl-7.34.0.out',
-	  'curl',
-	  '7.34.0',
-	  [
-	      'CVE-2019-3823',
-	      'CVE-2018-14618',
-	  ],
-	  [
-	      'CVE-2017-1000101',
-	  ])
+            'test-curl-7.34.0.out',
+            'curl',
+            '7.34.0',
+            [
+                'CVE-2019-3823',
+                'CVE-2018-14618',
+            ],
+            [
+                'CVE-2017-1000101',
+            ])
+
 
     def test_curl_7_57_0(self):
         """Scanning test-curl-7.57.0.out"""

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -84,17 +84,18 @@ class TestScanner(unittest.TestCase):
             self.assertNotIn(ensure_out, cves[package][version])
 
     def test_curl_7_34_0(self):
+	"""Scanning test-curl-7.34.0.out"""
         self._binary_test(
-    'test-curl-7.34.0.out',
-    'curl',
-    '7.34.0',
-    [
-      'CVE-2017-1000101',
-      'CVE-2019-3823',
-      'CVE-2018-14618',
-    ],
-    [
-    ])
+	  'test-curl-7.34.0.out',
+	  'curl',
+	  '7.34.0',
+	  [
+	      'CVE-2019-3823',
+	      'CVE-2018-14618',
+	  ],
+	  [
+	      'CVE-2017-1000101',
+	  ])
 
     def test_curl_7_57_0(self):
         """Scanning test-curl-7.57.0.out"""

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -83,6 +83,19 @@ class TestScanner(unittest.TestCase):
         for ensure_out in not_in:
             self.assertNotIn(ensure_out, cves[package][version])
 
+    def test_curl_7_34_0(self):
+        self._binary_test(
+    'test-curl-7.34.0.out',
+    'curl',
+    '7.34.0',
+    [
+      'CVE-2017-1000101',
+      'CVE-2019-3823',
+      'CVE-2018-14618',
+    ],
+    [
+    ])
+
     def test_curl_7_57_0(self):
         """Scanning test-curl-7.57.0.out"""
         self._binary_test(


### PR DESCRIPTION
Hi, I am interested in joining the GSOC in 2019, and I am just starting with adding test cases. I found one curl bug that is not mapped in the database.

Reference:
https://curl.haxx.se/docs/CVE-2017-1000101.html