### PR TITLE
Disable kerberos tests temporarily due to #301

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -303,6 +303,7 @@ class TestScanner(unittest.TestCase):
             "2.0.0",
         )
 
+    @unittest.skip("Disabled because of bug #301")
     def test_kerberos_1_15_1(self):
         """Scanning test-kerberos-5-1.15.1.out"""
         self._binary_test(


### PR DESCRIPTION
#301 looks like it's going to take some careful thinking to handled correctly, so I'm disabling the test so people aren't constantly failing CI while we work that out.