### PR TITLE
Improve CVE update messages

### DIFF
--- a/cve_bin_tool/NVDAutoUpdate.py
+++ b/cve_bin_tool/NVDAutoUpdate.py
@@ -390,6 +390,8 @@ def get_cvelist_if_stale(nvddir, dbname, quiet):
         datetime.datetime.today()
         - datetime.datetime.fromtimestamp(os.path.getmtime(latest_zipfile))
     ) > datetime.timedelta(hours=24):
+        if not quiet:
+            print("Updating CVE data. This will take a few minutes.")
         get_cvelist(nvddir, dbname, quiet)
 
     if not os.path.isfile(dbname):

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -387,7 +387,7 @@ def main(argv=sys.argv, outfile=sys.stdout):
         # Update CVE database
         if args.update != "never":
             if not args.quiet:
-                print("Updating CVE data. This will take a few minutes.")
+                print("Checking if CVE data needs an update.")
             nvd.get_cvelist_if_stale()
         with nvd:
             extractor = Extractor()


### PR DESCRIPTION
Previously, the tool would print the message `"Updating CVE data. This will take a few minutes."` even if it then decided the database wasn't stale enough to warrant an update, so I've moved that message so it only happens if there's an update in progress. I left a generic "Checking if CVE data needs an update" where that message used to print, although this could maybe be moved to the debug log.