### PR TITLE
gnutls file test added for version 2.3.11

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -149,12 +149,12 @@ class TestScanner(unittest.TestCase):
     #         [],
     #     )
     # def test_bluez_5_50(self):
-        self._file_test(
-            "http://mirrors.kernel.org/fedora/releases/29/Workstation/x86_64/os/Packages/b/",
-            "bluez-5.50-3.fc29.x86_64.rpm",
-            "bluetoothctl",
-            "",
-        )
+        # self._file_test(
+        #     "http://mirrors.kernel.org/fedora/releases/29/Workstation/x86_64/os/Packages/b/",
+        #     "bluez-5.50-3.fc29.x86_64.rpm",
+        #     "bluetoothctl",
+        #     "",
+        # )
 
     
 
@@ -309,7 +309,7 @@ class TestScanner(unittest.TestCase):
                 )
 
     @unittest.skipUnless(os.getenv("LONG_TESTS") == "1", "Skipping long tests")
-    def test_gnutls_2_3_11_file(self):
+    def test_gnutls_bz2_2_3_11(self):
         """ Test detection of gnutls downloaded from gnutls site"""
         self._file_test(
             "https://alpha.gnu.org/gnu/gnutls/",

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -126,34 +126,6 @@ class TestScanner(unittest.TestCase):
             ["CVE-2019-3823"],
         )
 
-    # def test_bluez_5_42(self):
-    #     """Scanning test-bluez-5.42.out"""
-    #     self._binary_test(
-    #         "test-bluez-5.42.out",
-    #         "bluez",
-    #         "5.42-0",
-    #         [
-    #             "CVE-2016-9797",
-    #             "CVE-2016-9798",
-    #             "CVE-2016-9799",
-    #             "CVE-2016-9800",
-    #             "CVE-2016-9801",
-    #             "CVE-2016-9802",
-    #             "CVE-2016-9803",
-    #             "CVE-2016-9804",
-    #             "CVE-2016-9917",
-    #             "CVE-2016-9918",
-    #         ],
-    #         [],
-    #     )
-    # def test_bluez_5_50(self):
-    # self._file_test(
-    #     "http://mirrors.kernel.org/fedora/releases/29/Workstation/x86_64/os/Packages/b/",
-    #     "bluez-5.50-3.fc29.x86_64.rpm",
-    #     "bluetoothctl",
-    #     "",
-    # )
-
     def test_curl_7_34_0(self):
         """Scanning test-curl-7.34.0.out"""
         self._binary_test(

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -126,8 +126,6 @@ class TestScanner(unittest.TestCase):
             ["CVE-2019-3823"],
         )
 
-    
-
     # def test_bluez_5_42(self):
     #     """Scanning test-bluez-5.42.out"""
     #     self._binary_test(
@@ -149,14 +147,12 @@ class TestScanner(unittest.TestCase):
     #         [],
     #     )
     # def test_bluez_5_50(self):
-        # self._file_test(
-        #     "http://mirrors.kernel.org/fedora/releases/29/Workstation/x86_64/os/Packages/b/",
-        #     "bluez-5.50-3.fc29.x86_64.rpm",
-        #     "bluetoothctl",
-        #     "",
-        # )
-
-    
+    # self._file_test(
+    #     "http://mirrors.kernel.org/fedora/releases/29/Workstation/x86_64/os/Packages/b/",
+    #     "bluez-5.50-3.fc29.x86_64.rpm",
+    #     "bluetoothctl",
+    #     "",
+    # )
 
     def test_curl_7_34_0(self):
         """Scanning test-curl-7.34.0.out"""
@@ -199,7 +195,7 @@ class TestScanner(unittest.TestCase):
             ["CVE-2017-9502"],
         )
 
-    @unittest.skipUnless(os.getenv('LONG_TESTS') == '1', 'Skipping long tests')
+    @unittest.skipUnless(os.getenv("LONG_TESTS") == "1", "Skipping long tests")
     def test_curl_rpm_7_32_0(self):
         """
         test to see if we detect a real copy of curl 7.32.0
@@ -317,6 +313,7 @@ class TestScanner(unittest.TestCase):
             "gnutls-cli",
             "2.3.11",
         )
+
     def test_jpeg_2_0_1(self):
         """Scanning test-libjpeg-turbo-2.0.1"""
         self._binary_test(

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -126,6 +126,38 @@ class TestScanner(unittest.TestCase):
             ["CVE-2019-3823"],
         )
 
+    
+
+    # def test_bluez_5_42(self):
+    #     """Scanning test-bluez-5.42.out"""
+    #     self._binary_test(
+    #         "test-bluez-5.42.out",
+    #         "bluez",
+    #         "5.42-0",
+    #         [
+    #             "CVE-2016-9797",
+    #             "CVE-2016-9798",
+    #             "CVE-2016-9799",
+    #             "CVE-2016-9800",
+    #             "CVE-2016-9801",
+    #             "CVE-2016-9802",
+    #             "CVE-2016-9803",
+    #             "CVE-2016-9804",
+    #             "CVE-2016-9917",
+    #             "CVE-2016-9918",
+    #         ],
+    #         [],
+    #     )
+    # def test_bluez_5_50(self):
+        self._file_test(
+            "http://mirrors.kernel.org/fedora/releases/29/Workstation/x86_64/os/Packages/b/",
+            "bluez-5.50-3.fc29.x86_64.rpm",
+            "bluetoothctl",
+            "",
+        )
+
+    
+
     def test_curl_7_34_0(self):
         """Scanning test-curl-7.34.0.out"""
         self._binary_test(
@@ -167,7 +199,7 @@ class TestScanner(unittest.TestCase):
             ["CVE-2017-9502"],
         )
 
-    # @unittest.skipUnless(os.getenv('LONG_TESTS') == '1', 'Skipping long tests')
+    @unittest.skipUnless(os.getenv('LONG_TESTS') == '1', 'Skipping long tests')
     def test_curl_rpm_7_32_0(self):
         """
         test to see if we detect a real copy of curl 7.32.0
@@ -276,6 +308,15 @@ class TestScanner(unittest.TestCase):
                     ],
                 )
 
+    @unittest.skipUnless(os.getenv("LONG_TESTS") == "1", "Skipping long tests")
+    def test_gnutls_2_3_11_file(self):
+        """ Test detection of gnutls downloaded from gnutls site"""
+        self._file_test(
+            "https://alpha.gnu.org/gnu/gnutls/",
+            "gnutls-2.3.11.tar.bz2",
+            "gnutls-cli",
+            "2.3.11",
+        )
     def test_jpeg_2_0_1(self):
         """Scanning test-libjpeg-turbo-2.0.1"""
         self._binary_test(


### PR DESCRIPTION
Added gnutls file test for version 2.3.11. The 2.3.11 version was downloaded from the official gnutls website. All the test were fine. I've attached the test screenshot
![Screenshot (9)](https://user-images.githubusercontent.com/29910324/73242140-13d2c200-41ca-11ea-8974-566d2b07b021.png)
