### PR TITLE
Up long tests timeout to 45 min (from 30)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -42,7 +42,7 @@ jobs:
   long_tests:
     name: Long tests on python3.8
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       ACTIONS: 1
     steps:


### PR DESCRIPTION
We're starting to get close to the 30 minute timeout on the long tests, so I'm upping it to 45 minutes for now.  Hopefully we'll be able to get it back down a bit with cacheing in the future.