### PR TITLE
Use correct libexpat file for debian test (fixes #126)

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -213,7 +213,7 @@ class TestScanner(unittest.TestCase):
         """ Test detection of expat 2.2 debian package """
         self._file_test(
             "http://http.us.debian.org/debian/pool/main/e/expat/",
-            "expat_2.2.0-2+deb9u1_amd64.deb",
+            "libexpat1_2.2.0-2+deb9u1_amd64.deb",
             "expat",
             "2.2.0",
         )


### PR DESCRIPTION
Turns out that the "expat" package on debian is an example app and doesn't contain the library we're trying to detect.  We should have been testing against "libexpat" so this updates the test.