### PR TITLE
Fix Version not found error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup_kwargs = dict(
     ],
     install_requires=["jsonschema>=3.0.2", "pytest"],
     packages=find_packages(),
+    data_files=[(".", ["VERSION"])],
     entry_points={
         "console_scripts": [
             "cve-bin-tool = cve_bin_tool.cli:main",


### PR DESCRIPTION
It was reported that running `cve-bin-tool` after running `python3 setup.py install` resulted in file not found error due to missing VERSION file.
