### PR TITLE
modify syslog-ng real binary url

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1036,10 +1036,10 @@ class TestScanner:
                         "3.1.2",
                     ),
                     (
-                        "https://download-ib01.fedoraproject.org/pub/epel/7/x86_64/Packages/s/",
-                        "syslog-ng-3.5.6-3.el7.x86_64.rpm",
+                        "https://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/s/",
+                        "syslog-ng-3.25.1-2.fc32.x86_64.rpm",
                         "syslog-ng",
-                        "3.5.6",
+                        "3.25.1",
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",


### PR DESCRIPTION
Fixes #534 
The previous URL was failing sometimes, probably due to network issues. I switched it to a rpmfind url.