### PR TITLE
fixes many issues with extractor

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,9 @@ On windows systems, you may need:
 * `7z`
 * `Expand`
 
-Windows has `ar` and `Expand` installed in default, but `7z` in particular might need to be installed.  (7z is used only for rpm extraction, which is used heavily in our test suite, but if you're not scanning rpm files on windows you may be able to do without.)
+Windows has `ar` and `Expand` installed in default, but `7z` in particular might need to be installed. 
+If you wan to run our test-suite or scan a zstd compressed file, We recommend installing this [7-zip-zstd](https://github.com/mcmilk/7-Zip-zstd) 
+fork of 7zip. We are currently using `7z` for extracting `jar`, `apk`, `msi`, `exe` and `rpm` files.
 
 CSV2CVE
 -------

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -54,7 +54,7 @@ class BaseExtractor(object):
             self.extract_file_rpm: [".rpm"],
             self.extract_file_deb: [".deb", ".ipk"],
             self.extract_file_cab: [".cab"],
-            self.extract_file_zip: [".exe", ".zip", ".jar", ".apk"],
+            self.extract_file_zip: [".exe", ".zip", ".jar", ".apk", ".msi"],
         }
 
     def can_extract(self, filename):
@@ -67,11 +67,11 @@ class BaseExtractor(object):
     @classmethod
     def extract_file_tar(cls, filename, extraction_path):
         """ Extract tar files """
-        if not inpath("tar"):
-            """ Acutally MinGW provides tar, so this might never get called """
+        try:
             shutil.unpack_archive(filename, extraction_path)
-        else:
-            return subprocess.call(["tar", "-C", extraction_path, "-xf", filename])
+            return 0
+        except Exception:
+            return 1
 
     @classmethod
     def extract_file_rpm(cls, filename, extraction_path):
@@ -111,15 +111,12 @@ class BaseExtractor(object):
             result = subprocess.call(["ar", "x", filename], cwd=extraction_path)
             if result != 0:
                 return result
-            if not inpath("tar"):
-                shutil.unpack_archive(filename, extraction_path)
-            else:
-                datafile = glob.glob(os.path.join(extraction_path, "data.tar.*"))[0]
-                # flag a is not supported while using x
-                result = subprocess.call(
-                    ["tar", "-C", extraction_path, "-xf", datafile]
-                )
-                return result
+            datafile = glob.glob(os.path.join(extraction_path, "data.tar.*"))[0]
+            try:
+                shutil.unpack_archive(datafile, extraction_path)
+            except Exception:
+                return 1
+            return 0
 
     @classmethod
     def extract_file_cab(cls, filename, extraction_path):
@@ -135,12 +132,17 @@ class BaseExtractor(object):
     @classmethod
     def extract_file_zip(cls, filename, extraction_path):
         """ Extract zip files """
-        if not inpath("unzip"):
-            shutil.unpack_archive(filename, extraction_path)
-        else:
+        if inpath("unzip"):
             return subprocess.call(
                 ["unzip", "-qq", "-n", "-d", extraction_path, filename]
             )
+        elif inpath("7z"):
+            return subprocess.call(f'7z x {filename} -o"{extraction_path}"')
+        else:
+            try:
+                shutil.unpack_archive(filename, extraction_path)
+            except Exception:
+                return 1
 
 
 class TempDirExtractorContext(BaseExtractor):


### PR DESCRIPTION
Fixes issue #667. Now tar working fine in windows. zstd compressed archive can be supported via 7zip-zstd fork. 

I have removed "tar" subprocess call because it is too slow compare to "shutil".
Here, is the code I used  for benchmarking and result from it.
### Code
```python

import shutil
import subprocess
import os
from time import perf_counter as pc
py, sub = 0, 0
os.mkdir("new1")
os.mkdir("new2")
for i in range(5):
	d1 = f"new1/{i}"
	d2 = f"new2/{i}"
	os.mkdir(d1)
	os.mkdir(d2)
	d2 = os.path.join(os.getcwd(), d2)
	t1 = pc()
	shutil.unpack_archive("hadoop.tar", extract_dir=d1)
	t2 = pc()
	py += t2 - t1
	t1 = pc()
	subprocess.call(f"tar -C {d2} -xf hadoop.tar")
	t2 = pc()
	sub += t2 - t1
	print(f"round {i} completed.")
# shutil.rmtree("new")
print(f"time for subprocess tar: {sub}")
print(f"time for python shutil: {py}")
```
### Result
```console
round 0 completed.
round 1 completed.
round 2 completed.
round 3 completed.
round 4 completed.
time for subprocess tar: 37.440506299999996
time for python shutil: 6.781017499999997
[Finished in 44.4s]
```