### PR TITLE
Switch back to .cache/cve-bin-tool

### DIFF
--- a/cve_bin_tool/VersionSignature.py
+++ b/cve_bin_tool/VersionSignature.py
@@ -2,7 +2,7 @@ import os
 import sqlite3
 import time
 from datetime import datetime
-from cvedb import DISK_LOCATION_DEFAULT
+from .cvedb import DISK_LOCATION_DEFAULT
 
 
 class VersionSignatureDb:

--- a/cve_bin_tool/VersionSignature.py
+++ b/cve_bin_tool/VersionSignature.py
@@ -2,8 +2,7 @@ import os
 import sqlite3
 import time
 from datetime import datetime
-
-DISK_LOCATION_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
+from cvedb import DISK_LOCATION_DEFAULT
 
 
 class VersionSignatureDb:

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -421,6 +421,12 @@ def main(argv=None):
     # Connect to the database
     cvedb_orig = CVEDB()
 
+    # if OLD_CACHE_DIR (from cvedb.py) exists, print warning
+    if os.path.exists(OLD_CACHE_DIR):
+        LOGGER.warning(
+            f"Obsolete cache dir {OLD_CACHE_DIR} is no longer needed and can be removed."
+        )
+
     # Clear data if -u now is set
     if args.update == "now":
         cvedb_orig.clear_cached_data()

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -32,7 +32,7 @@ from .strings import Strings
 from .file import is_binary
 from .OutputEngine import OutputEngine
 
-from .cvedb import CVEDB
+from .cvedb import CVEDB, OLD_CACHE_DIR
 from .log import LOGGER
 
 try:

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -595,7 +595,7 @@ class CVEDB(object):
             shutil.rmtree(self.cachedir)
         # Remove files associated with pre-1.0 development tree
         if os.path.exists(OLD_CACHE_DIR):
-            seLf.LOGGER.warning(f"Deleting old cachedir {OLD_CACHE_DIR}")
+            self.LOGGER.warning(f"Deleting old cachedir {OLD_CACHE_DIR}")
             shutil.rmtree(OLD_CACHE_DIR)
 
 

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -30,8 +30,9 @@ from pkg_resources import parse_version
 logging.basicConfig(level=logging.DEBUG)
 
 # database defaults
-DISK_LOCATION_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
+DISK_LOCATION_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "cve-bin-tool")
 DBNAME = "cve.db"
+OLD_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
 
 
 class EmptyCache(Exception):
@@ -145,7 +146,7 @@ class CVEDB(object):
     Downloads NVD data in json form and stores it on disk in a cache.
     """
 
-    CACHEDIR = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
+    CACHEDIR = DISK_LOCATION_DEFAULT
     FEED = "https://nvd.nist.gov/vuln/data-feeds"
     LOGGER = LOGGER.getChild("CVEDB")
     NVDCVE_FILENAME_TEMPLATE = "nvdcve-1.1-{}.json"
@@ -592,6 +593,10 @@ class CVEDB(object):
         if os.path.exists(self.cachedir):
             self.LOGGER.warning(f"Deleting cachedir {self.cachedir}")
             shutil.rmtree(self.cachedir)
+        # Remove files associated with pre-1.0 development tree
+        if os.path.exists(OLD_CACHE_DIR):
+            seLf.LOGGER.warning(f"Deleting old cachedir {OLD_CACHE_DIR}")
+            shutil.rmtree(OLD_CACHE_DIR)
 
 
 def refresh():
@@ -601,7 +606,7 @@ def refresh():
 
 if __name__ == "__main__":
     LOGGER.debug("Experimenting...")
-    cvedb = CVEDB(os.path.join(os.path.expanduser("~"), ".cache", "cvedb"))
+    cvedb = CVEDB(DISK_LOCATION_DEFAULT)
     # cvedb.refresh()
     # print(cvedb.years())
     # connection = cvedb.init_database()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,7 +6,7 @@ import unittest
 import logging
 import subprocess
 from cve_bin_tool.cli import main
-import cve_bin_tool.cvedb  # for disk location default
+from cve_bin_tool.cvedb import DISK_LOCATION_DEFAULT
 from cve_bin_tool.extractor import Extractor
 
 from .utils import (

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,6 +6,7 @@ import unittest
 import logging
 import subprocess
 from cve_bin_tool.cli import main
+import cve_bin_tool.cvedb  # for disk location default
 from cve_bin_tool.extractor import Extractor
 
 from .utils import (
@@ -184,7 +185,7 @@ class TestCLI(TempDirTest):
 
         with self.assertLogs(logger, logging.INFO) as cm:
             main(["cve-bin-tool", "-u", "now", test_path])
-        db_path = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
+        db_path = DISK_LOCATION_DEFAULT
         self.assertTrue(
             ("WARNING:cve_bin_tool.CVEDB:Deleting cachedir " + db_path in cm.output)
             and (

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from test.utils import LONG_TESTS
-import cve_bin_tool.cvedb  # for default disk location
+from cve_bin_tool.cvedb import DISK_LOCATION_DEFAULT
 
 # Try python3 dependency, fall back if not available
 try:

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -13,6 +13,7 @@ from zipfile import ZipFile
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
 from test.utils import LONG_TESTS
+import cve_bin_tool.cvedb  # for default disk location
 
 # Try python3 dependency, fall back if not available
 try:
@@ -23,7 +24,6 @@ except ImportError:
 NVD_SCHEMA = "https://scap.nist.gov/schema/nvd/feed/1.1/nvd_cve_feed_json_1.1.schema"
 
 # NVD feeds from "https://nvd.nist.gov/vuln/data-feeds#JSON_FEED" but stored locally
-DISK_LOCATION_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
 NVD_FILE_TEMPLATE = "nvdcve-1.1-{}.json"
 
 


### PR DESCRIPTION
Fixes #320 
* Changes back to old default directory of .cache/cve-bin-tool (from .cache/cvedb)
* Adds warning if old directory exists
* Removes old directory when `-u now` is used

I'll likely do the switch back to gzipped json files as well in future, but probably in a separate PR.