### PR TITLE
Add basic json output

### DIFF
--- a/cve_bin_tool/OutputEngine.py
+++ b/cve_bin_tool/OutputEngine.py
@@ -1,4 +1,5 @@
 import csv
+import json
 import os
 
 from datetime import datetime
@@ -20,11 +21,21 @@ class OutputEngine(object):
             self.filename = f"output.cve-bin-tool.{now}.{extention}"
 
     def output_cves(self, outfile, output=None):
-
         """ Output a list of CVEs
-        format is modules[checker_name][version] = dict{id: severity}
+        format self.modules[checker_name][version] = dict{id: severity}
+        to other formats like CSV or JSON
         """
+        if output == "json":
+            self.output_json(outfile)
+        else:  # csv, console, or anything else that is unrecognised
+            self.output_csv(outfile)
 
+    def output_json(self, outfile):
+        """ Output a JSON of CVEs """
+        json.dump(self.modules, outfile)
+
+    def output_csv(self, outfile):
+        """ Output a CSV of CVEs """
         writer = csv.writer(outfile)
         writer.writerow(["Module Name", "Version", "CVE Number", "Severity"])
         for modulename, versions in self.modules.items():

--- a/cve_bin_tool/OutputEngine.py
+++ b/cve_bin_tool/OutputEngine.py
@@ -24,33 +24,24 @@ class OutputEngine(object):
         """ Output a list of CVEs
         format is modules[checker_name][version] = dict{id: severity}
         """
-        # if the output is csv we must open a file
-        if output == "csv":
-            outfile = open(f"{outfile}", "w")
-
-            writer = csv.writer(outfile)
-            writer.writerow(["Module Name", "Version", "CVE Number", "Severity"])
 
         writer = csv.writer(outfile)
+        writer.writerow(["Module Name", "Version", "CVE Number", "Severity"])
         for modulename, versions in self.modules.items():
             for version, cve_list in versions.items():
                 for cve_number, cve_severity in cve_list.items():
                     row = [modulename, version, cve_number, cve_severity]
                     writer.writerow(row)
 
-        # We must also close the file
-        if output == "csv":
-            outfile.close()
+    def output_file(self, output="csv"):
 
-    def output_csv(self):
-
-        """ Generate a CSV file for list of CVE """
+        """ Generate a file for list of CVE """
 
         # Check if we need to generate a filename
         if self.filename == None:
-            self.generate_filename("csv")
+            self.generate_filename(output)
         else:
-            self.filename = f"{self.filename}.csv"
+            self.filename = f"{self.filename}.{output}"
             # check if the filename already exists
             file_list = os.listdir(os.getcwd())
             if self.filename in file_list:
@@ -60,7 +51,7 @@ class OutputEngine(object):
                 self.logger.info(
                     "Generating a new filename with Default Naming Convention"
                 )
-                self.generate_filename("csv")
+                self.generate_filename(output)
 
             # try opening that file
             try:
@@ -70,10 +61,11 @@ class OutputEngine(object):
             except Exception as E:
                 self.logger.warning(E)
                 self.logger.info("Switching Back to Default Naming Convention")
-                self.generate_filename("csv")
+                self.generate_filename(output)
 
         # Log the filename generated
-        self.logger.info(f"CSV output stored at {os.getcwd()}/{self.filename}")
+        self.logger.info(f"Output stored at {os.getcwd()}/{self.filename}")
 
         # call to output_cves
-        self.output_cves(self.filename, "csv")
+        with open(self.filename, "w") as f:
+            self.output_cves(f, output)

--- a/cve_bin_tool/OutputEngine.py
+++ b/cve_bin_tool/OutputEngine.py
@@ -30,9 +30,27 @@ class OutputEngine(object):
         else:  # csv, console, or anything else that is unrecognised
             self.output_csv(outfile)
 
+    def formatted_modules(self):
+        """ Returns self.modules converted into form
+        formatted_output[modulesname][version] = {
+            "cve": cve_number,
+            "severity": cve_severity,
+        }
+        """
+        formatted_output = {}
+        for modulename in self.modules:
+            formatted_output[modulename] = {}
+            for version, cves in self.modules[modulename].items():
+                formatted_output[modulename][version] = []
+                for cve_number, cve_severity in cves.items():
+                    formatted_output[modulename][version].append(
+                        {"cve": cve_number, "severity": cve_severity,}
+                    )
+        return formatted_output
+
     def output_json(self, outfile):
         """ Output a JSON of CVEs """
-        json.dump(self.modules, outfile)
+        json.dump(self.formatted_modules(), outfile)
 
     def output_csv(self, outfile):
         """ Output a CSV of CVEs """

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -491,10 +491,9 @@ def main(argv=None, outfile=sys.stdout):
                     and args.output == "console"
                 ):
                     output.output_cves(outfile)
