### PR TITLE
Add test for output_csv in OutputEngine

### DIFF
--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -4,6 +4,7 @@ CVE-bin-tool OutputEngine tests
 import unittest
 import io
 import json
+import csv
 
 from cve_bin_tool.OutputEngine import OutputEngine
 
@@ -42,3 +43,19 @@ class TestOutputEngine(unittest.TestCase):
         self.output_engine.output_json(self.mock_file)
         self.mock_file.seek(0)  # reset file position
         self.assertEqual(json.load(self.mock_file), self.FORMATTED_MODULES)
+
+    def test_output_csv(self):
+        """ Test formatting output as CSV """
+        self.output_engine.output_csv(self.mock_file)
+        self.mock_file.seek(0)  # reset file position
+        reader = csv.reader(self.mock_file)
+        next(reader)  # sip first line (header)
+        # read CSV file and convert ourselves
+        read_modules = {}
+        for modulename, version, cve_number, severity in reader:
+            if modulename not in read_modules:
+                read_modules[modulename] = {}
+            if version not in read_modules[modulename]:
+                read_modules[modulename][version] = {}
+            read_modules[modulename][version][cve_number] = severity
+        self.assertEqual(read_modules, self.MOCK_MODULES)


### PR DESCRIPTION
As briefly mentioned in #418, we should test the output produced by each method in OutputEngine. This PR tests the CSV output.

EDIT: closes #419 