### PR TITLE
Adding CVE-id's to scanner test

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -357,11 +357,31 @@ class TestScanner:
                 "test-ncurses-6.1.out",
                 "ncurses",
                 "6.1",
-                ["CVE-2018-19211"],
+                ["CVE-2018-19211"
+                "CVE-2019-17595",
+                 "CVE-2019-17594",
+                 "CVE-2019-15546",
+                 "CVE-2018-19217"
+                ],
                 [
                     # Check to make sure older CVEs aren't included
+                    "CVE-2019-15548",
+                    "CVE-2019-15547",
+                    "CVE-2017-167879",
                     "CVE-2017-13734",
+                    "CVE-2017-13733",
+                    "CVE-2017-13732",
                     "CVE-2017-13731",
+                     "CVE-2017-13730",
+                    "CVE-2017-13729",
+                    "CVE-2017-13728",
+                    "CVE-2017-11113",
+                    "CVE-2017-11112",
+                    "CVE-2017-10685",
+                    "CVE-2017-10684",
+                    "CVE-2005-1796"
+
+
                 ],
             ),
             (
@@ -815,20 +835,30 @@ class TestScanner:
                 ],
             ),
             (
-                "test-binutils-2.31.1.out",
+                "test-binutils-2.32.out",
                 "binutils",
-                "2.31.1",
+                "2.32",
                 [
                     # Check for known cves
                     # Commented out because NVD data has only the last version
                     # 'CVE-2018-1000876',
-                    "CVE-2018-20671",
+                    #"CVE-2018-20671",
+                    "CVE-2018-10534",
+                    "CVE-2018-7208",
+                    "CVE-2019-17451",
+                    "CVE-2019-17450",
+                    "CVE-2019-9077"
+                    "CVE-2019-14444"
                     # 'CVE-2018-20712',
                 ],
                 [
                     # check for an older cve that should not apply
                     "CVE-2018-10534",
                     "CVE-2018-7208",
+                    "CVE-2018-6323",
+                    "CVE-2018-12629"
+                    "CVE-2017-15020"
+                     # 'CVE-2018-20712',
                 ],
             ),
             (


### PR DESCRIPTION
As a part of problem statement specified for adding new checkers sub category, added CVE id's for binutils (version:2.32) and ncurses (version:6.1). Currently coded on MacOS using VSC. Will work on Linux VM as I faced troubles setting it up