### PR TITLE
Remove 2.7 from supported versions

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -125,7 +125,9 @@ even though it may now be safely mitigated and the result a false positive.
 Limitations
 -----------
 
-When running this script, Python 3 is preferred over Python 2.7, as python 2.7 support will be ending soon. Linux and Windows are supported, as is usage within cygwin on windows.
+The last release of this tool to support python 2.7 is 0.3.1.  Please use
+python 3.6+ for development and future versions.   Linux and Windows are
+supported, as is usage within cygwin on windows.
 
 This tool does not scan for all possible known public vulnerabilities, it only
 scans for specific commonly vulnerable open source components.   A complete

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ You can also do `python -m cve_bin_tool.cli <flags> <path to directory>` which i
                         update schedule for NVD database. Default is daily.
 ```
 
-This release may be the last one to support python 2.7; please switch to python 3.
+The 0.3.1 release is intended to be the last release to officially support
+python 2.7; please switch to python 3 for future releases and to use the
+development tree.  We are currently testing on python 3.6 and 3.7.
 
 This readme is intended to be a quickstart guide for using the tool.  If you
 require more information, there is also a [user manual](MANUAL.md) available.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup_kwargs = dict(
     name="cve-bin-tool",
-    version="0.3.1",
+    version="0.3.2",
     description="CVE Binary Checker Tool",
     long_description=readme,
     long_description_content_type="text/markdown",
@@ -25,7 +25,6 @@ setup_kwargs = dict(
         "License :: OSI Approved :: MIT License",
         "Natural Language :: English",
         "Operating System :: OS Independent",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",

--- a/test/README.md
+++ b/test/README.md
@@ -26,18 +26,15 @@ python -m unittest test.test_scanner.TestScanner.test_sqlite_3_12_2
 
 ## Running tests on different versions of Python
 
-Our CI currently runs tests on Python 2.7, 3.3, 3.4, 3.5, 3.6.
+Our CI currently runs tests on Python 3.6 and 3.7 under Linux.
 
 The recommended way to do this yourself is to use python's `virtualenv`
 
 You can set up virtualenv for all these environments:
 
 ```console
-virtualenv -p python2.7 venv2.7
-virtualenv -p python3.3 venv3.3
-virtualenv -p python3.4 venv3.4
-virtualenv -p python3.5 venv3.5
 virtualenv -p python3.6 venv3.6
+virtualenv -p python3.7 venv3.7
 ```
 
 To activate one of these (the example uses 3.6), run the tests, and deactivate:


### PR DESCRIPTION
fixes #297 
We aren't stripping out the remaining 2.7 compat stuff yet (because I've got other issues that have higher priority) but we might as well be clear that we're no longer testing on 2.7 at this point and that 0.3.1 was the last release with official 2.7 support.