### PR TITLE
make extract_data more pythonic

### DIFF
--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -149,21 +149,12 @@ def extract_data(nvddir):
                 # FIXME: make this more pythonic. It's very c-arrays.
                 if cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"]:
                     for x, dummy_ven in enumerate(cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"]):
-                        ver = ''
-                        k = 0
                         cve_number.append(cve_dict["CVE_Items"][i]["cve"]["CVE_data_meta"]["ID"])
                         vendor_name.append(cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["vendor_name"])
 
                         product_name.append(cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["product"]["product_data"][0]["product_name"])
-                        for j, dummy_item in enumerate(cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["product"]["product_data"][0]["version"]["version_data"]):
-                            if k == 0:
-                                ver = cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["product"]["product_data"][0]["version"]["version_data"][j]["version_value"]
-                                k = k + 1
-                            else:
-                                ver = ver + ', ' + cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["product"]["product_data"][0]["version"]["version_data"][j]["version_value"]
-                        versions.append(ver)
-                        #if cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["product"]["product_data"][0]["product_name"] == 'curl':
-                            #print ('curl found!!!' + cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["vendor_name"]+ ver)
+                        ver_list = [j["version_value"] for j in cve_dict["CVE_Items"][i]["cve"]["affects"]["vendor"]["vendor_data"][x]["product"]["product_data"][0]["version"]["version_data"]]
+                        versions.append(', '.join(ver_list))
                         if 'baseMetricV3' not in cve_dict["CVE_Items"][i]["impact"]:
                             exploitability_score.append(cve_dict["CVE_Items"][i]["impact"]["baseMetricV2"]["exploitabilityScore"])
                             impact_score.append(cve_dict["CVE_Items"][i]["impact"]["baseMetricV2"]["impactScore"])


### PR DESCRIPTION
The way that extract_data() used to get version string was C-style iteration of the list, I modified that into using join, which is more pythonic, thus the code becomes more elegant and readable in terms of Python. I have tested in both python 2 and 3, all good.