### PR TITLE
Better error messages in extraction tests

### DIFF
--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -12,6 +12,7 @@ from .test_definitions import download_file, \
                               CURL_7_20_0_URL, \
                               VMWARE_CAB, \
                               TMUX_DEB
+from cve_bin_tool.util import inpath
 if sys.version_info.major == 3 and sys.version_info.minor >= 3:
     import lzma
 
@@ -53,6 +54,7 @@ class TestExtractor(TestExtractorBase):
 class TestExtractFileTar(TestExtractorBase):
     """ Tetss for tar file extraction """
     def setUp(self):
+        self.assertTrue(inpath('tar'), "Required tool 'tar' not found")
         for filename, tarmode in [('test.tgz', 'w:gz'),
                                   ('test.tar.gz', 'w:gz'),
                                   ('test.tar.bz2', 'w:bz2'),
@@ -96,6 +98,8 @@ class TestExtractFileTar(TestExtractorBase):
 class TestExtractFileRpm(TestExtractorBase):
     """ Tests for the rpm file extractor """
     def setUp(self):
+        self.assertTrue(inpath("rpm2cpio"), msg="Required tool 'rpm2cpio' not found")
+        self.assertTrue(inpath("cpio"), msg="Required tool 'cpio' not found")
         download_file(CURL_7_20_0_URL, os.path.join(self.tempdir, 'test.rpm'))
 
     def test_extract_file_rpm(self):
@@ -110,6 +114,7 @@ class TestExtractFileRpm(TestExtractorBase):
 class TestExtractFileDeb(TestExtractorBase):
     """ Tests for deb file extractor """
     def setUp(self):
+        self.assertTrue(inpath("ar"), msg="Required tool 'ar' not found")
         download_file(TMUX_DEB, os.path.join(self.tempdir, 'test.deb'))
         shutil.copyfile(os.path.join(self.tempdir, 'test.deb'),
                         os.path.join(self.tempdir, 'test.ipk'))
@@ -126,6 +131,7 @@ class TestExtractFileDeb(TestExtractorBase):
 class TestExtractFileCab(TestExtractorBase):
     """ Tests for the cab file extractor """
     def setUp(self):
+        self.assertTrue(inpath('cabextract'), msg="Required tool 'cabextract' not found")
         download_file(VMWARE_CAB, os.path.join(self.tempdir, 'test.cab'))
 
     def test_extract_file_cab(self):
@@ -142,6 +148,7 @@ class TestExtractFileZip(TestExtractorBase):
         This extractor also handles jar, apk, and sometimes exe files
         when the exe is a self-extracting zipfile """
     def setUp(self):
+        self.assertTrue(inpath('unzip'), msg="Required tool 'unzip' not found")
         for filename in ['test.exe', 'test.zip', 'test.jar', 'test.apk']:
             zippath = os.path.join(self.tempdir, filename)
             with ZipFile(zippath, 'w') as zipfile:


### PR DESCRIPTION
* check to see if required utilities exist (e.g. rpm, ar, unzip) before downloading files for extraction tests
* error messages now indicate that test failure is due to missing utility
* fixes #145 (well, it addresses the issue -- the test still fails but it's more obvious what's going on)
