### PR TITLE
Fix binutils false positives (fixes #677)

### DIFF
--- a/cve_bin_tool/checkers/binutils.py
+++ b/cve_bin_tool/checkers/binutils.py
@@ -55,23 +55,23 @@ class BinutilsChecker(Checker):
         # check if it's the library instead of the command line utils
         r"libbfd-((\d+\.)*\d+)[\d\w.-]*so",
         # command line utils
-        r"ld",  # the GNU linker.
-        r"as",  # the GNU assembler.
+        r"^ld$",  # the GNU linker.
+        r"^as$",  # the GNU assembler.
         r"addr2line",  # Converts addresses into filenames and line numbers.
-        r"ar",  # A utility for creating, modifying and extracting from archives.
+        r"^ar$",  # A utility for creating, modifying and extracting from archives.
         r"c\+{2}filt",  # Filter to demangle encoded C++ symbols.
         r"dlltool",  # Creates files for building and using DLLs.
-        r"gold",  # A new, faster, ELF only linker, still in beta test.
+        r"^gold$",  # A new, faster, ELF only linker, still in beta test.
         r"gprof",  # Displays profiling information.
         r"nlmconv",  # Converts object code into an NLM.
-        r"nm",  # Lists symbols from object files.
+        r"^nm$",  # Lists symbols from object files.
         r"objcopy",  # Copies and translates object files.
         r"objdump",  # Displays information from object files.
         r"ranlib",  # Generates an index to the contents of an archive.
         r"readelf",  # Displays information from any ELF format object file.
-        r"size",  # Lists the section sizes of an object or archive file.
-        r"strings",  # Lists printable strings from files.
-        r"strip",  # Discards symbols.
+        r"^size$",  # Lists the section sizes of an object or archive file.
+        r"^strings$",  # Lists printable strings from files.
+        r"^strip$",  # Discards symbols.
         r"windmc",  # A Windows compatible message compiler.
         r"windres",  # A compiler for Windows resource files.
         # distro-specific names

--- a/cve_bin_tool/checkers/png.py
+++ b/cve_bin_tool/checkers/png.py
@@ -14,7 +14,7 @@ from . import Checker
 class PngChecker(Checker):
     CONTAINS_PATTERNS = [
         r"libpng error: %s, offset=%d",
-        r"Application uses deprecated png_write_init() and should be recompiled",
+        r"Application uses deprecated png_write_init\(\) and should be recompiled",
         r"libpng version ",
     ]
     FILENAME_PATTERNS = [r"libpng.so.", r"libpng16.so."]

--- a/test/binaries/test-binutils-2.31.1.c
+++ b/test/binaries/test-binutils-2.31.1.c
@@ -5,6 +5,7 @@ int main() {
 	printf("It outputs a few strings normally associated with binutils 2.31.1");
 	printf("They appear below this line.");
 	printf("------------------");
+  printf("Using the --size-sort and --undefined-only options together");
 	printf("libbfd-2.31.1-system.so");
 
 	return 0;


### PR DESCRIPTION
Binutils includes some utilities with very short names, such as "ar" and "as" that were causing false positives in the filename checks.  I've updated a number of the shorter and more generic strings in binutils to include start and terminator matching so that we match "ar" but not "binaries" (which was causing binutils false positives on all our tests.  yuck!)

This caused the test case to fail because the test file wasn't matching the filename test.  I added one of the "contains" strings to the test file to trigger the match as expected.