### PR TITLE
Fix use of assert in test_scanner

### DIFF
--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -3,8 +3,10 @@
 import pytest
 import pkg_resources
 
+from test.utils import AssertionTest
 
-class TestCheckers:
+
+class TestCheckers(AssertionTest):
     """Run a series of tests directly against individual checkers.
     This is a companion to the tests in TestScanner."""
 
@@ -39,5 +41,5 @@ class TestCheckers:
                 get_version = checker.load()
 
         result = get_version([""], file_name)
-        assert result["is_or_contains"] == "is"
-        assert result["modulename"] == expected_result
+        self.assertEqual(result["is_or_contains"], "is")
+        self.assertEqual(result["modulename"], expected_result)

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1226,7 +1226,7 @@ class TestScanner(AssertionTest):
                     ),
                     (
                         "https://rpmfind.net/linux/opensuse/tumbleweed/repo/oss/x86_64/",
-                        "lighttpd-1.4.55-2.1.x86_64.rpm",
+                        "lighttpd-1.4.55-2.2.x86_64.rpm",
                         "lighttpd",
                         "1.4.55",
                     ),

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -12,8 +12,8 @@ from sys import platform
 
 import pytest
 
-from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.cli import Scanner, InvalidFileError
+from cve_bin_tool.cvedb import CVEDB
 from test.utils import download_file
 
 BINARIES_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "binaries")
@@ -52,6 +52,31 @@ class TestScanner:
     def teardown_class(cls):
         shutil.rmtree(cls.tempdir)
 
+    @staticmethod
+    def assertEqual(actual, expected):
+        if actual != expected:
+            raise AssertionError
+
+    @staticmethod
+    def assertIn(actual, expected):
+        if actual not in expected:
+            raise AssertionError
+
+    @staticmethod
+    def assertNotIn(actual, expected):
+        if actual in expected:
+            raise AssertionError
+
+    @staticmethod
+    def assertIsNone(actual):
+        if actual is not None:
+            raise AssertionError
+
+    @staticmethod
+    def assertIsNotNone(actual):
+        if actual is None:
+            raise AssertionError
+
     def setup_method(self):
         self.cvedb.open()
 
@@ -69,17 +94,17 @@ class TestScanner:
                 "\n".join(["VPkg: haxx, curl", "VPkg: feed, face"])
             )
         )
-        assert pairs
-        assert "haxx" in dict(pairs)
-        assert "curl" in dict(map(lambda x: x[::-1], pairs))
-        assert "feed" in dict(pairs)
-        assert "face" in dict(map(lambda x: x[::-1], pairs))
+        self.assertIsNotNone(pairs)
+        self.assertIn("haxx", dict(pairs))
+        self.assertIn("curl", dict(map(lambda x: x[::-1], pairs)))
+        self.assertIn("feed", dict(pairs))
+        self.assertIn("face", dict(map(lambda x: x[::-1], pairs)))
 
     def test_does_not_scan_symlinks(self):
         """ Test that the scanner doesn't scan symlinks """
         os.symlink("non-existant-file", "non-existant-link")
         try:
-            assert self.scanner.scan_file("non-existant-link") is None
+            self.assertIsNone(self.scanner.scan_file("non-existant-link"))
         finally:
             os.unlink("non-existant-link")
 
@@ -94,14 +119,14 @@ class TestScanner:
         # Run the scan
         cves = self.scan_file(binary)
         # Make sure the package and version are in the results
-        assert package in list(cves.keys())
-        assert version in list(cves[package].keys())
+        self.assertIn(package, cves)
+        self.assertIn(version, cves[package])
         # Test for CVEs known in this version
         for ensure_in in are_in:
-            assert ensure_in in list(cves[package][version].keys())
+            self.assertIn(ensure_in, cves[package][version])
         # Test for a CVE that is not in this version
         for ensure_out in not_in:
