### PR TITLE
Add xml2 file tests for the rpms on the xmlsoft website

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -648,6 +648,48 @@ class TestScanner(unittest.TestCase):
             "2.9.8",
         )
 
+    @unittest.skipUnless(os.getenv("LONG_TESTS") == "1", "Skipping long tests")
+    def test_xml2_rpm_all(self):
+        """ Test detection of 32 xml2 binaries on the xmlsoft download page.
+        (All the binaries as of the time this test was written) """
+        rpmlist = [
+            ["libxml2-2.7.2-1.x86_64.rpm", "2.7.2"],
+            ["libxml2-2.7.3-1.x86_64.rpm", "2.7.3"],
+            ["libxml2-2.7.4-1.x86_64.rpm", "2.7.4"],
+            ["libxml2-2.7.5-1.x86_64.rpm", "2.7.5"],
+            ["libxml2-2.7.6-1.x86_64.rpm", "2.7.6"],
+            ["libxml2-2.7.7-1.x86_64.rpm", "2.7.7"],
+            ["libxml2-2.7.8-1.x86_64.rpm", "2.7.8"],
+            ["libxml2-2.8.0-1.x86_64.rpm", "2.8.0"],
+            ["libxml2-2.9.0-0rc0.x86_64.rpm", "2.9.0"],
+            ["libxml2-2.9.0-0rc1.x86_64.rpm", "2.9.0"],
+            ["libxml2-2.9.0-0rc2.x86_64.rpm", "2.9.0"],
+            ["libxml2-2.9.0-1.x86_64.rpm", "2.9.0"],
+            ["libxml2-2.9.1-1.fc17.x86_64.rpm", "2.9.1"],
+            ["libxml2-2.9.2-0rc1.fc19.x86_64.rpm", "2.9.2"],
+            ["libxml2-2.9.2-0rc2.fc19.x86_64.rpm", "2.9.2"],
+            ["libxml2-2.9.2-1.fc19.x86_64.rpm", "2.9.2"],
+            ["libxml2-2.9.3-1.fc23.x86_64.rpm", "2.9.3"],
+            ["libxml2-2.9.4-0rc1.fc23.x86_64.rpm", "2.9.4"],
+            ["libxml2-2.9.4-0rc2.fc23.x86_64.rpm", "2.9.4"],
+            ["libxml2-2.9.4-1.fc23.x86_64.rpm", "2.9.4"],
+            ["libxml2-2.9.5-0rc1.fc24.x86_64.rpm", "2.9.5"],
+            ["libxml2-2.9.5-0rc2.fc24.x86_64.rpm", "2.9.5"],
+            ["libxml2-2.9.5-1.fc24.x86_64.rpm", "2.9.5"],
+            ["libxml2-2.9.6-0rc1.fc26.x86_64.rpm", "2.9.6"],
+            ["libxml2-2.9.6-1.fc26.x86_64.rpm", "2.9.6"],
+            ["libxml2-2.9.7-0rc1.fc26.x86_64.rpm", "2.9.7"],
+            ["libxml2-2.9.7-1.fc26.x86_64.rpm", "2.9.7"],
+            ["libxml2-2.9.8-0rc1.fc26.x86_64.rpm", "2.9.8"],
+            ["libxml2-2.9.8-1.fc26.x86_64.rpm", "2.9.8"],
+            ["libxml2-2.9.9-0rc1.fc28.x86_64.rpm", "2.9.9"],
+            ["libxml2-2.9.9-0rc2.fc28.x86_64.rpm", "2.9.9"],
+            ["libxml2-2.9.9-1.fc28.x86_64.rpm", "2.9.9"],
+        ]
+        for rpm, version in rpmlist:
+            print("rpm: {} version: {}".format(rpm, version))
+            self._file_test("http://xmlsoft.org/sources/", rpm, "xml2", version)
+
     def test_zlib_1_2_8(self):
         """Scanning test-zlib-1.2.8.out"""
         self._binary_test(


### PR DESCRIPTION
This was a side effect of testing something for a colleague about xml2 detection, and I figured once I'd done the parsing I might as well just turn it into a regression test because I hear testing is awesome.

Also, every single version of libxml2 has CVEs apparently.