### PR TITLE
Add invalid param tests

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -339,7 +339,12 @@ def main(argv=sys.argv, outfile=sys.stdout):
         parser.print_help()
         return 0
 
-    args = parser.parse_args(argv[1:])
+    try:
+        args = parser.parse_args(argv[1:])
+    except SystemExit:
+        # override default argparse exit(2) behaviour so positive numbers can indicate
+        # number of cves (useful in quiet mode)
+        sys.exit(-2)
 
     logging.basicConfig(level=args.log_level)
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -66,3 +66,27 @@ class TestCLI(TempDirTest):
         self.assertNotEqual(
             main(["cve-bin-tool", "-l", "debug", "-m", "-x", self.tempdir]), 0
         )
+
+    def test_invalid_parameter(self):
+        """ Test that invalid parmeters exit with expected error code.
+       ArgParse calls sys.exit(2) for all errors, we've overwritten to -2 """
+
+        # no directory specified
+        with self.assertRaises(SystemExit) as exit:
+            main(["cve-bin-tool", "--bad-param"])
+        self.assertEqual(exit.exception.code, -2)
+
+        # bad parameter (but good directory)
+        with self.assertRaises(SystemExit) as exit:
+            main(["cve-bin-tool", "--bad-param", self.tempdir])
+        self.assertEqual(exit.exception.code, -2)
+
+        # worse parameter
+        with self.assertRaises(SystemExit) as exit:
+            main(["cve-bin-tool", "--bad-param && cat hi", self.tempdir])
+        self.assertEqual(exit.exception.code, -2)
+
+        # bad parameter after directory
+        with self.assertRaises(SystemExit) as exit:
+            main(["cve-bin-tool", self.tempdir, "--bad-param;cat hi"])
+        self.assertEqual(exit.exception.code, -2)


### PR DESCRIPTION
Argparse does a sys.exit(2) for all bad arguments, but we're using the return code out of main for the # of cves (per a user request to go with quiet mode) so over-ride the behaviour to return a negative number instead, and add tests.