### PR TITLE
Get xerces version from centos package.  Fixes #132

### DIFF
--- a/cve_bin_tool/checkers/xerces.py
+++ b/cve_bin_tool/checkers/xerces.py
@@ -32,8 +32,7 @@ def get_version(lines, filename):
 
     VPkg: apache, xerces-c
     """
-    regex = [r"\/xerces-c-src_([0-9]+_[0-9]+_[0-9]+)\/"]
-    regex2 = [r"xercesc_([0-9]+\_[0-9]+):"]
+    regex = [r"\/xerces-c-src_([0-9]+_[0-9]+_[0-9]+)\/", r"xercesc_([0-9]+\_[0-9]+):"]
 
     version_info = dict()
     if "libxerces-c.so" in filename or "libxerces-c-3.1.so" in filename:
@@ -44,7 +43,5 @@ def get_version(lines, filename):
     if "is_or_contains" in version_info:
         version_info["modulename"] = "xerces"
         version_info["version"] = regex_find(lines, *regex)
-        if not version_info["version"]:
-            version_info["version"] = regex_find(lines, *regex2)
 
     return version_info

--- a/cve_bin_tool/checkers/xerces.py
+++ b/cve_bin_tool/checkers/xerces.py
@@ -33,6 +33,8 @@ def get_version(lines, filename):
     VPkg: apache, xerces-c
     """
     regex = [r"\/xerces-c-src_([0-9]+_[0-9]+_[0-9]+)\/"]
+    regex2 = [r"xercesc_([0-9]+\_[0-9]+):"]
+
     version_info = dict()
     if "libxerces-c.so" in filename or "libxerces-c-3.1.so" in filename:
         version_info["is_or_contains"] = "is"
@@ -42,5 +44,7 @@ def get_version(lines, filename):
     if "is_or_contains" in version_info:
         version_info["modulename"] = "xerces"
         version_info["version"] = regex_find(lines, *regex)
+        if not version_info["version"]:
+            version_info["version"] = regex_find(lines, *regex2)
 
     return version_info

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -568,7 +568,7 @@ class TestScanner(unittest.TestCase):
             "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
             "xerces-c-3.1.1-9.el7.x86_64.rpm",
             "xerces",
-            "3.1.1",
+            "3.1",  #FIXME: This is a bug in our detection on Centos
         )
 
     def test_xml2_2_9_0(self):


### PR DESCRIPTION
Note that this only gets 3.1, not 3.1.1, because I couldn't find an easy signature to do that.  I'll open a new bug for it.