### PR TITLE
Fix openssh version not found issue, improve version error handling.

### DIFF
--- a/cve_bin_tool/checkers/bluez.py
+++ b/cve_bin_tool/checkers/bluez.py
@@ -17,11 +17,11 @@ def get_version(lines, filename):
     version_info = dict()
     if filename[::-1].startswith(("bluetoothctl")[::-1]):
         version_info["is_or_contains"] = "is"
+    elif "libbluetooth.so" in filename:
+        version_info["is_or_contains"] = "is"
 
     if "is_or_contains" in version_info:
         version_info["modulename"] = "bluetoothctl"
         version_info["version"] = regex_find(lines, *regex)
-    elif "libbluetooth.so" in filename:
-        version_info["is_or_contains"] = "is"
 
     return version_info

--- a/cve_bin_tool/checkers/openssh.py
+++ b/cve_bin_tool/checkers/openssh.py
@@ -47,6 +47,8 @@ def get_version(lines, filename):
             if check in os.path.split(filename)[-1]:
                 version_info["is_or_contains"] = "is"
                 version_info["modulename"] = modulename
+                if "version" not in version_info:
+                    version_info["version"] = "UNKNOWN"
                 return version_info
 
     return {}

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -186,7 +186,15 @@ class Scanner(object):
         ) in self.checkers.items():
             result = get_version(lines, filename)
             if "is_or_contains" in result:
-                modulename, version = result["modulename"], result["version"]
+                modulename = result["modulename"]
+                version = "UNKNOWN"
+                if "version" in result:
+                    version = result["version"]
+                else:
+                    self.logger.error(
+                        "error: no version info for %r", result["modulename"]
+                    )
+
                 found_cves = self.get_cves(vendor_package_pairs, version)
                 if found_cves.keys():
                     self.files_with_cve = self.files_with_cve + 1


### PR DESCRIPTION
Fixes #268 #263 #259.  The version detection in openssh.py probably has a bug that's causing this still, though.