### PR TITLE
Get Coloured Output

### DIFF
--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -16,6 +16,9 @@ try:
     from urllib2 import urlopen
 except ImportError:
     from urllib.request import urlopen
+from colorama import init, Fore
+
+init()
 
 DLPAGE = "https://nvd.nist.gov/download.cfm"
 DBNAME = "nvd.vulnerabilities.db"
@@ -57,11 +60,11 @@ def get_cvelist(output, dbname, json_feed=JSON_FEED, json_zip=JSON_ZIP, **kargs)
                     file_handle.write(chunk)
             file_handle.close()
             if year in filename:
-                print("Updated current year file "+ filename)
+                print(Fore.YELLOW + "Updated current year file "+ filename)
             else:
-                print("Creating new file "+ filename)
+                print(Fore.YELLOW + "Creating new file "+ filename)
         else:
-            print("Previous year file: " + filename+" already exists")
+            print(Fore.YELLOW + "Previous year file: " + filename+" already exists")
 
     #extract_data(conn)
     cve_number, vendor_name, product_name, exploitability_score, impact_score, severity, versions = extract_data(output)
@@ -73,7 +76,7 @@ def get_cvelist(output, dbname, json_feed=JSON_FEED, json_zip=JSON_ZIP, **kargs)
 def init_database(dbname):
     """ Create new database if needed """
     if not os.path.isfile(dbname):
-        print("Database file does not exist. Initializing it")
+        print(Fore.CYAN + "Database file does not exist. Initializing it")
     conn = sqlite3.connect(dbname)
     db_cursor = conn.cursor()
     db_cursor.execute(CREATE_SYNTAX)
@@ -175,7 +178,7 @@ def extract_data(nvddir):
 
             jsonfile.close()
         except Exception as exception:
-            print("Exception in extract_data: " + str(exception))
+            print(Fore.CYAN + "Exception in extract_data: " + str(exception))
 
 
     """ Extract curl data using script """
@@ -191,7 +194,7 @@ def store_cve_data(conn, cve_number, vendor_name, product_name, exploitability_s
         try:
             cur.execute('''INSERT OR REPLACE INTO nvd_data(CVE_Number,Vendor_Name,Product_Name,Exploitability_Score,Impact_Score,Severity,version) VALUES(?,?,?,?,?,?,?)''', (cve_number[i], vendor_name[i], product_name[i], exploitability_score[i], impact_score[i], severity[i], versions[i]))
         except Exception as exception:
-            print("Exception in store_cve_data: " + str(exception))
+            print(Fore.CYAN + "Exception in store_cve_data: " + str(exception))
     lastrowid = cur.lastrowid
     conn.commit()
     return lastrowid
@@ -223,9 +226,9 @@ def get_cvelist_if_stale(nvddir, dbname):
         conn.close()
 
     else:
-        print("Last Update: " + datetime.date.fromtimestamp(os.path.getmtime(dbname)).isoformat())
-        print("Local database has been updated in the past 24h.")
-        print("New data not downloaded.  Remove old files present at {} to force the update.".format(
+        print(Fore.YELLOW + "Last Update: " + datetime.date.fromtimestamp(os.path.getmtime(dbname)).isoformat())
+        print(Fore.YELLOW + "Local database has been updated in the past 24h.")
+        print(Fore.YELLOW + "New data not downloaded.  Remove old files present at {} to force the update.".format(
             DISK_LOCATION_DEFAULT))
 
 class NVDSQLite(object):

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -20,11 +20,14 @@ import subprocess
 import logging
 import argparse
 import pkg_resources
+from colorama import init, Fore
 
 from .util import DirWalk, inpath
 from .extractor import Extractor
 from .NVDAutoUpdate import NVDSQLite
 from .log import LOGGER
+
+init()
 
 class InvalidFileError(Exception):
     """ Filepath is invalid for scanning."""
@@ -158,7 +161,7 @@ def scan_and_or_extract_file(scanner, ectx, walker, should_extract, filepath):
     # Attempt to extract the file and scan the contents
     if ectx.can_extract(filepath):
         if not should_extract:
-            print("%s is an archive. Pass " % (filepath,) + \
+            print(Fore.CYAN + "%s is an archive. Pass " % (filepath,) + \
                   "-x option to auto-extract")
             return
         for filename in walker([ectx.extract(filepath)]):
@@ -221,19 +224,19 @@ def main(argv=sys.argv, outfile=sys.stdout):
                           to use it on other operating systems.
                           **********************************************
                           """
-        print(warning_nolinux)
+        print(Fore.CYAN + warning_nolinux)
 
     if not os.path.isfile(args.directory) and not os.path.isdir(args.directory):
-        print("Error: directory/file invalid")
+        print(Fore.CYAN + "Error: directory/file invalid")
         print(usage)
         return 0
 
     if not inpath('file'):
-        print("Error: need `file` binary in path")
+        print(Fore.CYAN + "Error: need `file` binary in path")
         return 0
 
     if not inpath('strings'):
-        print("Error: need `strings` binary in path")
+        print(Fore.CYAN + "Error: need `strings` binary in path")
         return 0
 
     exclude_folders = ['.git']
@@ -246,7 +249,7 @@ def main(argv=sys.argv, outfile=sys.stdout):
 
     # Update CVE database
     if not args.quiet:
-        print("Connecting to NVD database and extracting the CVE list ... " + \
+        print(Fore.YELLOW + "Connecting to NVD database and extracting the CVE list ... " + \
               "Please hold on.. This will take few minutes... ")
     nvd = NVDSQLite()
     nvd.get_cvelist_if_stale()
@@ -267,12 +270,12 @@ def main(argv=sys.argv, outfile=sys.stdout):
 
         if (not args.quiet) and scanner.files_with_cve > 0:
             print("")
-            print("Overall CVE summary: ")
-            print("There are", scanner.files_with_cve, "files with known CVEs detected")
+            print(Fore.RED + "Overall CVE summary: ")
+            print(Fore.RED + "There are", scanner.files_with_cve, "files with known CVEs detected")
             affected_string = ', '.join(
                 map(lambda module_version: ' '.join(module_version),
                     scanner.affected()))
-            print("Known CVEs in %s:" % (affected_string,))
+            print(Fore.RED + "Known CVEs in %s:" % (affected_string,))
             output_cves(outfile, scanner.all_cves, include_details=args.verbose)
 
         # Use the number of files with known cves as error code

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+colorama


### PR DESCRIPTION
Since `cve-bin-tool` prints out a lot of things, it  becomes to difficult to differentiate between warnings/errors, information, result. 

Hence colorama has be added. 
Information in yellow, Output in red and Others in cyan

This way, I can easily locate what I am searching for.

<img width="1483" alt="screen shot 2019-02-24 at 8 50 43 am" src="https://user-images.githubusercontent.com/30733262/53294780-7c275f80-3813-11e9-810b-6e34b4b90e15.png">
<img width="1614" alt="screen shot 2019-02-24 at 8 50 28 am" src="https://user-images.githubusercontent.com/30733262/53294781-7cbff600-3813-11e9-936e-27afb05afcf9.png">
