### PR TITLE
Threading for downloading cve data

### DIFF
--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -16,6 +16,7 @@ try:
     from urllib2 import urlopen
 except ImportError:
     from urllib.request import urlopen
+import threading
 
 DLPAGE = "https://nvd.nist.gov/download.cfm"
 DBNAME = "nvd.vulnerabilities.db"
@@ -46,22 +47,17 @@ def get_cvelist(output, dbname, json_feed=JSON_FEED, json_zip=JSON_ZIP, **kargs)
     today = str(datetime.date.today())
     year = str(int(today[:4]))
 
+    threads = []
+
     # TODO Previous year files will get updated as well.
     r_feed = urlopen(json_feed, **kargs)
     for filename in re.findall(r"nvdcve-1.0-[0-9]*\.json\.zip", r_feed.read().decode('utf-8')):
-        r_file = urlopen(json_zip + filename, **kargs)
-        filepath = os.path.join(output, filename)
-        if year in filename or not os.path.exists(filepath):
-            with open(filepath, 'wb') as file_handle:
-                for chunk in r_file:
-                    file_handle.write(chunk)
-            file_handle.close()
-            if year in filename:
-                print("Updated current year file "+ filename)
-            else:
-                print("Creating new file "+ filename)
-        else:
-            print("Previous year file: " + filename+" already exists")
+        t = threading.Thread(target=download_cves, args=(filename, output, json_zip, kargs, year))
+        t.start()
+        threads.append(t)
+
+    for t in threads:
+        t.join()
 
     #extract_data(conn)
     cve_number, vendor_name, product_name, exploitability_score, impact_score, severity, versions = extract_data(output)
@@ -69,6 +65,21 @@ def get_cvelist(output, dbname, json_feed=JSON_FEED, json_zip=JSON_ZIP, **kargs)
     store_cve_data(conn, cve_number, vendor_name, product_name, exploitability_score, impact_score, severity, versions)
     #display_data(conn)
     conn.close()
+
+def download_cves(filename, output, json_zip, kargs, year):
+    r_file = urlopen(json_zip + filename, **kargs)
+    filepath = os.path.join(output, filename)
+    if year in filename or not os.path.exists(filepath):
+        with open(filepath, 'wb') as file_handle:
+            for chunk in r_file:
+                file_handle.write(chunk)
+        file_handle.close()
+        if year in filename:
+            print("Updated current year file " + filename)
+        else:
+            print("Creating new file " + filename)
+    else:
+        print("Previous year file: " + filename + " already exists")
 
 def init_database(dbname):
     """ Create new database if needed """


### PR DESCRIPTION
I was finding for ways to reduce download time of cve files and found using threads was a solution. The download time for the cve data can be significantly improved by using threads. 
I know that threading must be done safely. But since none of the threads in this PR access/work on the same resource, I think threads are safe here. 
Asynchronous programming would also have been a good solution . I wanted to use `async/await`,  but it does not work for earlier versions of python. 