-            assert ensure_out not in list(cves[package][version].keys())
+            self.assertNotIn(ensure_out, cves[package][version])
 
     def _file_test(self, url, filename, package, version):
         """ Helper function to get a file (presumed to be a real copy
@@ -117,8 +142,8 @@ class TestScanner:
         cves = self.scanner.extract_and_scan(tempfile)
 
         # make sure we found the expected package/version
-        assert package in cves
-        assert version in cves[package]
+        self.assertIn(package, cves)
+        self.assertIn(version, cves[package])
 
     @pytest.mark.parametrize(
         "binary, package, version, are_in, not_in",
@@ -1131,7 +1156,8 @@ class TestScanner:
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
                         "libdb-5.3.21-25.el7.i686.rpm",
                         "libdb",
-                        "11.2.5.3.21",  # Note that the full libdb version is longer than the package version
+                        "11.2.5.3.21",
+                        # Note that the full libdb version is longer than the package version
                     ),
                     (
                         "https://kojipkgs.fedoraproject.org/packages/ncurses/6.2/1.20200222.fc33/x86_64/",

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -14,12 +14,12 @@ import pytest
 
 from cve_bin_tool.cli import Scanner, InvalidFileError
 from cve_bin_tool.cvedb import CVEDB
-from test.utils import download_file
+from test.utils import download_file, AssertionTest
 
 BINARIES_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "binaries")
 
 
-class TestScanner:
+class TestScanner(AssertionTest):
     """Runs a series of tests against our "faked" binaries.
 
     The faked binaries are very small c files containing the same string signatures we use
@@ -51,31 +51,6 @@ class TestScanner:
     @classmethod
     def teardown_class(cls):
         shutil.rmtree(cls.tempdir)
-
-    @staticmethod
-    def assertEqual(actual, expected):
-        if actual != expected:
-            raise AssertionError
-
-    @staticmethod
-    def assertIn(actual, expected):
-        if actual not in expected:
-            raise AssertionError
-
-    @staticmethod
-    def assertNotIn(actual, expected):
-        if actual in expected:
-            raise AssertionError
-
-    @staticmethod
-    def assertIsNone(actual):
-        if actual is not None:
-            raise AssertionError
-
-    @staticmethod
-    def assertIsNotNone(actual):
-        if actual is None:
-            raise AssertionError
 
     def setup_method(self):
         self.cvedb.open()

--- a/test/utils.py
+++ b/test/utils.py
@@ -33,6 +33,38 @@ class TempDirTest(unittest.TestCase):
         shutil.rmtree(cls.tempdir)
 
 
+class AssertionTest:
+    @staticmethod
+    def assertEqual(actual, expected):
+        if actual != expected:
+            raise AssertionError
+
+    @staticmethod
+    def assertNotEqual(actual, expected):
+        if actual == expected:
+            raise AssertionError
+
+    @staticmethod
+    def assertIn(actual, expected):
+        if actual not in expected:
+            raise AssertionError
+
+    @staticmethod
+    def assertNotIn(actual, expected):
+        if actual in expected:
+            raise AssertionError
+
+    @staticmethod
+    def assertIsNone(actual):
+        if actual is not None:
+            raise AssertionError
+
+    @staticmethod
+    def assertIsNotNone(actual):
+        if actual is None:
+            raise AssertionError
+
+
 def download_file(url, target):
     """ helper method to download a file """
     download = urlopen(url)

--- a/test/utils.py
+++ b/test/utils.py
@@ -37,32 +37,32 @@ class AssertionTest:
     @staticmethod
     def assertEqual(actual, expected):
         if actual != expected:
-            raise AssertionError
+            raise AssertionError(f"{actual} != {expected}")
 
     @staticmethod
     def assertNotEqual(actual, expected):
         if actual == expected:
-            raise AssertionError
+            raise AssertionError(f"{actual} == {expected}")
 
     @staticmethod
     def assertIn(actual, expected):
         if actual not in expected:
-            raise AssertionError
+            raise AssertionError(f"{actual} not in {expected}")
 
     @staticmethod
     def assertNotIn(actual, expected):
         if actual in expected:
-            raise AssertionError
+            raise AssertionError(f"{actual} in {expected}")
 
     @staticmethod
     def assertIsNone(actual):
         if actual is not None:
-            raise AssertionError
+            raise AssertionError(f"{actual} is not None")
 
     @staticmethod
     def assertIsNotNone(actual):
         if actual is None:
-            raise AssertionError
+            raise AssertionError(f"{actual} is None")
 
 
 def download_file(url, target):


### PR DESCRIPTION
Created static methods which raise AssertionError when condition don't meet. I have tried Inheriting unittest.TestCase but pytest docs says,
The following pytest features do not work, and probably never will due to different design philosophies:

- Fixtures (except for autouse fixtures, see below);
- Parametrization;
- Custom hooks;

So , I have decided to make our custom method for this problem. I have checked bandit isn't showing issue anymore.