### PR TITLE
Enable test_sample_csv

### DIFF
--- a/test/test_csv2cve.py
+++ b/test/test_csv2cve.py
@@ -37,9 +37,6 @@ class TestCsv2cve(unittest.TestCase):
         output = csv2cve(os.path.join(self.CSV_PATH, "bad_version.csv"))
         self.assertEqual(-2, output)
 
-    @unittest.skipUnless(
-        os.getenv("ACTIONS") != "1", "Skipping tests that cannot pass in github actions"
-    )
     def test_sample_csv(self):
         output = csv2cve(os.path.join(self.CSV_PATH, "test.csv"))
         self.assertIn("CVE-2018-19664", output[0])


### PR DESCRIPTION
fixes #249 
This test was previously disabled because it was faililng on Github Actions.  The problem appears to have been resolved, so I'm re-enabling it. 