### PR TITLE
setup: requires: Add version to jsonschema

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup_kwargs = dict(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    install_requires=["jsonschema"],
+    install_requires=["jsonschema>=3.0.2"],
     packages=find_packages(),
     entry_points={
         "console_scripts": ["cve-bin-tool = cve_bin_tool.cli:main"],


### PR DESCRIPTION
Just in case a user has an older version installed, this will make sure their version of `jsonschema` is at least what it is today, or more up to date.