### PR TITLE
test: Rename test_definitions to utils

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -8,7 +8,7 @@ import subprocess
 from cve_bin_tool.cli import main
 from cve_bin_tool.extractor import Extractor
 
-from .test_definitions import (
+from .utils import (
     TempDirTest,
     download_file,
     CURL_7_20_0_RPM,

--- a/test/test_extract.py
+++ b/test/test_extract.py
@@ -8,7 +8,7 @@ import unittest
 from zipfile import ZipFile, ZipInfo
 from io import BytesIO
 from cve_bin_tool.extractor import Extractor
-from .test_definitions import download_file, CURL_7_20_0_URL, VMWARE_CAB, TMUX_DEB
+from .utils import download_file, CURL_7_20_0_URL, VMWARE_CAB, TMUX_DEB
 from cve_bin_tool.util import inpath
 
 if sys.version_info.major == 3 and sys.version_info.minor >= 3:

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -11,7 +11,7 @@ from sys import platform
 
 from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.cli import Scanner, InvalidFileError
-from .test_definitions import download_file
+from .utils import download_file
 
 BINARIES_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "binaries")
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -1,5 +1,5 @@
 """
-Resource definitions and helper functions for tests.
+Resource definitions and helper utilities for tests.
 """
 import shutil
 import tempfile


### PR DESCRIPTION
My decision making process was subpar when I choose the  name test_definitions.py for the test utilities. This PR renames it to  utils.py