### PR TITLE
Add tests for ffmpeg

### DIFF
--- a/test/binaries/test-ffmpeg-4.1.3.c
+++ b/test/binaries/test-ffmpeg-4.1.3.c
@@ -1,0 +1,12 @@
+#include <stdio.h>
+
+int main() {
+	printf("This program is designed to test the cve-bin-tool checker.");
+	printf("It outputs a few strings normally associated with ffmepg 4.1.3.");
+	printf("They appear below this line.");
+	printf("------------------");
+	printf("Codec '%s' is not recognized by FFmpeg.", "whatever");
+	printf("%s version 4.1.3", "FFmpeg");
+
+	return 0;
+}

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -229,21 +229,29 @@ class TestScanner(unittest.TestCase):
             "2.2.0",
         )
 
-    @unittest.skip("FIXME: needs repair")
-    def test_ffmpeg_4_1_4(self):
-        """Scanning test-ffmpeg-4.1.4.out"""
+    def test_ffmpeg_4_1_3(self):
+        """Scanning test-ffmpeg-4.1.3.out"""
         self._binary_test(
-            "test-ffmpeg-4.1.4.out",
+            "test-ffmpeg-4.1.3.out",
             "ffmpeg",
-            "4.1.4",
+            "4.1.3",
             [
-                # known cves in 4.1.4
-                "CVE-2019-12730"
+                # known cves in 4.1.3
+                "CVE-2019-13312"
             ],
             [
-                # an older cve from before 4.1.4
+                # an older cve from before 4.1.3
                 "CVE-2019-11339"
             ],
+        )
+
+    @unittest.skipUnless(os.getenv("LONG_TESTS") == "1", "Skipping long tests")
+    def test_ffmpeg_deb_4_1_1(self):
+        self._file_test(
+            "http://archive.ubuntu.com/ubuntu/pool/universe/f/ffmpeg/",
+            "ffmpeg_4.1.1-1_amd64.deb",
+            "ffmpeg",
+            "4.1.1"
         )
 
     def test_gnutls_2_3_11(self):
@@ -694,7 +702,7 @@ class TestScanner(unittest.TestCase):
             [
                 # Check to make sure an older CVE isn't included
                 "CVE-2011-1944"
-            ],
+            ]
         )
 
     def test_xml2_2_9_2(self):
@@ -712,7 +720,7 @@ class TestScanner(unittest.TestCase):
             [
                 # Check to make sure an older CVE isn't included
                 "CVE-2011-1944"
-            ],
+            ]
         )
 
     @unittest.skipUnless(os.getenv("LONG_TESTS") == "1", "Skipping long tests")

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -251,7 +251,7 @@ class TestScanner(unittest.TestCase):
             "http://archive.ubuntu.com/ubuntu/pool/universe/f/ffmpeg/",
             "ffmpeg_4.1.1-1_amd64.deb",
             "ffmpeg",
-            "4.1.1"
+            "4.1.1",
         )
 
     def test_gnutls_2_3_11(self):
@@ -702,7 +702,7 @@ class TestScanner(unittest.TestCase):
             [
                 # Check to make sure an older CVE isn't included
                 "CVE-2011-1944"
-            ]
+            ],
         )
 
     def test_xml2_2_9_2(self):
@@ -720,7 +720,7 @@ class TestScanner(unittest.TestCase):
             [
                 # Check to make sure an older CVE isn't included
                 "CVE-2011-1944"
-            ]
+            ],
         )
 
     @unittest.skipUnless(os.getenv("LONG_TESTS") == "1", "Skipping long tests")


### PR DESCRIPTION
Signed-off-by: sbs2001 <shivam.sandbhor@gmail.com>

The signature test for ffmpeg is `test_ffmpeg_deb_4_1_1` .

The  CVE mapping test for ffmpeg is `ffmpeg_4_1_3` .


Here is the output:

