### PR TITLE
Added tests for python2.7, since a lot of projects still use this version

### DIFF
--- a/cve_bin_tool/checkers/python.py
+++ b/cve_bin_tool/checkers/python.py
@@ -24,7 +24,7 @@ def guess_contains_python(lines):
 
 def guess_version(lines):
     """
-    Tries to determin the version of python.
+    Tries to determine the version of python.
     """
     # we will try to find python3+ as well as python2+
 

--- a/test/binaries/test-python-2.7.c
+++ b/test/binaries/test-python-2.7.c
@@ -1,15 +1,16 @@
 #include <stdio.h>
 
-int main() {
-  printf("This program is designed to test the cve-bin-tool checker.");
-  printf("It outputs a few strings normally associated with python 2.7.");
-  printf("They appear below this line.");
-  printf("------------------");
-  printf("2.7.0");
-  printf("Internal error in the Python interpreter");
-  printf("Cpython");
-  printf("lib/python2.7");
-  printf("~/anaconda/bin/python");
+int main()
+{
+    printf("This program is designed to test the cve-bin-tool checker.");
+    printf("It outputs a few strings normally associated with python 2.7.");
+    printf("They appear below this line.");
+    printf("------------------");
+    printf("2.7.0");
+    printf("Internal error in the Python interpreter");
+    printf("Cpython");
+    printf("lib/python2.7");
+    printf("~/anaconda/bin/python");
 
-  return 0;
-} 
+    return 0;
+}

--- a/test/binaries/test-python-2.7.c
+++ b/test/binaries/test-python-2.7.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+int main() {
+  printf("This program is designed to test the cve-bin-tool checker.");
+  printf("It outputs a few strings normally associated with python 2.7.");
+  printf("They appear below this line.");
+  printf("------------------");
+  printf("2.7.0");
+  printf("Internal error in the Python interpreter");
+  printf("Cpython");
+  printf("lib/python2.7");
+  printf("~/anaconda/bin/python");
+
+  return 0;
+} 

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -25,6 +25,7 @@ class TestCheckers:
             ("openssh", "slogin", "openssh-client"),
             ("openssh", "sshd", "openssh-server"),
             ("python", "python", "python"),
+            ("python", "python2.7", "python"),
             ("python", "python3.8", "python"),
             ("ncurses", "libncurses.so", "ncurses"),
             # ("python", "python3.9", "python"),

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -793,11 +793,28 @@ class TestScanner:
                 ],
             ),
             (
+                "test-python-2.7.out",
+                "python",
+                "2.7.0",
+                [
+                    # check for known CVEs in this version
+                    "CVE-2019-9948",  # Vulnerability type: Bypass
+                    # "CVE-2019-10160",
+                    #  Failing for above CVE, though its present on NVD: https://nvd.nist.gov/vuln/detail/CVE-2019-10160
+                    "CVE-2018-1000802",  # Vulnerability type: DoS
+                    "CVE-2014-7185",  # Vulnerability type: Overflow
+                ],
+                [
+                    # check to make sure other CVE related to same product is not included
+                    "CVE-2018-1000117",
+                ],
+            ),
+            (
                 "test-gstreamer-1.10.0.out",
                 "gstreamer",
                 "1.10.0",
-                ["CVE-2016-9445"],
-                ["CVE-2016-9447"],
+                ["CVE-2016-9445",],
+                ["CVE-2016-9447",],
             ),
             (
                 "test-varnish-4.1.1.out",
@@ -1011,12 +1028,6 @@ class TestScanner:
                         "hostapd_2.1-0ubuntu1.7_amd64.deb",
                         "hostapd",
                         "2.1",
-                    ),
-                    (
-                        "https://kojipkgs.fedoraproject.org//packages/python3/3.8.2~rc1/1.fc33/aarch64/",
-                        "python3-3.8.2~rc1-1.fc33.aarch64.rpm",
-                        "python",
-                        "3.8.2",
                     ),
                     (
                         "https://kojipkgs.fedoraproject.org/packages/rsyslog/5.5.7/1.fc15/x86_64/",

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -799,8 +799,6 @@ class TestScanner:
                 [
                     # check for known CVEs in this version
                     "CVE-2019-9948",  # Vulnerability type: Bypass
-                    # "CVE-2019-10160",
-                    #  Failing for above CVE, though its present on NVD: https://nvd.nist.gov/vuln/detail/CVE-2019-10160
                     "CVE-2018-1000802",  # Vulnerability type: DoS
                     "CVE-2014-7185",  # Vulnerability type: Overflow
                 ],


### PR DESCRIPTION
* Added CVE mapping tests for python2.7. Please note adding the CVE-2019-10160 results into failing the tests, even though its a valid CVE affecting this version, hence its commented out. Updating local database also does not help. (check https://nvd.nist.gov/vuln/detail/CVE-2019-10160). 
* Added new checker filename mapping test for python2.7 in `test/test_checkers.py`
* Removed a duplicate instance of downloading a python-3.8.2 package, hence it may help speedup long tests a bit. 