### PR TITLE
Set explicit directory permissions at creation time

### DIFF
--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -50,7 +50,7 @@ def get_cvelist(
 ):
     """ Get list of CVEs and add to the database """
     if not os.path.exists(output):
-        os.makedirs(output)
+        os.makedirs(output, 0o750)
     conn = init_database(dbname, quiet)
 
     today = str(datetime.date.today())

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -151,7 +151,7 @@ class TempDirExtractorContext(BaseExtractor):
                     )
                     if os.path.exists(extracted_path):
                         shutil.rmtree(extracted_path)
-                    os.makedirs(extracted_path)
+                    os.makedirs(extracted_path, 0o700)
                     if extractor(filename, extracted_path) != 0:
                         if self.raise_failure:
                             raise ExtractionFailed(filename)

--- a/test/test_nvd.py
+++ b/test/test_nvd.py
@@ -167,6 +167,21 @@ class TestNVDSQLite(unittest.TestCase):
             self.assertEqual(os.stat(self.nvd.dbname).st_mode & stat.S_IXOTH, 0)
             self.assertEqual(os.stat(self.nvd.dbname).st_mode & stat.S_IWOTH, 0)
 
+    def test_dir_permissions(self):
+        """ Test directory permissions on the directory containing the nvd db """
+        directory = os.path.dirname(self.nvd.dbname)
+
+        with self.nvd:
+            # User should be able to read/write/execute the directory
+            self.assertNotEqual(os.stat(directory).st_mode & stat.S_IRUSR, 0)
+            self.assertNotEqual(os.stat(directory).st_mode & stat.S_IWUSR, 0)
+            self.assertNotEqual(os.stat(directory).st_mode & stat.S_IXUSR, 0)
+
+            # Others should not
+            self.assertEqual(os.stat(directory).st_mode & stat.S_IROTH, 0)
+            self.assertEqual(os.stat(directory).st_mode & stat.S_IWOTH, 0)
+            self.assertEqual(os.stat(directory).st_mode & stat.S_IXOTH, 0)
+
     def test_get_cves(self):
         """ Test that you can get cves from the nvd database """
         check = [("CVE-001", "example0", "app0"), ("CVE-002", "example1", "app1")]


### PR DESCRIPTION
Our internal checklist encourages us to set directory permissions explicitly rather than relying on defaults, so that's what this patch is about.  the nvd directory is public info, so it *could* be 755 if we want, but I couldn't really think of too many cases where anyone would care so I defaulted to a less permissive 750.