### PR TITLE
improved_coverage for output_engine

### DIFF
--- a/cve_bin_tool/OutputEngine.py
+++ b/cve_bin_tool/OutputEngine.py
@@ -26,7 +26,7 @@ class OutputEngine(object):
     def generate_filename(self, extension=None):
         """ Generates a random filename"""
         if extension:
-            now = datetime.now().strftime("%Y-%m-%d.%H:%m:%S")
+            now = datetime.now().strftime("%Y-%m-%d.%H-%m-%S")
             self.filename = f"output.cve-bin-tool.{now}.{extension}"
 
     def output_cves(self, outfile, output_type=None):

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -6,6 +6,8 @@ import tempfile
 import json
 import csv
 import sys
+import os
+import logging
 
 from cve_bin_tool.OutputEngine import OutputEngine
 
@@ -112,3 +114,106 @@ class TestOutputEngine(unittest.TestCase):
 """
         self.mock_file.seek(0)  # reset file position
         self.assertEqual(output_modules, self.mock_file.read())
+
+    def test_output_file(self):
+        """Test file generation logic in output_file"""
+        logger = logging.getLogger()
+        
+        with self.assertLogs(logger, logging.INFO) as cm:
+            self.output_engine.output_file(output_type="json")
+        
+        contains_filename = False
+        contains_msg = False
+
+        filename = self.output_engine.filename
+
+        file_list = os.listdir(os.getcwd())
+        for file_ in file_list:
+            if filename == file_:
+                contains_filename = True
+        
+        if "Output stored at" in cm.output[0]:
+            contains_msg = True
+
+        self.assertEqual(contains_filename, True)
+        self.assertEqual(contains_msg, True)
+        
+        # reset everything back
+        os.remove(filename)
+        self.output_engine.filename = None
+    
+    def test_output_file_filename_already_exists(self):
+        """Tests output_file when filename already exist"""
+        
+        # update the filename in output_engine
+        self.output_engine.filename = "testfile"
+
+        # create a file with the same name as output_engine.filename 
+        with open("testfile", "w") as f:
+                    f.write("testing")
+        
+        logger = logging.getLogger()
+
+        # setup the context manager
+        with self.assertLogs(logger, logging.INFO) as cm:
+            self.output_engine.output_file(output_type="csv")
+        
+        # logs to check in cm
+        msg_generate_filename = "Generating a new filename with Default Naming Convention"
+        msg_failed_to_write = "Failed to write at 'testfile'. File already exists"
+
+        # flags for logs
+        contains_fail2write = False
+        contains_gen_file = False
+
+        # check if the logger contains msg
+        for log in cm.output:
+            if msg_generate_filename in log:
+                contains_gen_file = True
+            elif msg_failed_to_write in log:
+                contains_fail2write = True
+        
+        # remove the generated files and reset updated variables
+        os.remove("testfile")
+        os.remove(self.output_engine.filename)
+        self.output_engine.filename = None
+
+        # assert 
+        self.assertEqual(contains_gen_file, True)
+        self.assertEqual(contains_fail2write, True)        
+
+    def test_output_file_incorrect_filename(self):
+        """Tests filenames that are incorrect or are not accessible"""
+
+        # update the filename in output_engine
+        self.output_engine.filename = "/not/a/good_filename"
+
+        logger = logging.getLogger()
+
+        # setup the context manager
+        with self.assertLogs(logger, logging.INFO) as cm:
+            self.output_engine.output_file(output_type="csv")
+        
+        # log to check
+        msg_switch_back = "Switching Back to Default Naming Convention"
+        
+        # flags
+        contains_sb = False
+
+        for log in cm.output:
+            if msg_switch_back in log:
+                contains_sb = True
+        
+        # remove the generated files and reset updated variables 
+        os.remove(self.output_engine.filename)
+        self.output_engine.filename = None
+
+        # assert
+        self.assertEqual(contains_sb, True) 
+
+
+        
+
+
+
+        

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -125,11 +125,11 @@ class TestOutputEngine(unittest.TestCase):
         contains_filename = False
         contains_msg = False
 
-        filename = os.path.join(os.getcwd(), self.output_engine.filename)
+        filename = self.output_engine.filename
 
         file_list = os.listdir(os.getcwd())
         for file_ in file_list:
-            if self.output_engine.filename == file_:
+            if filename == file_:
                 contains_filename = True
 
         if "Output stored at" in cm.output[0]:

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -125,11 +125,11 @@ class TestOutputEngine(unittest.TestCase):
         contains_filename = False
         contains_msg = False
 
-        filename = self.output_engine.filename
+        filename = os.path.join(os.getcwd(), self.output_engine.filename)
 
         file_list = os.listdir(os.getcwd())
         for file_ in file_list:
-            if filename == file_:
+            if self.output_engine.filename == file_:
                 contains_filename = True
 
         if "Output stored at" in cm.output[0]:

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -118,10 +118,10 @@ class TestOutputEngine(unittest.TestCase):
     def test_output_file(self):
         """Test file generation logic in output_file"""
         logger = logging.getLogger()
-        
+
         with self.assertLogs(logger, logging.INFO) as cm:
             self.output_engine.output_file(output_type="json")
-        
+
         contains_filename = False
         contains_msg = False
 
@@ -131,35 +131,37 @@ class TestOutputEngine(unittest.TestCase):
         for file_ in file_list:
             if filename == file_:
                 contains_filename = True
-        
+
         if "Output stored at" in cm.output[0]:
             contains_msg = True
 
         self.assertEqual(contains_filename, True)
         self.assertEqual(contains_msg, True)
-        
+
         # reset everything back
         os.remove(filename)
         self.output_engine.filename = None
-    
+
     def test_output_file_filename_already_exists(self):
         """Tests output_file when filename already exist"""
-        
+
         # update the filename in output_engine
         self.output_engine.filename = "testfile"
 
-        # create a file with the same name as output_engine.filename 
+        # create a file with the same name as output_engine.filename
         with open("testfile", "w") as f:
-                    f.write("testing")
-        
+            f.write("testing")
+
         logger = logging.getLogger()
 
         # setup the context manager
         with self.assertLogs(logger, logging.INFO) as cm:
             self.output_engine.output_file(output_type="csv")
-        
+
         # logs to check in cm
-        msg_generate_filename = "Generating a new filename with Default Naming Convention"
+        msg_generate_filename = (
+            "Generating a new filename with Default Naming Convention"
+        )
         msg_failed_to_write = "Failed to write at 'testfile'. File already exists"
 
         # flags for logs
@@ -172,15 +174,15 @@ class TestOutputEngine(unittest.TestCase):
                 contains_gen_file = True
             elif msg_failed_to_write in log:
                 contains_fail2write = True
-        
+
         # remove the generated files and reset updated variables
         os.remove("testfile")
         os.remove(self.output_engine.filename)
         self.output_engine.filename = None
 
-        # assert 
+        # assert
         self.assertEqual(contains_gen_file, True)
-        self.assertEqual(contains_fail2write, True)        
+        self.assertEqual(contains_fail2write, True)
 
     def test_output_file_incorrect_filename(self):
         """Tests filenames that are incorrect or are not accessible"""
@@ -193,27 +195,20 @@ class TestOutputEngine(unittest.TestCase):
         # setup the context manager
         with self.assertLogs(logger, logging.INFO) as cm:
             self.output_engine.output_file(output_type="csv")
-        
+
         # log to check
         msg_switch_back = "Switching Back to Default Naming Convention"
-        
+
         # flags
         contains_sb = False
 
         for log in cm.output:
             if msg_switch_back in log:
                 contains_sb = True
-        
-        # remove the generated files and reset updated variables 
+
+        # remove the generated files and reset updated variables
         os.remove(self.output_engine.filename)
         self.output_engine.filename = None
 
         # assert
-        self.assertEqual(contains_sb, True) 
-
-
-        
-
-
-
-        
+        self.assertEqual(contains_sb, True)


### PR DESCRIPTION
Changes
------------
- changed filename generation function in OutputEngine.py. Changed ```:```  to ```-``` because ```:``` is not a valid name character in Windows. And was the reason my tests were failing in windows.
-  Improved Coverage for cve_bin_tool/OutputEngine.py  (98% from  68.24%)