### PR TITLE
Fix lighttpd filename

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1225,7 +1225,7 @@ class TestScanner:
                     ),
                     (
                         "https://rpmfind.net/linux/opensuse/tumbleweed/repo/oss/x86_64/",
-                        "lighttpd-1.4.55-2.1.x86_64.rpm",
+                        "lighttpd-1.4.55-2.2.x86_64.rpm",
                         "lighttpd",
                         "1.4.55",
                     ),

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1224,8 +1224,8 @@ class TestScanner:
                         "1.4.54",
                     ),
                     (
-                        "https://rpmfind.net/linux/opensuse/tumbleweed/repo/oss/x86_64/",
-                        "lighttpd-1.4.55-2.2.x86_64.rpm",
+                        "https://download-ib01.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/",
+                        "lighttpd-1.4.55-1.el8.x86_64.rpm",
                         "lighttpd",
                         "1.4.55",
                     ),


### PR DESCRIPTION
This will fix the broken build issue.  However, I'm a bit concerned that if rpmfind isn't keeping the older files available, that this is always going to be a moving target.  We may need to find a better archival site to use for these tests.