### PR TITLE
Refactor get_cve func

### DIFF
--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -474,6 +474,7 @@ class NVDSQLite(object):
             )
         )
         if len(vendor_product_pairs) == 1:
+            print(vendor_product_pairs[0])
             cur.execute(query, vendor_product_pairs[0])
         else:
             cur.execute(query, tuple(itertools.chain(*vendor_product_pairs)))

--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -458,15 +458,18 @@ class NVDSQLite(object):
         """ Get CVEs against a specific version of a package.
 
         Example:
-            nvd.get_cves(('haxx', 'curl'))
-            nvd.get_cves(('haxx', 'curl'), ('rubygems', 'curl'))
+            nvd.get_cves(('haxx', 'curl', '7.34.0'))
+            nvd.get_cves(('haxx', 'curl', '7.34.0'), ('rubygems', 'curl', '7.34.0'))
         """
         cur = self.conn.cursor()
         query = (
             "SELECT CVE_Number, version, Severity FROM nvd_data WHERE "
             + " OR ".join(
                 itertools.chain(
-                    ["(Vendor_Name=? AND Product_Name=?)"] * len(vendor_product_pairs)
+                    [
+                        "(Vendor_Name=? AND Product_Name=? AND (version like ? OR version = '-'))"
+                    ]
+                    * len(vendor_product_pairs)
                 )
             )
         )

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -121,7 +121,15 @@ class Scanner(object):
         cves = defaultdict(list)
 
         for i in range(len(vendor_package_pairs)):
-            vendor_package_pairs[i] = vendor_package_pairs[i] + ("%" + vers + "%",)
+            if isinstance(vers, str):
+                vendor_package_pairs[i] = tuple(vendor_package_pairs[i])[:2] + (
+                    "%" + vers + "%",
+                )
+            else:
+                for v in vers:
+                    vendor_package_pairs[i] = tuple(vendor_package_pairs[i])[:2] + (
+                        "%" + v + "%",
+                    )
 
         # here we don't need to grab all of the versions
         for row in self.nvd.get_cves(*vendor_package_pairs):

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -121,15 +121,9 @@ class Scanner(object):
         cves = defaultdict(list)
 
         for i in range(len(vendor_package_pairs)):
-            if isinstance(vers, str):
-                vendor_package_pairs[i] = tuple(vendor_package_pairs[i])[:2] + (
-                    "%" + vers + "%",
-                )
-            else:
-                for v in vers:
-                    vendor_package_pairs[i] = tuple(vendor_package_pairs[i])[:2] + (
-                        "%" + v + "%",
-                    )
+            vendor_package_pairs[i] = tuple(vendor_package_pairs[i])[:2] + (
+                "%" + vers + "%",
+            )
 
         # here we don't need to grab all of the versions
         for row in self.nvd.get_cves(*vendor_package_pairs):

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -23,6 +23,7 @@ import argparse
 import threading
 import pkg_resources
 import multiprocessing
+from collections import defaultdict
 
 from .util import DirWalk, inpath
 from .extractor import Extractor
@@ -58,7 +59,7 @@ class Scanner(object):
         self.checkers = checkers
         self.logger = logger
         self.verbose = verbose
-        self.all_cves = {}
+        self.all_cves = defaultdict(dict)
         self.files_with_cve = 0
         self.logger.info("Checkers loaded: %s", ", ".join(self.checkers.keys()))
 
@@ -117,17 +118,15 @@ class Scanner(object):
     def get_cves(self, vendor_package_pairs, vers):
         """Returns a list of cves affecting a given version of a piece of software
         """
-        cves_by_version = dict()
+        cves = defaultdict(list)
+
+        for i in range(len(vendor_package_pairs)):
+            vendor_package_pairs[i] = vendor_package_pairs[i] + ("%" + vers + "%",)
+
+        # here we don't need to grab all of the versions
         for row in self.nvd.get_cves(*vendor_package_pairs):
-            for ver in [ver.strip() for ver in row.version.split(",")]:
-                if not ver in cves_by_version:
-                    cves_by_version[ver] = {}
-                cves_by_version[ver][row.number] = row
-        # `-` version is all versions are affected. Aka no patch
-        grab_all = {}
-        grab_all.update(cves_by_version.get("-", {}))
-        grab_all.update(cves_by_version.get(vers, {}))
-        return grab_all
+            cves[row.number] = row
+        return cves
 
     def scan_file(self, filename):
         """Scans a file to see if it contains any of the target libraries,
@@ -190,8 +189,6 @@ class Scanner(object):
                 found_cves = self.get_cves(vendor_package_pairs, version)
                 if found_cves.keys():
                     self.files_with_cve = self.files_with_cve + 1
-                if not modulename in self.all_cves:
-                    self.all_cves[modulename] = {}
                 self.all_cves[modulename][version] = found_cves
                 if self.verbose:
                     print(filename, result["is_or_contains"], modulename, version)

--- a/test/test_nvd.py
+++ b/test/test_nvd.py
@@ -184,15 +184,18 @@ class TestNVDSQLite(unittest.TestCase):
 
     def test_get_cves(self):
         """ Test that you can get cves from the nvd database """
-        check = [("CVE-001", "example0", "app0"), ("CVE-002", "example1", "app1")]
+        check = [
+            ("CVE-001", "example0", "app0", "-"),
+            ("CVE-002", "example1", "app1", "-"),
+        ]
         with self.nvd:
             cursor = self.nvd.conn.cursor()
             cursor.execute(CREATE_SYNTAX)
             for cve in check:
                 cursor.execute(
                     """INSERT INTO nvd_data(
-                             CVE_Number, Vendor_Name, Product_Name)
-                             VALUES(?,?,?)""",
+                             CVE_Number, Vendor_Name, Product_Name, version)
+                             VALUES(?,?,?,?)""",
                     cve,
                 )
             self.nvd.conn.commit()


### PR DESCRIPTION
Previously, the `nvd.get_cves()` function selected all versions for given package and then check whether the version we want is in the result. I refactored the code by using `LIKE` statement to select the version we want, so the performance is better now (also consumed less memory)