### PR TITLE
Openssh checker

### DIFF
--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -10,10 +10,12 @@ __all__ = [
     "libnss",
     "png",
     "xerces",
-    "libjpeg" "xerces",
+    "libjpeg",
+    "xerces",
     "libgcrypt",
     "systemd",
     "sqlite",
     "kerberos",
     "icu",
+    "openssh",
 ]

--- a/cve_bin_tool/checkers/openssh.py
+++ b/cve_bin_tool/checkers/openssh.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+"""
+CVE checker for openssh
+
+References:
+https://www.cvedetails.com/product/585/Openbsd-Openssh.html?vendor_id=97
+"""
+from ..util import regex_find
+
+import sys, re
+
+def get_version(lines, filename):
+    """
+    Get the version and return it for OpenSSH server or client
+
+    VPkg: openssh
+    """
+    regex = re.compile("OpenSSH_([0-9]+\.[0-9]+[0-9a-z\s]*)")
+    version_info = dict()
+
+    # determine version
+    for l in lines:
+        if regex.match(l):
+            version_info["version"] = regex.match(l).groups()[0]
+            break # The binary seems to contain many version strings and the 
+            #first one matches the binary in question
+
+    if filename in ["scp", "sftp", "ssh", "ssh-add", "ssh-agent", "ssh-argv0", \
+        "ssh-copy-id", "ssh-keygen", "ssh-keyscan", "slogin"]:
+        version_info["is_or_contains"] = "is"
+        version_info["modulename"] = "openssh-client"
+    elif filename in ["sshd"]:
+        version_info["is_or_contains"] = "is"
+        version_info["modulename"] = "openssh-server"
+
+    if "is_or_contains" in version_info:
+        version_info["modulename"] = "openssl"
+    else:
+        return dict()
+
+    return version_info


### PR DESCRIPTION
Tested with a few debian variants (kali, ubuntu)
- listed the binaries with dpkq-query -L openssh-server and dpkg-query -L openssh-client
- checked with actual binaries from a few ubuntu server versions and current kali

Note, some(/all?) distributions ship versions with patches on top of the baseline release, eg: "OpenSSH_8.1p1 Debian-1" instead of just "OpenSSH_8.1". The checker checks for the complete version string, which should reduce the amount of false positives (vendor patched binaries hopefully don't contain vulnerabilities found in the baseline version).