### PR TITLE
Disabling python3.4 in travis because of unrelated network errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - openssl
 python:
   - "2.7"
-  - "3.4"
+#  - "3.4"  Failing due to what look like travis network errors; disabling for now
   - "3.5"
   - "3.6"
 # 3.7 fails with: Unable to download 3.7 archive. The archive may not exist.


### PR DESCRIPTION
It looks like travis network is failing during one of the update tests, and leaving us with an incomplete nvd database.  This doesn't seem to be related to our code, so I'm disabling travis for now and we can debug more if someone needs 3.4 support.