### PR TITLE
ci: Use checkout action v2

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: jpetrucciani/black-check@master
 
   tests:
@@ -22,7 +22,7 @@ jobs:
     env:
       ACTIONS: 1
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
@@ -50,7 +50,7 @@ jobs:
     env:
       ACTIONS: 1
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v1
       with:
@@ -102,7 +102,7 @@ jobs:
       ACTIONS: 1
       LONG_TESTS: 1
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
- Sometimes when re-running the CI checking out the repo fails.
  Upgrading to v2 of the checkout action fixes this.

Signed-off-by: John Andersen <johnandersenpdx@gmail.com>