### PR TITLE
Fix final_log to check only the skip line

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -109,7 +109,11 @@ class TestCLI(TempDirTest):
         """Tests the skips option"""
 
         logger = logging.getLogger()
-        test_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "binaries")
+        test_path = os.path.join(
+            os.path.abspath(os.path.dirname(__file__)),
+            "binaries",
+            "test-sqlite-3.12.2.out",
+        )
 
         skip_checkers = ["systemd", "xerces", "xml2", "kerberos"]
         include_checkers = ["expat", "libgcrypt", "openssl", "sqlite"]
@@ -118,21 +122,31 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", test_path, "-s", ",".join(skip_checkers)])
 
         # The final log has all the checkers detected
-        final_log = cm.output[-1]
+        final_log = cm.output[1]
         for checker in skip_checkers:
-            self.assertTrue(checker not in final_log)
+            self.assertTrue(
+                checker not in final_log, "found skipped checker {}".format(checker)
+            )
 
         for checker in include_checkers:
-            self.assertTrue(checker in final_log)
+            self.assertTrue(
+                checker in final_log,
+                "could not find expected checker {}".format(checker),
+            )
 
         # swap skip_checkers and include_checkers
         include_checkers, skip_checkers = skip_checkers, include_checkers
         with self.assertLogs(logger, logging.INFO) as cm:
             main(["cve-bin-tool", test_path, "-s", ",".join(skip_checkers)])
 
-        final_log = cm.output[-1]
+        final_log = cm.output[1]
         for checker in skip_checkers:
-            self.assertTrue(checker not in final_log)
+            self.assertTrue(
+                checker not in final_log, "found skipped checker {}".format(checker)
+            )
 
         for checker in include_checkers:
-            self.assertTrue(checker in final_log)
+            self.assertTrue(
+                checker in final_log,
+                "could not find expected checker {}".format(checker),
+            )

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -109,11 +109,7 @@ class TestCLI(TempDirTest):
         """Tests the skips option"""
 
         logger = logging.getLogger()
-        test_path = os.path.join(
-            os.path.abspath(os.path.dirname(__file__)),
-            "binaries",
-            "test-sqlite-3.12.2.out",
-        )
+        test_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
 
         skip_checkers = ["systemd", "xerces", "xml2", "kerberos"]
         include_checkers = ["expat", "libgcrypt", "openssl", "sqlite"]
@@ -122,7 +118,9 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", test_path, "-s", ",".join(skip_checkers)])
 
         # The final log has all the checkers detected
-        final_log = cm.output[1]
+        final_log = [i for i in cm.output if "Checkers:" in i]
+        self.assertTrue(len(final_log) > 0, "Could not find checkers line in log")
+        final_log = final_log[0]
         for checker in skip_checkers:
             self.assertTrue(
                 checker not in final_log, "found skipped checker {}".format(checker)
@@ -139,7 +137,9 @@ class TestCLI(TempDirTest):
         with self.assertLogs(logger, logging.INFO) as cm:
             main(["cve-bin-tool", test_path, "-s", ",".join(skip_checkers)])
 
-        final_log = cm.output[1]
+        final_log = [i for i in cm.output if "Checkers:" in i]
+        self.assertTrue(len(final_log) > 0, "Could not find checkers line in log")
+        final_log = final_log[0]
         for checker in skip_checkers:
             self.assertTrue(
                 checker not in final_log, "found skipped checker {}".format(checker)


### PR DESCRIPTION
* Fixing error caused by #327 by changing it search only the skips list. 
* Changed the scanner to do a directory without binaries (for speed)
* added some more detailed error messages to the asserts.