### PR TITLE
Revert "Disabling python3.4 in travis because of unrelated network errors"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
       - openssl
 python:
   - "2.7"
-#  - "3.4"  Failing due to what look like travis network errors; disabling for now
+  - "3.4"
   - "3.5"
   - "3.6"
 # 3.7 fails with: Unable to download 3.7 archive. The archive may not exist.


### PR DESCRIPTION
Reverts intel/cve-bin-tool#207 (because it didn't fix the problem, just moved it to another version of python)