### PR TITLE
Remove codecov checks from short tests

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: jpetrucciani/black-check@master
 
   tests:
-    name: Short tests
+    name: Short
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: jpetrucciani/black-check@master
 
   tests:
-    name: Run short tests
+    name: Short tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -39,72 +39,6 @@ jobs:
         python setup.py test
         pytest -v test/test_scanner.py test/test_checkers.py
 
-  windows_tests:
-    name: Windows tests on python3.8
-    runs-on: windows-latest
-    timeout-minutes: 10
-    env:
-      ACTIONS: 1
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install coverage
-    - name: try single cli run of tool
-      run: |
-        python -m cve_bin_tool.cli test/binaries
-    - name: Run checker tests
-      run: |
-        coverage run --append -m pytest -v test/test_checkers.py
-    - name: Run cli tests
-      run: |
-        coverage run --append -m unittest test.test_cli
-      continue-on-error: true
-    - name: Run csv2cve tests
-      run: |
-        coverage run --append -m unittest test.test_csv2cve
-    - name: Run cvedb tests
-      run: |
-        coverage run --append -m unittest test.test_cvedb
-    - name: Run output engine tests
-      run: |
-        coverage run --append -m unittest test.test_output_engine
-    - name: Run extract tests
-      run: |
-        coverage run --append -m unittest test.test_extract
-    - name: Run file tests
-      run: |
-        coverage run --append -m unittest test.test_file
-    - name: Run json tests
-      run: |
-        coverage run --append -m unittest test.test_json
-    - name: Run scanner tests
-      run: |
-        coverage run --append -m pytest -v test/test_scanner.py
-      continue-on-error: true
-    - name: Run strings tests
-      run: |
-        coverage run --append -m unittest test.test_strings
-    - name: Run util tests
-      run: |
-        coverage run --append -m unittest test.test_util
-    - name: Create xml file of coverage report
-      run: |
-        coverage xml -o win_cov_report.xml
-    - name: upload code coverage to codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./win_cov_report.xml
-        flags: wintests
-        name: codecov-umbrella
-        fail_ci_if_error: false
-
   long_tests:
     name: Long tests on python3.8
     runs-on: ubuntu-latest
@@ -138,4 +72,60 @@ jobs:
         flags: longtests
         name: codecov-umbrella
         fail_ci_if_error: false
+
+  windows_tests:
+    name: Windows tests on python3.8
+    runs-on: windows-latest
+    timeout-minutes: 10
+    env:
+      ACTIONS: 1
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install coverage
+    - name: try single cli run of tool
+      run: |
+        python -m cve_bin_tool.cli test/binaries
+    - name: Run checker tests
+      run: |
+        coverage run --append -m pytest -v test/test_checkers.py
+    - name: Run cli tests
+      run: |
+        python -m unittest test.test_cli
+      continue-on-error: true
+    - name: Run csv2cve tests
+      run: |
+        python -m unittest test.test_csv2cve
+    - name: Run cvedb tests
+      run: |
+        python -m unittest test.test_cvedb
+    - name: Run output engine tests
+      run: |
+        python -m unittest test.test_output_engine
+    - name: Run extract tests
+      run: |
+        python -m unittest test.test_extract
+    - name: Run file tests
+      run: |
+        python -m unittest test.test_file
+    - name: Run json tests
+      run: |
+        python -m unittest test.test_json
+    - name: Run scanner tests
+      run: |
+        coverage run --append -m pytest -v test/test_scanner.py
+      continue-on-error: true
+    - name: Run strings tests
+      run: |
+        python -m unittest test.test_strings
+    - name: Run util tests
+      run: |
+        python -m unittest test.test_util
 

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: jpetrucciani/black-check@master
 
   tests:
-    name: Short
+    name: Tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,8 +16,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-         os: [ubuntu-latest]
-         python: [3.6, 3.7]
+        os: [ubuntu-latest]
+        python: [3.6, 3.7]
     timeout-minutes: 10
     env:
       ACTIONS: 1
@@ -74,7 +74,7 @@ jobs:
         fail_ci_if_error: false
 
   windows_tests:
-    name: Windows tests on python3.8
+    name: Windows py3.8
     runs-on: windows-latest
     timeout-minutes: 10
     env:

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: jpetrucciani/black-check@master
 
   tests:
-    name: Run tests
+    name: Run short tests
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -36,21 +36,8 @@ jobs:
         python -m cve_bin_tool.cli test/binaries
     - name: Run tests
       run: |
-        pip install coverage
-        coverage run --append setup.py test
-        coverage run --append -m pytest -v test/test_scanner.py test/test_checkers.py
-        coverage xml -o py36_cov_report.xml
-    - name: upload code coverage to codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./py36_cov_report.xml
-        flags: ubuntutests
-        name: codecov-umbrella
-        fail_ci_if_error: false
-    - name: Check files
-      run: |
-        ls -al ~/.cache/
-        ls -al ~/.cache/cvedb
+        python setup.py test
+        pytest -v test/test_scanner.py test/test_checkers.py
 
   windows_tests:
     name: Windows tests on python3.8


### PR DESCRIPTION
as discussed in gitter, runninng codecov on the short tests results in kind of useless automated coverage stuff that always says coverage is going down ~10%.  This is an attempt to make the coverage numbers we get on PRs be more realistic and meaningful.