### PR TITLE
Removed second lighttpd 1.4.54 test

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1339,12 +1339,6 @@ class TestScanner:
                         "1.4.54",
                     ),
                     (
-                        "https://download-ib01.fedoraproject.org/pub/fedora/linux/releases/31/Everything/x86_64/os/Packages/l/",
-                        "lighttpd-1.4.54-2.fc31.x86_64.rpm",
-                        "lighttpd",
-                        "1.4.54",
-                    ),
-                    (
                         "https://ftp.lysator.liu.se/pub/opensuse/distribution/leap/15.1/repo/oss/x86_64/",
                         "lighttpd-1.4.49-lp151.2.3.x86_64.rpm",
                         "lighttpd",


### PR DESCRIPTION
There were two lighttpd tests on the same file, just one stored at fedora and one in the fedora mirror on kernel.org.  Since the fedora one wasn't working, I've removed it and left the kernel.org one for now.  As kernel.org should be a mirror of fedora, I'm guessing if one breaks it's only a matter of time before the other does too.