### PR TITLE
Openssh test

### DIFF
--- a/cve_bin_tool/checkers/openssh.py
+++ b/cve_bin_tool/checkers/openssh.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import os
 
 """
 CVE checker for openssh
@@ -17,7 +18,7 @@ def get_version(lines, filename):
 
     VPkg: openbsd, openssh
     """
-    regex = re.compile("OpenSSH_([0-9]+\.[0-9]+[0-9a-z\s]*)")
+    regex = re.compile(r"OpenSSH_([0-9]+\.[0-9]+[0-9a-z\s]*)")
     version_info = dict()
 
     # determine version
@@ -27,27 +28,27 @@ def get_version(lines, filename):
             break  # The binary seems to contain many version strings and the
             # first one matches the binary in question
 
-    if filename in [
-        "scp",
-        "sftp",
-        "ssh",
-        "ssh-add",
-        "ssh-agent",
-        "ssh-argv0",
-        "ssh-copy-id",
-        "ssh-keygen",
-        "ssh-keyscan",
-        "slogin",
-    ]:
-        version_info["is_or_contains"] = "is"
-        version_info["modulename"] = "openssh-client"
-    elif filename in ["sshd"]:
-        version_info["is_or_contains"] = "is"
-        version_info["modulename"] = "openssh-server"
+    for modulename, binary_names in (
+        {
+            "openssh-client": [
+                "scp",
+                "sftp",
+                "ssh",
+                "ssh-add",
+                "ssh-agent",
+                "ssh-argv0",
+                "ssh-copy-id",
+                "ssh-keygen",
+                "ssh-keyscan",
+                "slogin",
+            ],
+            "openssh-server": ["sshd"],
+        }
+    ).items():
+        for check in binary_names:
+            if check in os.path.split(filename)[-1]:
+                version_info["is_or_contains"] = "is"
+                version_info["modulename"] = modulename
+                return version_info
 
-    if "is_or_contains" in version_info:
-        version_info["modulename"] = "openssl"
-    else:
-        return dict()
-
-    return version_info
+    return {}

--- a/test/binaries/test-openssh-7.9.c
+++ b/test/binaries/test-openssh-7.9.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main() {
+	printf("This program is designed to test the cve-bin-tool checker.");
+	printf("It outputs a few strings normally associated with OpenSSH 7.9");
+	printf("They appear below this line.");
+	printf("------------------");
+	printf("OpenSSH_7.9");
+
+	return 0;
+}

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -412,6 +412,25 @@ class TestScanner(unittest.TestCase):
             "3.26.2",
         )
 
+    def test_openssh_7_9(self):
+        """Scanning test-openssh-7.9.out"""
+        self._binary_test(
+            "test-openssh-7.9.out",
+            "openssh-client",
+            "7.9",
+            [
+                # known CVEs in this version
+                "CVE-2019-6111",
+                "CVE-2019-6110",
+                "CVE-2019-6109",
+                "CVE-2018-20685",
+            ],
+            [
+                # older CVEs that should not be detected
+                "CVE-2018-15919",
+                "CVE-2018-15473",
+            ],
+        )
     def test_openssl_1_0_2g(self):
         """Scanning test-openssl-1.0.2g.out"""
         self._binary_test(


### PR DESCRIPTION
In the checker we were doing a direct match on filenames and in the test `filename` = `/path/to/test-openssh-7.9.out` and that isn't and exact match with any of the filenames in the array.

Sorry it took me so long to get to this.