-
-                # If the args are passed for csv we will generate a CSV output
-                if args.output == "csv":
-                    output.output_csv()
+                else:
+                    # If the args are passed for csv/json we will generate a file output
+                    output.output_file(args.output)
 
             # Use the number of files with known cves as error code
             # as requested by folk planning to automate use of this script.

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -1,0 +1,33 @@
+"""
+CVE-bin-tool OutputEngine tests
+"""
+import unittest
+
+from cve_bin_tool.OutputEngine import OutputEngine
+
+
+class TestOutputEngine(unittest.TestCase):
+    """ Test the OutputEngine class functions """
+
+    MOCK_MODULES = {
+        "modulename0": {
+            "1.0": {"CVE-1234-1234": "MEDIUM", "CVE-1234-9876": "LOW",},
+            "2.8.6": {"CVE-1234-1111": "LOW",},
+        },
+        "modulename1": {"3.2.1.0": {"CVE-1234-5678": "HIGH",}},
+    }
+    FORMATTED_MODULES = {
+        "modulename0": {
+            "1.0": [
+                {"cve": "CVE-1234-1234", "severity": "MEDIUM"},
+                {"cve": "CVE-1234-9876", "severity": "LOW"},
+            ],
+            "2.8.6": [{"cve": "CVE-1234-1111", "severity": "LOW"},],
+        },
+        "modulename1": {"3.2.1.0": [{"cve": "CVE-1234-5678", "severity": "HIGH"},]},
+    }
+
+    def test_formatted_modules(self):
+        """ Test reformatting modules """
+        output_engine = OutputEngine(modules=self.MOCK_MODULES)
+        self.assertEqual(output_engine.formatted_modules(), self.FORMATTED_MODULES)

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -2,6 +2,8 @@
 CVE-bin-tool OutputEngine tests
 """
 import unittest
+import io
+import json
 
 from cve_bin_tool.OutputEngine import OutputEngine
 
@@ -31,3 +33,11 @@ class TestOutputEngine(unittest.TestCase):
         """ Test reformatting modules """
         output_engine = OutputEngine(modules=self.MOCK_MODULES)
         self.assertEqual(output_engine.formatted_modules(), self.FORMATTED_MODULES)
+
+    def test_output_json(self):
+        """ Test formatting output as JSON """
+        output_engine = OutputEngine(modules=self.MOCK_MODULES)
+        mock_file = io.StringIO()
+        output_engine.output_json(mock_file)
+        mock_file.seek(0)  # reset file position
+        self.assertEqual(json.load(mock_file), self.FORMATTED_MODULES)

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -29,15 +29,16 @@ class TestOutputEngine(unittest.TestCase):
         "modulename1": {"3.2.1.0": [{"cve": "CVE-1234-5678", "severity": "HIGH"},]},
     }
 
+    def setUp(self):
+        self.output_engine = OutputEngine(modules=self.MOCK_MODULES)
+        self.mock_file = io.StringIO()
+
     def test_formatted_modules(self):
         """ Test reformatting modules """
-        output_engine = OutputEngine(modules=self.MOCK_MODULES)
-        self.assertEqual(output_engine.formatted_modules(), self.FORMATTED_MODULES)
+        self.assertEqual(self.output_engine.formatted_modules(), self.FORMATTED_MODULES)
 
     def test_output_json(self):
         """ Test formatting output as JSON """
-        output_engine = OutputEngine(modules=self.MOCK_MODULES)
-        mock_file = io.StringIO()
-        output_engine.output_json(mock_file)
-        mock_file.seek(0)  # reset file position
-        self.assertEqual(json.load(mock_file), self.FORMATTED_MODULES)
+        self.output_engine.output_json(self.mock_file)
+        self.mock_file.seek(0)  # reset file position
+        self.assertEqual(json.load(self.mock_file), self.FORMATTED_MODULES)


### PR DESCRIPTION
Currently, CVE Binary Tool only outputs results in CSV format. It might be good to allow a wider range of uses by implementing alternative output formats such as JSON.

This pull requests implements very naive JSON output:
```
$ python -m cve_bin_tool.cli -f json test/binaries/test-expat-2.0.1.out 
cve_bin_tool.CVEDB - INFO - Using cached CVE data (<24h old). Use -u now to update immediately.
cve_bin_tool.Scanner - INFO - Checkers: bluez, curl, expat, ffmpeg, gnutls, icu, kerberos, libcurl, libdb, libgcrypt, libjpeg, libnss, libtiff, node, openssh, openssl, png, python, sqlite, systemd, xerces, xml2, zlib
cve_bin_tool - INFO - None
cve_bin_tool.Scanner - INFO - test/binaries/test-expat-2.0.1.out contains expat 2.0.1
cve_bin_tool.Scanner - INFO - Known CVEs in version 2.0.1
cve_bin_tool.Scanner - INFO - CVE-2012-0876, CVE-2012-1147, CVE-2012-1148, CVE-2012-6702, CVE-2013-0340, CVE-2015-1283, CVE-2016-0718, CVE-2016-4472, CVE-2016-5300, CVE-2018-20843, CVE-2017-9233, CVE-2019-15903
cve_bin_tool - INFO - 
cve_bin_tool - INFO - Overall CVE summary: 
cve_bin_tool - INFO - There are 1 files with known CVEs detected
cve_bin_tool - INFO - Known CVEs in ('expat', '2.0.1'):
{"expat": {"2.0.1": {"CVE-2012-0876": "MEDIUM", "CVE-2012-1147": "MEDIUM", "CVE-2012-1148": "MEDIUM", "CVE-2012-6702": "MEDIUM", "CVE-2013-0340": "MEDIUM", "CVE-2015-1283": "MEDIUM", "CVE-2016-0718": "CRITICAL", "CVE-2016-4472": "HIGH", "CVE-2016-5300": "HIGH", "CVE-2018-20843": "HIGH", "CVE-2017-9233": "HIGH", "CVE-2019-15903": "HIGH"}}}
```

Immediately obvious to me is that the JSON is not structured intuitively. I would suggest further changes like adding not having the key be the CVE and value be the severity, but rather have each version contain a list of objects structured like this:

```{"cve": "CVE-2012-0876", "severity": "MEDIUM"}```

This might be better implemented by modifying the code relating to `scanner.all_cves` rather than working around the problem in the JSON formatter. This would mean adding other similar formats, like XML, would be very nice and easy.

Another question, is whether this should be considered an "output mode" in the command line arguments. Based on the manual, it seems that "output mode" only deals with the verbosity of the output, but then again, this is the first non-CSV format :smiley: 

Anyway, thanks in advance for reviewing this.