### PR TITLE
Faster native solution for string parsing and removed parser for python2

### DIFF
--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -7,6 +7,7 @@ and MacOS.
 """
 
 import sys
+import string
 
 try:
     import cve_bin_tool.pstring as pstring
@@ -18,44 +19,18 @@ class Strings(object):
     def __init__(self, filename=""):
         self.filename = filename
         self.output = ""
+        self.printable = set(string.printable)
 
     def parse(self):
         # Use c extention if available
         if pstring is not None:
             return pstring.string(self.filename)
-        elif sys.version_info.major == 3:
-            return self.parse_3()
         else:
-            return self.parse_2()
-
-    def parse_2(self):
-        f = file(self.filename, "rb")
-        l = f.readline()
-        tmp = ""
-        while l:
-            for c in l:
-                # remove all unprintable characters
-                if ord(c) < 128 and ord(c) > 31:
-                    tmp += c
-                else:
-                    if tmp != "":
-                        self.output += tmp + "\n"
-                        tmp = ""
-            l = f.readline()
-        return self.output
+            return self.parse_3()
 
     def parse_3(self):
-        with open(self.filename, "rb") as f:
-            tmp = ""
-            for l in f:
-                for c in l:
-                    # remove all unprintable characters
-                    if c <= 31 or c >= 128:
-                        if tmp != "":
-                            self.output += tmp[:] + "\n"
-                            tmp = ""
-                    else:
-                        tmp += chr(c)
+        with open(self.filename, "r", encoding="ascii", errors="surrogateescape") as f:
+            self.output = "".join(filter(lambda x: x in self.printable, f.read()))
         return self.output
 
 

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -6,6 +6,7 @@ import sys
 import tempfile
 import unittest
 import subprocess
+from time import perf_counter
 
 from cve_bin_tool.strings import Strings
 
@@ -32,7 +33,14 @@ class TestStrings(unittest.TestCase):
         f = tempfile.TemporaryFile()
         subprocess.call(["strings", self.strings.filename], stdout=f)
         binutils_strings = f.readlines()
+        t1 = perf_counter()
         ours = self.strings.parse().split("\n")
+        t2 = perf_counter()
+        print(f"pstring: {t2 - t1}")
+        t1 = perf_counter()
+        ours = self.strings.parse_3().split("\n")
+        t2 = perf_counter()
+        print(f"string: {t2 - t1}")
         for theirs in binutils_strings:
             self.assertIn(theirs.decode("utf-8"), ours)
 


### PR DESCRIPTION
Here is the time it take to run comparison of time between pstring and new improved parse_3 function. New native implementation is twice as fast.  

pstring: 0.002876685000046564
string:   0.0014867500001400913

I have kept code i used to measure performance in test_strings.py. If anyone wants to check it. 