### PR TITLE
Temporarily disable failing tests

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1097,11 +1097,12 @@ class TestScanner:
                         "expat",
                         "2.2.0",
                     ),
-                    (
+                    pytest.param(
                         "http://archive.ubuntu.com/ubuntu/pool/universe/f/ffmpeg/",
                         "ffmpeg_4.1.1-1_amd64.deb",
                         "ffmpeg",
                         "4.1.1",
+                        marks=pytest.mark.xfail(reason="File cannot be downloaded"),
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
@@ -1223,11 +1224,12 @@ class TestScanner:
                         "lighttpd",
                         "1.4.54",
                     ),
-                    (
+                    pytest.param(
                         "https://download-ib01.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/",
                         "lighttpd-1.4.55-1.el8.x86_64.rpm",
                         "lighttpd",
                         "1.4.55",
+                        marks=pytest.mark.xfail(reason="File won't download on github"),
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",


### PR DESCRIPTION
two of our tests are failing in CI due to the test files not downloading.  This PR temporarily disables them both.

When I run locally the lightttpd one runs correctly but the ffmpeg one does not.