### PR TITLE
cvedb: Store NVD JSON files gzip compressed

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -91,7 +91,7 @@ def cache_update(cachedir, url, sha, chunk_size=16 * 1024, logger=LOGGER):
     """
     Update the cache for a single year of NVD data.
     """
-    filename = url.split("/")[-1].replace(".gz", "")
+    filename = url.split("/")[-1]
     # Ensure we only write to files within the cachedir
     filepath = os.path.abspath(os.path.join(cachedir, filename))
     if not filepath.startswith(os.path.abspath(cachedir)):
@@ -101,7 +101,7 @@ def cache_update(cachedir, url, sha, chunk_size=16 * 1024, logger=LOGGER):
         # Validate the sha and write out
         sha = sha.upper()
         calculate = hashlib.sha256()
-        with open(filepath, "rb") as handle:
+        with gzip.open(filepath, "rb") as handle:
             chunk = handle.read(chunk_size)
             while chunk:
                 calculate.update(chunk)
@@ -127,7 +127,7 @@ def cache_update(cachedir, url, sha, chunk_size=16 * 1024, logger=LOGGER):
             sha = sha.upper()
             calculate = hashlib.sha256()
             # Copy the contents while updating the sha
-            with open(filepath, "wb") as filepath_handle:
+            with gzip.open(filepath, "wb") as filepath_handle:
                 chunk = jsondata_fileobj.read(chunk_size)
                 while chunk:
                     calculate.update(chunk)
@@ -149,7 +149,7 @@ class CVEDB(object):
     CACHEDIR = DISK_LOCATION_DEFAULT
     FEED = "https://nvd.nist.gov/vuln/data-feeds"
     LOGGER = LOGGER.getChild("CVEDB")
-    NVDCVE_FILENAME_TEMPLATE = "nvdcve-1.1-{}.json"
+    NVDCVE_FILENAME_TEMPLATE = "nvdcve-1.1-{}.json.gz"
     META_REGEX = re.compile(r"https:\/\/.*\/json\/.*-[0-9]*\.[0-9]*-[0-9]*\.meta")
     RANGE_UNSET = ""
 
@@ -558,7 +558,7 @@ class CVEDB(object):
         if not os.path.isfile(filename):
             raise CVEDataForYearNotInCache(year)
         # Open the file and load the JSON data, log the number of CVEs loaded
-        with open(filename, "rb") as fileobj:
+        with gzip.open(filename, "rb") as fileobj:
             cves_for_year = json.load(fileobj)
             self.LOGGER.debug(
                 f'Year {year} has {len(cves_for_year["CVE_Items"])} CVEs in dataset'
@@ -571,9 +571,9 @@ class CVEDB(object):
         """
         return sorted(
             [
-                int(filename.split(".")[-2].split("-")[-1])
+                int(filename.split(".")[-3].split("-")[-1])
                 for filename in glob.glob(
-                    os.path.join(self.cachedir, "nvdcve-1.1-*.json")
+                    os.path.join(self.cachedir, "nvdcve-1.1-*.json.gz")
                 )
             ]
         )

--- a/test/test_cvedb.py
+++ b/test/test_cvedb.py
@@ -46,6 +46,6 @@ class TestCVEDB(unittest.TestCase):
         with self.cvedb:
             self.assertTrue(
                 os.path.isfile(
-                    os.path.join(self.cvedb.cachedir, "nvdcve-1.1-2015.json")
+                    os.path.join(self.cvedb.cachedir, "nvdcve-1.1-2015.json.gz")
                 )
             )

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -6,6 +6,7 @@ This uses the schemas mentioned here: https://nvd.nist.gov/vuln/Data-Feeds/JSON-
 """
 import hashlib
 import json
+import gzip
 import os
 import unittest
 import datetime
@@ -24,7 +25,7 @@ except ImportError:
 NVD_SCHEMA = "https://scap.nist.gov/schema/nvd/feed/1.1/nvd_cve_feed_json_1.1.schema"
 
 # NVD feeds from "https://nvd.nist.gov/vuln/data-feeds#JSON_FEED" but stored locally
-NVD_FILE_TEMPLATE = "nvdcve-1.1-{}.json"
+NVD_FILE_TEMPLATE = "nvdcve-1.1-{}.json.gz"
 
 
 class TestJSON(unittest.TestCase):
@@ -39,11 +40,11 @@ class TestJSON(unittest.TestCase):
         years = list(range(2002, datetime.datetime.now().year + 1))
         # Open the latest nvd file on disk
         for year in years:
-            with open(
-                os.path.join(DISK_LOCATION_DEFAULT, f"nvdcve-1.1-{year}.json"), "rb",
+            with gzip.open(
+                os.path.join(DISK_LOCATION_DEFAULT, f"nvdcve-1.1-{year}.json.gz"), "rb",
             ) as json_file:
                 nvd_json = json.loads(json_file.read())
-                print(f"Loaded json for year {year}: nvdcve-1.1-{year}.json")
+                print(f"Loaded json for year {year}: nvdcve-1.1-{year}.json.gz")
 
                 # Validate -- will raise a ValidationError if not valid
                 try:


### PR DESCRIPTION
### Before

```console
$ du -h ~/.cache/cve-bin-tool/*
226M    /home/johnsa1/.cache/cve-bin-tool/cve.db
20M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2002.json
5.4M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2003.json
12M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2004.json
18M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2005.json
28M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2006.json
27M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2007.json
31M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2008.json
30M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2009.json
43M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2010.json
83M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2011.json
40M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2012.json
43M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2013.json
42M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2014.json
39M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2015.json
48M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2016.json
65M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2017.json
68M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2018.json
69M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2019.json
16M     /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2020.json
$ du -h ~/.cache/cve-bin-tool/
944M    /home/johnsa1/.cache/cve-bin-tool/
```

### After

```console
$ du -h ~/.cache/cve-bin-tool/*
226M    /home/johnsa1/.cache/cve-bin-tool/cve.db
1.3M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2002.json.gz
388K    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2003.json.gz
760K    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2004.json.gz
1.2M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2005.json.gz
2.0M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2006.json.gz
2.0M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2007.json.gz
2.0M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2008.json.gz
1.8M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2009.json.gz
2.2M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2010.json.gz
3.1M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2011.json.gz
2.0M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2012.json.gz
2.2M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2013.json.gz
2.3M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2014.json.gz
2.1M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2015.json.gz
2.4M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2016.json.gz
3.2M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2017.json.gz
3.5M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2018.json.gz
3.6M    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2019.json.gz
784K    /home/johnsa1/.cache/cve-bin-tool/nvdcve-1.1-2020.json.gz
$ du -h ~/.cache/cve-bin-tool/
264M    /home/johnsa1/.cache/cve-bin-tool/
```

So we save `944M - 264M = 680M ~= 0.5G` space with this... I should have done this earlier when we did the initial CVEDB stuff but for some reason I couldn't figure it out, I'd tried several times I don't know why it didn't make sense. Opened it up today and everything made sense! :D