```
shivam@shivam-Latitude-D630:~/coding/opensource/cve-bin-tool$ python -m unittest test.test_scanner.TestScanner.test_ffmpeg_deb_4_1_1
rm *.out
gcc -o test-nss-3.45.out test-nss-3.45.c
gcc -o test-ffmpeg-4.1.3.out test-ffmpeg-4.1.3.c
gcc -o test-expat-2.0.1.out test-expat-2.0.1.c
gcc -o test-nss-3.35.out test-nss-3.35.c
gcc -o test-png-1.6.26.out test-png-1.6.26.c
gcc -o test-libgcrypt-1.7.6.out test-libgcrypt-1.7.6.c
gcc -o test-png-1.6.36.out test-png-1.6.36.c
gcc -o test-libjpeg-turbo-2.0.1.out test-libjpeg-turbo-2.0.1.c
gcc -o test-openssl-1.0.2g.out test-openssl-1.0.2g.c
gcc -o test-zlib-1.2.8.out test-zlib-1.2.8.c
gcc -o test-gnutls-serv-2.3.11.out test-gnutls-serv-2.3.11.c
gcc -o test-gnutls-cli-2.3.11.out test-gnutls-cli-2.3.11.c
gcc -o test-png-1.4.11.out test-png-1.4.11.c
gcc -o test-sqlite-3.12.2.out test-sqlite-3.12.2.c
gcc -o test-xml2-2.9.2.out test-xml2-2.9.2.c
gcc -o test-xml2-2.9.0.out test-xml2-2.9.0.c
gcc -o test-xerces-3_1_1.out test-xerces-3_1_1.c
gcc -o test-tiff-4.0.9.out test-tiff-4.0.9.c
gcc -o test-curl-7.59.0.out test-curl-7.59.0.c
gcc -o test-node-9.3.0.out test-node-9.3.0.c
gcc -o test-openssh-7.9.out test-openssh-7.9.c
gcc -o test-systemd-239.out test-systemd-239.c
gcc -o test-icu-3.8.1.out test-icu-3.8.1.c
gcc -o test-curl-7.34.0.out test-curl-7.34.0.c
gcc -o test-curl-7.57.0.out test-curl-7.57.0.c
gcc -o test-openssl-1.1.0g.out test-openssl-1.1.0g.c
gcc -o test-kerberos-5-1.15.1.out test-kerberos-5-1.15.1.c
Skip NVD database updates.
s
----------------------------------------------------------------------
Ran 1 test in 3.116s

OK (skipped=1)
shivam@shivam-Latitude-D630:~/coding/opensource/cve-bin-tool$ python -m unittest test.test_scanner.TestScanner.test_ffmpeg_4_1_3
rm *.out
gcc -o test-nss-3.45.out test-nss-3.45.c
gcc -o test-ffmpeg-4.1.3.out test-ffmpeg-4.1.3.c
gcc -o test-expat-2.0.1.out test-expat-2.0.1.c
gcc -o test-nss-3.35.out test-nss-3.35.c
gcc -o test-png-1.6.26.out test-png-1.6.26.c
gcc -o test-libgcrypt-1.7.6.out test-libgcrypt-1.7.6.c
gcc -o test-png-1.6.36.out test-png-1.6.36.c
gcc -o test-libjpeg-turbo-2.0.1.out test-libjpeg-turbo-2.0.1.c
gcc -o test-openssl-1.0.2g.out test-openssl-1.0.2g.c
gcc -o test-zlib-1.2.8.out test-zlib-1.2.8.c
gcc -o test-gnutls-serv-2.3.11.out test-gnutls-serv-2.3.11.c
gcc -o test-gnutls-cli-2.3.11.out test-gnutls-cli-2.3.11.c
gcc -o test-png-1.4.11.out test-png-1.4.11.c
gcc -o test-sqlite-3.12.2.out test-sqlite-3.12.2.c
gcc -o test-xml2-2.9.2.out test-xml2-2.9.2.c
gcc -o test-xml2-2.9.0.out test-xml2-2.9.0.c
gcc -o test-xerces-3_1_1.out test-xerces-3_1_1.c
gcc -o test-tiff-4.0.9.out test-tiff-4.0.9.c
gcc -o test-curl-7.59.0.out test-curl-7.59.0.c
gcc -o test-node-9.3.0.out test-node-9.3.0.c
gcc -o test-openssh-7.9.out test-openssh-7.9.c
gcc -o test-systemd-239.out test-systemd-239.c
gcc -o test-icu-3.8.1.out test-icu-3.8.1.c
gcc -o test-curl-7.34.0.out test-curl-7.34.0.c
gcc -o test-curl-7.57.0.out test-curl-7.57.0.c
gcc -o test-openssl-1.1.0g.out test-openssl-1.1.0g.c
gcc -o test-kerberos-5-1.15.1.out test-kerberos-5-1.15.1.c
Skip NVD database updates.
/home/shivam/coding/opensource/cve-bin-tool/test/binaries/test-ffmpeg-4.1.3.out contains ffmpeg 4.1.3
Known CVEs in version 4.1.3
CVE-2019-13390, CVE-2019-13312
.
----------------------------------------------------------------------
Ran 1 test in 3.372s

OK

```