### PR TITLE
JSON out_file formatted

### DIFF
--- a/cve_bin_tool/OutputEngine.py
+++ b/cve_bin_tool/OutputEngine.py
@@ -50,7 +50,7 @@ class OutputEngine(object):
 
     def output_json(self, outfile):
         """ Output a JSON of CVEs """
-        json.dump(self.formatted_modules(), outfile)
+        json.dump(self.formatted_modules(), outfile, indent="   ")
 
     def output_csv(self, outfile):
         """ Output a CSV of CVEs """


### PR DESCRIPTION
Currently, the JSON out file looks something like the below code.

![Screenshot (18)](https://user-images.githubusercontent.com/29910324/75793914-1494e000-5d96-11ea-8f8c-c5710d5717f2.png)

Although the output file can be used by machines as it is but this is not a good human-readable file. So we can use some indentation to reformat the JSON code. The following code shows  the expected output.

![Screenshot (19)](https://user-images.githubusercontent.com/29910324/75794292-9422af00-5d96-11ea-97a1-9afb63cd4dbe.png)
