### PR TITLE
Fixes ffmpeg link for ubuntu and added lighttpd for suse

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1101,7 +1101,7 @@ class TestScanner:
                         "http://archive.ubuntu.com/ubuntu/pool/universe/f/ffmpeg/",
                         "ffmpeg_4.1.4-1build2_amd64.deb",
                         "ffmpeg",
-                        "4.1.4",
+                        "4.1.4"
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
@@ -1223,11 +1223,18 @@ class TestScanner:
                         "lighttpd",
                         "1.4.54",
                     ),
-                    (
-                        "https://ftp.lysator.liu.se/pub/opensuse/distribution/leap/15.1/repo/oss/x86_64/",
-                        "lighttpd-1.4.49-lp151.2.3.x86_64.rpm",
+                    pytest.param(
+                        "https://download-ib01.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/",
+                        "lighttpd-1.4.55-1.el8.x86_64.rpm",
                         "lighttpd",
-                        "1.4.49",
+                        "1.4.55",
+                        marks=pytest.mark.xfail(reason="File won't download on github"),
+                    ),
+                    (
+                            "https://ftp.lysator.liu.se/pub/opensuse/distribution/leap/15.1/repo/oss/x86_64/",
+                            "lighttpd-1.4.49-lp151.2.3.x86_64.rpm",
+                            "lighttpd",
+                            "1.4.49",
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1097,12 +1097,11 @@ class TestScanner:
                         "expat",
                         "2.2.0",
                     ),
-                    pytest.param(
+                    (
                         "http://archive.ubuntu.com/ubuntu/pool/universe/f/ffmpeg/",
-                        "ffmpeg_4.1.1-1_amd64.deb",
+                        "ffmpeg_4.1.4-1build2_amd64.deb",
                         "ffmpeg",
-                        "4.1.1",
-                        marks=pytest.mark.xfail(reason="File cannot be downloaded"),
+                        "4.1.4",
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
@@ -1224,12 +1223,11 @@ class TestScanner:
                         "lighttpd",
                         "1.4.54",
                     ),
-                    pytest.param(
-                        "https://download-ib01.fedoraproject.org/pub/epel/8/Everything/x86_64/Packages/l/",
-                        "lighttpd-1.4.55-1.el8.x86_64.rpm",
+                    (
+                        "https://ftp.lysator.liu.se/pub/opensuse/distribution/leap/15.1/repo/oss/x86_64/",
+                        "lighttpd-1.4.49-lp151.2.3.x86_64.rpm",
                         "lighttpd",
-                        "1.4.55",
-                        marks=pytest.mark.xfail(reason="File won't download on github"),
+                        "1.4.49",
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1101,7 +1101,7 @@ class TestScanner:
                         "http://archive.ubuntu.com/ubuntu/pool/universe/f/ffmpeg/",
                         "ffmpeg_4.1.4-1build2_amd64.deb",
                         "ffmpeg",
-                        "4.1.4"
+                        "4.1.4",
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
@@ -1231,10 +1231,10 @@ class TestScanner:
                         marks=pytest.mark.xfail(reason="File won't download on github"),
                     ),
                     (
-                            "https://ftp.lysator.liu.se/pub/opensuse/distribution/leap/15.1/repo/oss/x86_64/",
-                            "lighttpd-1.4.49-lp151.2.3.x86_64.rpm",
-                            "lighttpd",
-                            "1.4.49",
+                        "https://ftp.lysator.liu.se/pub/opensuse/distribution/leap/15.1/repo/oss/x86_64/",
+                        "lighttpd-1.4.49-lp151.2.3.x86_64.rpm",
+                        "lighttpd",
+                        "1.4.49",
                     ),
                     (
                         "http://mirror.centos.org/centos/7/os/x86_64/Packages/",


### PR DESCRIPTION
ubuntu have updated ffmpeg version in archive that's why old link wasn't working. Don't know why Fedora link isn't working. 