### PR TITLE
OpenSSH: Remove trailing whitespace and add file tests.

### DIFF
--- a/cve_bin_tool/checkers/openssh.py
+++ b/cve_bin_tool/checkers/openssh.py
@@ -22,7 +22,7 @@ def get_version(lines, filename):
     # determine version
     for l in lines:
         if regex.match(l):
-            version_info["version"] = regex.match(l).groups()[0]
+            version_info["version"] = regex.match(l).groups()[0].strip()
             break  # The binary seems to contain many version strings and the
             # first one matches the binary in question
 

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -679,6 +679,18 @@ class TestScanner:
                         "11.2.5.3.21",  # Note that the full libdb version is longer than the package version
                     ),
                     (
+                        "http://ftp.debian.org/debian/pool/main/o/openssh/",
+                        "openssh-server_7.4p1-10+deb9u7_mipsel.deb",
+                        "openssh-server",
+                        "7.4p1",
+                    ),
+                    (
+                        "https://download.fedoraproject.org/pub/fedora/linux/updates/29/Everything/x86_64/Packages/o/",
+                        "openssh-server-7.9p1-6.fc29.x86_64.rpm",
+                        "openssh-server",
+                        "7.9p1",
+                    ),
+                    (
                         "http://rpmfind.net/linux/mageia/distrib/5/i586/media/core/updates/",
                         "openssl-1.0.2g-1.1.mga5.i586.rpm",
                         "openssl",


### PR DESCRIPTION
Removes trailing white-space left after regex matching in some cases. Added 2 file tests for openssh-server. #274.

Another way to do this would be to remove the '\s' from the regex. It should work, however, I am not certain this wouldn't have side effects (maybe it is needed for some version formats found or some other reason I am not aware of? I ran `strings` on some of the files in the tests and couldn't find any cases where the white-space match was needed.)