### PR TITLE
Naively implement strings in pure Python

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -23,6 +23,7 @@ import pkg_resources
 
 from .util import DirWalk, inpath
 from .extractor import Extractor
+from .strings import Strings
 from .NVDAutoUpdate import NVDSQLite
 from .log import LOGGER
 
@@ -112,9 +113,11 @@ class Scanner(object):
         if ("LSB " not in o) and ("LSB shared" not in o) and ("LSB executable" not in o) and ("PE32 executable" not in o) and ("PE32+ executable" not in o) and ("Mach-O" not in o):
             return None
 
-        o = subprocess.check_output(["strings", filename])
-        if sys.version_info.major == 3:
-            o = o.decode('utf-8')
+        #o = subprocess.check_output(["strings", filename])
+        #if sys.version_info.major == 3:
+            #o = o.decode('utf-8')
+        s = Strings(filename)
+        o = s.parse()
         lines = o.split("\n")
 
     #tko

--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python3
+
+"""
+These are the customized strings and file classes, by doing this
+the tool is able to support other operating systems like Windows
+and MacOS.
+"""
+
+import sys
+
+class Strings(object):
+
+    def __init__(self, filename):
+        self.filename = filename
+        self.o = ''
+
+    def parse(self):
+        if sys.version_info.major == 3:
+            return self.parse_3()
+        else:
+            return self.parse_2()
+
+    def parse_2(self):
+        f = file(self.filename, 'rb')
+        l = f.readline()
+        tmp = ''
+        while l:
+            for c in l:
+                if ord(c) < 128:
+                    tmp += c
+                else:
+                    if tmp != '':
+                        self.o += tmp + '\n'
+                        tmp = ''
+                    
+            l = f.readline()
+        return self.o
+
+    def parse_3(self):
+        with open(self.filename, "rb") as f:
+            tmp = ''
+            for l in f:
+                for c in l:
+                    if c <= 1 or c >= 128:
+                        if tmp != '':
+                            self.o += tmp[:] + '\n'
+                            tmp = ''
+                    else:
+                        tmp += chr(c)
+        return self.o

--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -6,13 +6,14 @@ the tool is able to support other operating systems like Windows
 and MacOS.
 """
 
+import string
 import sys
 
 class Strings(object):
 
-    def __init__(self, filename):
+    def __init__(self, filename = ''):
         self.filename = filename
-        self.o = ''
+        self.output = ''
 
     def parse(self):
         if sys.version_info.major == 3:
@@ -30,11 +31,11 @@ class Strings(object):
                     tmp += c
                 else:
                     if tmp != '':
-                        self.o += tmp + '\n'
+                        self.output += tmp + '\n'
                         tmp = ''
                     
             l = f.readline()
-        return self.o
+        return self.output
 
     def parse_3(self):
         with open(self.filename, "rb") as f:
@@ -43,8 +44,8 @@ class Strings(object):
                 for c in l:
                     if c <= 1 or c >= 128:
                         if tmp != '':
-                            self.o += tmp[:] + '\n'
+                            self.output += tmp[:] + '\n'
                             tmp = ''
                     else:
                         tmp += chr(c)
-        return self.o
+        return self.output

--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -27,7 +27,8 @@ class Strings(object):
         tmp = ''
         while l:
             for c in l:
-                if ord(c) < 128:
+                # remove all unprintable characters
+                if ord(c) < 128 and ord(c) > 31:
                     tmp += c
                 else:
                     if tmp != '':
@@ -42,7 +43,8 @@ class Strings(object):
             tmp = ''
             for l in f:
                 for c in l:
-                    if c <= 1 or c >= 128:
+                    # remove all unprintable characters
+                    if c <= 31 or c >= 128:
                         if tmp != '':
                             self.output += tmp[:] + '\n'
                             tmp = ''

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -2,6 +2,7 @@
 CVE-bin-tool Strings tests
 """
 import os
+import sys
 import unittest
 import subprocess
 
@@ -22,12 +23,16 @@ class TestStrings(unittest.TestCase):
         cls.strings = Strings()
 
     def _parse_test(self, filename):
-        """Helper function to parse a binary file and check whether 
+        """Helper function to parse a binary file and check whether
         the given string is in the parsed result"""
         self.strings.filename = os.path.join(BINARIES_PATH, filename)
-        filename = filename[5:-4]
-        filename = filename.replace("-", " ", 1) 
-        self.assertIn(filename, self.strings.parse())
+        binutils_strings = subprocess.check_output(['strings',
+                                                    self.strings.filename])
+        ours = self.strings.parse().split('\n')
+        for theirs in binutils_strings.split(b'\n' \
+                                             if sys.version_info.major == 3 \
+                                             else '\n'):
+            self.assertIn(theirs.decode('utf-8'), ours)
 
     def test_curl_7_34_0(self):
         """Stringsing test-curl-7.34.0.out"""

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -1,0 +1,36 @@
+"""
+CVE-bin-tool Strings tests
+"""
+import os
+import unittest
+import subprocess
+
+from cve_bin_tool.strings import Strings
+
+BINARIES_PATH = os.path.join(
+    os.path.abspath(os.path.dirname(__file__)), 'binaries')
+
+
+class TestStrings(unittest.TestCase):
+    """ Tests the CVE Bin Tool Strings"""
+
+    @classmethod
+    def setUpClass(cls):
+        # build binaries
+        subprocess.call(["make", "clean"], cwd=BINARIES_PATH)
+        subprocess.call(["make", "all"], cwd=BINARIES_PATH)
+        cls.strings = Strings()
+
+    def _parse_test(self, filename):
+        """Helper function to parse a binary file and check whether 
+        the given string is in the parsed result"""
+        self.strings.filename = os.path.join(BINARIES_PATH, filename)
+        self.assertIn(filename[:-4], self.strings.parse())
+
+    def test_curl_7_34_0(self):
+        """Stringsing test-curl-7.34.0.out"""
+        self._parse_test('test-curl-7.34.0.out')
+
+    def test_kerberos_1_15_1(self):
+        """Stringsing test-kerberos-5-1.15.1.out"""
+        self._parse_test('test-kerberos-5-1.15.1.out')

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -25,7 +25,9 @@ class TestStrings(unittest.TestCase):
         """Helper function to parse a binary file and check whether 
         the given string is in the parsed result"""
         self.strings.filename = os.path.join(BINARIES_PATH, filename)
-        self.assertIn(filename[:-4], self.strings.parse())
+        filename = filename[5:-4]
+        filename = filename.replace("-", " ", 1) 
+        self.assertIn(filename, self.strings.parse())
 
     def test_curl_7_34_0(self):
         """Stringsing test-curl-7.34.0.out"""


### PR DESCRIPTION
I have read the source code of `strings.c`, and I found it is reading each character in the file per se rather than trying to parse the file, which means categorizing each character and if it is a legal utf-8 character, adding it to the output. However, Python is hard to do that since it treats those differently with bash and neither `encode` nor `decode` could work. Finally I got my naive version of strings based on that, which is able to run.

Of course this has many deficiencies such as unnecessarily added many garbage into `o` and it is potentially able to overflow buffers.

Any thoughts for the improvement would be appreciated.