### PR TITLE
Add list of checkers to usage; improve error output

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -75,6 +75,13 @@ class Scanner(object):
             checkers[checker_name] = (checker, vendor_package_pairs)
         return checkers
 
+    @classmethod
+    def available_checkers(cls):
+        checkers = pkg_resources.iter_entry_points(cls.CHECKER_ENTRYPOINT)
+        checker_list = [item.name for item in checkers]
+        return checker_list
+
+
     def remove_skiplist(self, skips=None, quiet=False):
         # Take out any checkers that are on the skip list
         # (string of comma-delimited checker names)
@@ -234,9 +241,10 @@ def output_cves(outfile, modules, include_details=False):
 def main(argv=sys.argv, outfile=sys.stdout):
     """ Scan a binary file for certain open source libraries that may have CVEs """
     parser = argparse.ArgumentParser(
+            prog='cve-bin-tool',
             description="The CVE Binary Tool scans for a number of common, vulnerable open source components (openssl, libpng, libxml2, expat and a few others) to let you know if a given directory or binary file includes common libraries with known vulnerabilities.",
 
-            epilog="Please disclose issues responsibly!")
+            epilog="Available Checkers: {} \n Please disclose issues responsibly!".format(', '.join(Scanner.available_checkers())))
     parser.add_argument("directory",
                         help="directory to scan")
     parser.add_argument('-x', "--extract", action="store_true",
@@ -256,7 +264,6 @@ def main(argv=sys.argv, outfile=sys.stdout):
         parser.print_help()
         return 0
 
-
     args = parser.parse_args(argv[1:])
 
     logging.basicConfig(level=args.log_level)
@@ -273,16 +280,16 @@ def main(argv=sys.argv, outfile=sys.stdout):
 
     if not os.path.isfile(args.directory) and not os.path.isdir(args.directory):
         print("Error: directory/file invalid")
-        parser.print_help()
-        return 0
+        parser.print_usage()
+        return -1
 
     if not inpath('file'):
         print("Error: need `file` binary in path")
-        return 0
+        return -10
 
     if not inpath('strings'):
         print("Error: need `strings` binary in path")
-        return 0
+        return -11
 
     exclude_folders = ['.git']
     walker = DirWalk(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -46,4 +46,4 @@ class TestCLI(TempDirTest):
 
     def test_invalid_file_or_directory(self):
         """ Test behaviour with an invalid file/directory """
-        self.assertEqual(main(['cve-bin-tool', 'non-existant']), 0)
+        self.assertEqual(main(['cve-bin-tool', 'non-existant']), -1)


### PR DESCRIPTION
- Made the list of checkers available when you do -h or run with no arguments
- made the error cases return negative numbers to use as error codes (positive returns indicate the # of files with CVEs, 0 indicates all is well and nothing was found)
