### PR TITLE
Skip long_test if the url is not reachable.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+requests
 jsonschema
 pytest
-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema
 pytest
+requests

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -8,6 +8,7 @@ import shutil
 import subprocess
 import tempfile
 import unittest
+import requests
 from sys import platform
 
 import pytest

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -1562,7 +1562,7 @@ class TestScanner:
             requests.head(url + filename).status_code != 200,
             reason="url cannot be reached",
         )
-        def _file_test(self, url, filename, package, version):
+        def _file_test(url, filename, package, version):
             """ Helper function to get a file (presumed to be a real copy
             of a library, probably from a Linux distribution) and run a
             scan on it.  Any test using this should likely be listed as a
@@ -1579,4 +1579,4 @@ class TestScanner:
             assert package in cves
             assert version in cves[package]
 
-        self._file_test(url, filename, package, version)
+        _file_test(url, filename, package, version)

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -103,23 +103,6 @@ class TestScanner:
         for ensure_out in not_in:
             assert ensure_out not in list(cves[package][version].keys())
 
-    def _file_test(self, url, filename, package, version):
-        """ Helper function to get a file (presumed to be a real copy
-        of a library, probably from a Linux distribution) and run a
-        scan on it.  Any test using this should likely be listed as a
-        long test."""
-        # get file
-        tempfile = os.path.join(self.tempdir, filename)
-        download_file(url + filename, tempfile)
-        # new scanner for the new test.
-        self.scanner = Scanner(cvedb=self.cvedb)
-        # run the tests
-        cves = self.scanner.extract_and_scan(tempfile)
-
-        # make sure we found the expected package/version
-        assert package in cves
-        assert version in cves[package]
-
     @pytest.mark.parametrize(
         "binary, package, version, are_in, not_in",
         [
@@ -1574,4 +1557,25 @@ class TestScanner:
     )
     @unittest.skipUnless(LONG_TESTS() > 0, "Skipping long tests")
     def test_files(self, url, filename, package, version):
+        @pytest.mark.skipif(
+            requests.head(url + filename).status_code != 200,
+            reason="url cannot be reached",
+        )
+        def _file_test(self, url, filename, package, version):
+            """ Helper function to get a file (presumed to be a real copy
+            of a library, probably from a Linux distribution) and run a
+            scan on it.  Any test using this should likely be listed as a
+            long test."""
+            # get file
+            tempfile = os.path.join(self.tempdir, filename)
+            download_file(url + filename, tempfile)
+            # new scanner for the new test.
+            self.scanner = Scanner(cvedb=self.cvedb)
+            # run the tests
+            cves = self.scanner.extract_and_scan(tempfile)
+
+            # make sure we found the expected package/version
+            assert package in cves
+            assert version in cves[package]
+
         self._file_test(url, filename, package, version)


### PR DESCRIPTION
Problem
------------
As we all have encountered the problem of long_tests failing due to multiple reasons. Some of the reasons were 
- Website is not reachable due to maintenance issue.
- Links were updated 
- other unseen issues

This problem can be solved if before downloading the package we can check that the website is up and we can download the package. If not then mark it as "skip" and continue   