### PR TITLE
wrong test file name in README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -10,7 +10,7 @@ python setup.py test
 
 To run scanner and checker tests
 ```console
-pytest test/test_scanner.py test/test_checker.py
+pytest test/test_scanner.py test/test_checkers.py
 ```
 
 By default, some longer-running tests are turned off.  If you want to enable them, you can set the environment variable LONG_TESTS to 1.  You can do this just for a single command line as follows:
@@ -21,7 +21,7 @@ LONG_TESTS=1 python setup.py test
 
 For scanner tests
 ```console
-LONG_TESTS=1 pytest test/test_scanner.py test/test_checker.py
+LONG_TESTS=1 pytest test/test_scanner.py test/test_checkers.py
 ```
 
 ## Running a single test


### PR DESCRIPTION
small fix.
test/test_checker.py -> test/test_checkers.py at two places in the doc.