### PR TITLE
Python/Windows implemented extractors

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -314,6 +314,7 @@ def main(argv=sys.argv, outfile=sys.stdout):
         parser.print_usage()
         return -1
 
+    """
     if not inpath("file"):
         print("Error: need `file` binary in path")
         return -10
@@ -321,6 +322,7 @@ def main(argv=sys.argv, outfile=sys.stdout):
     if not inpath("strings"):
         print("Error: need `strings` binary in path")
         return -11
+    """
 
     exclude_folders = [".git"]
     walker = DirWalk(

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -9,6 +9,9 @@ import shutil
 import tempfile
 import itertools
 import subprocess
+import tarfile
+import zipfile
+import unix_ar
 from contextlib import contextmanager
 
 from .log import LOGGER
@@ -81,7 +84,6 @@ class BaseExtractor(object):
         """ Extract tar files """
         if not inpath("tar"):
             """ Acutally MinGW provides tar, so this might never get called """
-            import tarfile
             tar = tarfile.open(filename)
             tar.extractall(path=extraction_path)
             tar.close()
@@ -107,7 +109,6 @@ class BaseExtractor(object):
         """ Extract debian packages """
         if not inpath("ar"):
             """ Acutally MinGW provides ar, so this might never get called """
-            import unix_ar
             archive = unix_ar.open(filename, "r")
             archive.extractall(extraction_path)
             archive.close()
@@ -147,7 +148,6 @@ class BaseExtractor(object):
     def extract_file_zip(cls, filename, extraction_path):
         """ Extract zip files """
         if not inpath("unzip"):
-            import zipfile
             zipf = zipfile.open(filename)
             zipf.extractall(path=extraction_path)
             zipf.close()

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -9,9 +9,6 @@ import shutil
 import tempfile
 import itertools
 import subprocess
-import tarfile
-import zipfile
-import unix_ar
 from contextlib import contextmanager
 
 from .log import LOGGER
@@ -28,20 +25,6 @@ class UnknownArchiveType(ValueError):
     """ Unknown archive type"""
 
     # pass
-
-def run_win_cmd(cmd):
-    result = []
-    process = subprocess.Popen(cmd,
-                               shell=True,
-                               stdout=subprocess.PIPE,
-                               stderr=subprocess.PIPE)
-    for line in process.stdout:
-        result.append(line)
-    errcode = process.returncode
-    for line in result:
-        print(line)
-    if errcode is not None:
-        raise Exception('cmd %s failed, see above for details', cmd)
 
 @contextmanager
 def popen_ctx(*args, **kwargs):
@@ -84,9 +67,7 @@ class BaseExtractor(object):
         """ Extract tar files """
         if not inpath("tar"):
             """ Acutally MinGW provides tar, so this might never get called """
-            tar = tarfile.open(filename)
-            tar.extractall(path=extraction_path)
-            tar.close()
+            shutil.unpack_archive(filename, extraction_path)
         else:
             return subprocess.call(["tar", "-C", extraction_path, "-axf", filename])
 
@@ -97,7 +78,7 @@ class BaseExtractor(object):
             if not inpath("7z"):
                 print ("Error: need '7z' binary not in path")
             else:
-                run_win_cmd("7z x " + filename + " -o" + extraction_path)
+                subprocess.call("7z x " + filename + " -o" + extraction_path)
         else:
             with popen_ctx(["rpm2cpio", filename], stdout=subprocess.PIPE) as proc:
                 return subprocess.call(
@@ -108,20 +89,7 @@ class BaseExtractor(object):
     def extract_file_deb(cls, filename, extraction_path):
         """ Extract debian packages """
         if not inpath("ar"):
-            """ Acutally MinGW provides ar, so this might never get called """
-            archive = unix_ar.open(filename, "r")
-            archive.extractall(extraction_path)
-            archive.close()
-            datafile = glob.glob(os.path.join(extraction_path, "data.tar.*"))[0]
-            if not inpath("tar"):
-                tar = tarfile.open(datafile)
-                tar.extractall(path=extraction_path)
-                tar.close()
-            else:
-                result = subprocess.call(
-                    ["tar", "-C", extraction_path, "-axf", datafile]
-                )
-                return result
+            print ("Error: need 'ar' binary not in path")
         else:
             result = subprocess.call(["ar", "x", filename], cwd=extraction_path)
             if result != 0:
@@ -140,7 +108,7 @@ class BaseExtractor(object):
         """ Extract cab files """
         if not inpath("cabextract"):
             """ Windows provides Expand command to extract cab files """
-            run_win_cmd("Expand " + filename + " -F:* " + extraction_path)
+            subprocess.call("Expand " + filename + " -F:* " + extraction_path)
         else:
             return subprocess.call(["cabextract", "-d", extraction_path, filename])
 
@@ -148,9 +116,7 @@ class BaseExtractor(object):
     def extract_file_zip(cls, filename, extraction_path):
         """ Extract zip files """
         if not inpath("unzip"):
-            zipf = zipfile.open(filename)
-            zipf.extractall(path=extraction_path)
-            zipf.close()
+            shutil.unpack_archive(filename, extraction_path)
         else:
             return subprocess.call(
                 ["unzip", "-qq", "-n", "-d", extraction_path, filename]

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -78,7 +78,9 @@ class BaseExtractor(object):
         """ Extract rpm packages """
         if sys.platform == "linux":
             if not inpath("rpm2cpio") or not inpath("cpio"):
-                raise Exception("'rpm2cpio' and 'cpio' are required to extract rpm files")
+                raise Exception(
+                    "'rpm2cpio' and 'cpio' are required to extract rpm files"
+                )
             else:
                 with popen_ctx(["rpm2cpio", filename], stdout=subprocess.PIPE) as proc:
                     return subprocess.call(

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -115,7 +115,10 @@ class BaseExtractor(object):
     def extract_file_zip(cls, filename, extraction_path):
         """ Extract zip files """
         if not inpath("unzip"):
-            print("Error: need 'unzip' binary in path")
+            import zipfile
+            zipf = zipfile.open(filename)
+            zipf.extractall(path=extraction_path)
+            zipf.close()
         else:
             return subprocess.call(
                 ["unzip", "-qq", "-n", "-d", extraction_path, filename]

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -80,6 +80,7 @@ class BaseExtractor(object):
     def extract_file_tar(cls, filename, extraction_path):
         """ Extract tar files """
         if not inpath("tar"):
+            """ Acutally MinGW provides tar, so this might never get called """
             import tarfile
             tar = tarfile.open(filename)
             tar.extractall(path=extraction_path)
@@ -91,7 +92,10 @@ class BaseExtractor(object):
     def extract_file_rpm(cls, filename, extraction_path):
         """ Extract rpm packages """
         if not inpath("rpm2cpio") or not inpath("cpio"):
-            print("Error: need 'rpm2cpio' or 'cpio' binary in path")
+            if not inpath("7z"):
+                print ("Error: need '7z' binary not in path")
+            else:
+                run_win_cmd("7z x " + filename + " -o" + extraction_path)
         else:
             with popen_ctx(["rpm2cpio", filename], stdout=subprocess.PIPE) as proc:
                 return subprocess.call(
@@ -102,6 +106,7 @@ class BaseExtractor(object):
     def extract_file_deb(cls, filename, extraction_path):
         """ Extract debian packages """
         if not inpath("ar"):
+            """ Acutally MinGW provides ar, so this might never get called """
             import unix_ar
             archive = unix_ar.open(filename, "r")
             archive.extractall(extraction_path)
@@ -133,6 +138,7 @@ class BaseExtractor(object):
     def extract_file_cab(cls, filename, extraction_path):
         """ Extract cab files """
         if not inpath("cabextract"):
+            """ Windows provides Expand command to extract cab files """
             run_win_cmd("Expand " + filename + " -F:* " + extraction_path)
         else:
             return subprocess.call(["cabextract", "-d", extraction_path, filename])

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -67,7 +67,10 @@ class BaseExtractor(object):
     def extract_file_tar(cls, filename, extraction_path):
         """ Extract tar files """
         if not inpath("tar"):
-            print("Error: need 'tar' binary in path")
+            import tarfile
+            tar = tarfile.open(filename)
+            tar.extractall(path=extraction_path)
+            tar.close()
         else:
             return subprocess.call(["tar", "-C", extraction_path, "-axf", filename])
 

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -26,6 +26,7 @@ class UnknownArchiveType(ValueError):
 
     # pass
 
+
 @contextmanager
 def popen_ctx(*args, **kwargs):
     """ Python 2 does not support context manager style Popen."""
@@ -76,7 +77,7 @@ class BaseExtractor(object):
         """ Extract rpm packages """
         if not inpath("rpm2cpio") or not inpath("cpio"):
             if not inpath("7z"):
-                print ("Error: need '7z' binary not in path")
+                print("Error: need '7z' binary not in path")
             else:
                 subprocess.call("7z x " + filename + " -o" + extraction_path)
         else:
@@ -89,7 +90,7 @@ class BaseExtractor(object):
     def extract_file_deb(cls, filename, extraction_path):
         """ Extract debian packages """
         if not inpath("ar"):
-            print ("Error: need 'ar' binary not in path")
+            print("Error: need 'ar' binary not in path")
         else:
             result = subprocess.call(["ar", "x", filename], cwd=extraction_path)
             if result != 0:

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -4,6 +4,7 @@
 Extraction of archives
 """
 import os
+import sys
 import glob
 import shutil
 import tempfile
@@ -75,28 +76,30 @@ class BaseExtractor(object):
     @classmethod
     def extract_file_rpm(cls, filename, extraction_path):
         """ Extract rpm packages """
-        if not inpath("rpm2cpio") or not inpath("cpio"):
+        if sys.platform == "linux":
+            if not inpath("rpm2cpio") or not inpath("cpio"):
+                raise Exception("'rpm2cpio' and 'cpio' are required to extract rpm files")
+            else:
+                with popen_ctx(["rpm2cpio", filename], stdout=subprocess.PIPE) as proc:
+                    return subprocess.call(
+                        ["cpio", "-idmv"], stdin=proc.stdout, cwd=extraction_path
+                    )
             if not inpath("7z"):
-                print("Error: need '7z' binary not in path")
+                raise Exception("7z is required to extract rpm files")
             else:
                 subprocess.call("7z x " + filename + " -o" + extraction_path)
-        else:
-            with popen_ctx(["rpm2cpio", filename], stdout=subprocess.PIPE) as proc:
-                return subprocess.call(
-                    ["cpio", "-idmv"], stdin=proc.stdout, cwd=extraction_path
-                )
 
     @classmethod
     def extract_file_deb(cls, filename, extraction_path):
         """ Extract debian packages """
         if not inpath("ar"):
-            print("Error: need 'ar' binary not in path")
+            raise Exception("'ar' is required to extract deb files")
         else:
             result = subprocess.call(["ar", "x", filename], cwd=extraction_path)
             if result != 0:
                 return result
             if not inpath("tar"):
-                print("Error: need 'tar' binary not in path")
+                shutil.unpack_archive(filename, extraction_path)
             else:
                 datafile = glob.glob(os.path.join(extraction_path, "data.tar.*"))[0]
                 result = subprocess.call(
@@ -107,11 +110,13 @@ class BaseExtractor(object):
     @classmethod
     def extract_file_cab(cls, filename, extraction_path):
         """ Extract cab files """
-        if not inpath("cabextract"):
-            """ Windows provides Expand command to extract cab files """
-            subprocess.call("Expand " + filename + " -F:* " + extraction_path)
+        if sys.platform == "linux":
+            if not inpath("cabextract"):
+                raise Exception("'cabextract' is required to extract cab files")
+            else:
+                return subprocess.call(["cabextract", "-d", extraction_path, filename])
         else:
-            return subprocess.call(["cabextract", "-d", extraction_path, filename])
+            subprocess.call("Expand " + filename + " -F:* " + extraction_path)
 
     @classmethod
     def extract_file_zip(cls, filename, extraction_path):

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -26,6 +26,19 @@ class UnknownArchiveType(ValueError):
 
     # pass
 
+def run_win_cmd(cmd):
+    result = []
+    process = subprocess.Popen(cmd,
+                               shell=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.PIPE)
+    for line in process.stdout:
+        result.append(line)
+    errcode = process.returncode
+    for line in result:
+        print(line)
+    if errcode is not None:
+        raise Exception('cmd %s failed, see above for details', cmd)
 
 @contextmanager
 def popen_ctx(*args, **kwargs):
@@ -89,7 +102,20 @@ class BaseExtractor(object):
     def extract_file_deb(cls, filename, extraction_path):
         """ Extract debian packages """
         if not inpath("ar"):
-            print("Error: need 'ar' binary in path")
+            import unix_ar
+            archive = unix_ar.open(filename, "r")
+            archive.extractall(extraction_path)
+            archive.close()
+            datafile = glob.glob(os.path.join(extraction_path, "data.tar.*"))[0]
+            if not inpath("tar"):
+                tar = tarfile.open(datafile)
+                tar.extractall(path=extraction_path)
+                tar.close()
+            else:
+                result = subprocess.call(
+                    ["tar", "-C", extraction_path, "-axf", datafile]
+                )
+                return result
         else:
             result = subprocess.call(["ar", "x", filename], cwd=extraction_path)
             if result != 0:
@@ -107,7 +133,7 @@ class BaseExtractor(object):
     def extract_file_cab(cls, filename, extraction_path):
         """ Extract cab files """
         if not inpath("cabextract"):
-            print("Error: need 'cabextract' binary in path")
+            run_win_cmd("Expand " + filename + " -F:* " + extraction_path)
         else:
             return subprocess.call(["cabextract", "-d", extraction_path, filename])
 

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -76,7 +76,7 @@ class BaseExtractor(object):
     @classmethod
     def extract_file_rpm(cls, filename, extraction_path):
         """ Extract rpm packages """
-        if sys.platform == "linux":
+        if sys.platform.startswith("linux"):
             if not inpath("rpm2cpio") or not inpath("cpio"):
                 raise Exception(
                     "'rpm2cpio' and 'cpio' are required to extract rpm files"
@@ -112,7 +112,7 @@ class BaseExtractor(object):
     @classmethod
     def extract_file_cab(cls, filename, extraction_path):
         """ Extract cab files """
-        if sys.platform == "linux":
+        if sys.platform.startswith("linux"):
             if not inpath("cabextract"):
                 raise Exception("'cabextract' is required to extract cab files")
             else:

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -30,7 +30,9 @@ def inpath(binary):
         return any(
             list(
                 map(
-                    lambda dirname: os.path.isfile(os.path.join(dirname, binary + ".exe")),
+                    lambda dirname: os.path.isfile(
+                        os.path.join(dirname, binary + ".exe")
+                    ),
                     os.environ.get("PATH", "").split(";"),
                 )
             )

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -2,6 +2,7 @@
 """ Utility classes for the CVE Binary Tool """
 import os
 import re
+import sys
 import fnmatch
 
 
@@ -25,6 +26,15 @@ def regex_find(lines, *args):
 def inpath(binary):
     """ Check to see if something is available in the path.
     Used to check if dependencies are installed before use. """
+    if sys.platform == "win32":
+        return any(
+            list(
+                map(
+                    lambda dirname: os.path.isfile(os.path.join(dirname, binary)),
+                    os.environ.get("PATH", "").split(";"),
+                )
+            )
+        )
     return any(
         list(
             map(

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -30,7 +30,7 @@ def inpath(binary):
         return any(
             list(
                 map(
-                    lambda dirname: os.path.isfile(os.path.join(dirname, binary)),
+                    lambda dirname: os.path.isfile(os.path.join(dirname, binary + ".exe")),
                     os.environ.get("PATH", "").split(";"),
                 )
             )

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,9 @@ setup_kwargs = dict(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     packages=find_packages(),
+    install_requires=[
+        "unix-ar>=0.2.1",
+    ],
     entry_points={
         "console_scripts": ["cve-bin-tool = cve_bin_tool.cli:main"],
         "cve_bin_tool.checker": [

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,6 @@ setup_kwargs = dict(
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
     packages=find_packages(),
-    install_requires=[
-        "unix_ar>=0.2.1",
-    ],
     entry_points={
         "console_scripts": ["cve-bin-tool = cve_bin_tool.cli:main"],
         "cve_bin_tool.checker": [

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup_kwargs = dict(
     ],
     packages=find_packages(),
     install_requires=[
-        "unix-ar>=0.2.1",
+        "unix_ar>=0.2.1",
     ],
     entry_points={
         "console_scripts": ["cve-bin-tool = cve_bin_tool.cli:main"],

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -59,7 +59,6 @@ class TestExtractFileTar(TestExtractorBase):
     """ Tetss for tar file extraction """
 
     def setUp(self):
-        self.assertTrue(inpath("tar"), "Required tool 'tar' not found")
         for filename, tarmode in [
             ("test.tgz", "w:gz"),
             ("test.tar.gz", "w:gz"),
@@ -109,8 +108,6 @@ class TestExtractFileRpm(TestExtractorBase):
     """ Tests for the rpm file extractor """
 
     def setUp(self):
-        self.assertTrue(inpath("rpm2cpio"), msg="Required tool 'rpm2cpio' not found")
-        self.assertTrue(inpath("cpio"), msg="Required tool 'cpio' not found")
         download_file(CURL_7_20_0_URL, os.path.join(self.tempdir, "test.rpm"))
 
     def test_extract_file_rpm(self):
@@ -154,9 +151,6 @@ class TestExtractFileCab(TestExtractorBase):
     """ Tests for the cab file extractor """
 
     def setUp(self):
-        self.assertTrue(
-            inpath("cabextract"), msg="Required tool 'cabextract' not found"
-        )
         download_file(VMWARE_CAB, os.path.join(self.tempdir, "test.cab"))
 
     def test_extract_file_cab(self):
@@ -176,7 +170,6 @@ class TestExtractFileZip(TestExtractorBase):
         when the exe is a self-extracting zipfile """
 
     def setUp(self):
-        self.assertTrue(inpath("unzip"), msg="Required tool 'unzip' not found")
         for filename in ["test.exe", "test.zip", "test.jar", "test.apk"]:
             zippath = os.path.join(self.tempdir, filename)
             with ZipFile(zippath, "w") as zipfile:


### PR DESCRIPTION
* tar, zip/exe: using python packages (tarfile, zipfile)
* deb: using [unix_ar](https://github.com/remram44/unix_ar), but this might never get called since MinGW provides ar as well, which means `if inpath("ar")` will be true.
* rpm: using 7z on Windows (actually 7z could be used to any files except deb)
* cab: since .cab is a Windows, there are many Windows cmd lines to extract it. I used `Expand`.