### PR TITLE
Fail silently if .cache/cve-bin-tool does not exist (fixes #216)

### DIFF
--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -487,4 +487,5 @@ class NVDSQLite(object):
 
     @classmethod
     def clear_cached_data(cls):
-        shutil.rmtree(DISK_LOCATION_DEFAULT)
+        if os.path.exists(DISK_LOCATION_DEFAULT):
+            shutil.rmtree(DISK_LOCATION_DEFAULT)


### PR DESCRIPTION
This just checks if the directory exists before trying to delete it.  Since there's nothing for the user to do if there's no directory, I'm not bothering to print a message.