### PR TITLE
Add checker for busybox

### DIFF
--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -9,6 +9,7 @@ __all__ = [
     "VendorPackagePair",
     "binutils",
     "bluez",
+    "busybox",
     "bzip2",
     "cups",
     "curl",

--- a/cve_bin_tool/checkers/busybox.py
+++ b/cve_bin_tool/checkers/busybox.py
@@ -1,0 +1,17 @@
+#!/usr/bin/python3
+
+"""
+CVE checker for busybox
+
+https://www.cvedetails.com/product/7452/Busybox-Busybox.html?vendor_id=4282
+
+"""
+from . import Checker
+
+
+class OpenafsChecker(Checker):
+    CONTAINS_PATTERNS = [r"BusyBox v([0-9]+\.[0-9]+\.[0-9]+)"]
+    FILENAME_PATTERNS = [r"busybox"]
+    VERSION_PATTERNS = [r"BusyBox v([0-9]+\.[0-9]+\.[0-9]+)"]
+    VENDOR_PACKAGE = [("busybox", "busybox")]
+    MODULE_NAME = "busybox"

--- a/cve_bin_tool/checkers/busybox.py
+++ b/cve_bin_tool/checkers/busybox.py
@@ -9,7 +9,7 @@ https://www.cvedetails.com/product/7452/Busybox-Busybox.html?vendor_id=4282
 from . import Checker
 
 
-class OpenafsChecker(Checker):
+class BusyboxChecker(Checker):
     CONTAINS_PATTERNS = [r"BusyBox v([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"busybox"]
     VERSION_PATTERNS = [r"BusyBox v([0-9]+\.[0-9]+\.[0-9]+)"]

--- a/test/binaries/test-busy.box-1.18.3.c
+++ b/test/binaries/test-busy.box-1.18.3.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main() {
+	printf("This program is designed to test the cve-bin-tool checker.");
+	printf("It outputs a few strings normally associated with busybox-1.18.3");
+	printf("They appear below this line.");
+	printf("------------------");
+	printf("BusyBox v1.18.3");
+
+	return 0;
+}

--- a/test/binaries/test-busybox-1.10.3.c
+++ b/test/binaries/test-busybox-1.10.3.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+int main() {
+	printf("This program is designed to test the cve-bin-tool checker.");
+	printf("It outputs a few strings normally associated with busybox-1.10.3");
+	printf("They appear below this line.");
+	printf("------------------");
+	printf("BusyBox v1.10.3");
+
+	return 0;
+}

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -181,6 +181,35 @@ class TestScanner:
                     ),
                 ],
                 [
+                    # CVE Mapping tests for busybox checker
+                    (
+                        "test-busybox-1.10.3.out",
+                        "busybox",
+                        "1.10.3",
+                        [
+                            # Check for known cves in this version
+                            "CVE-2018-20679"
+                        ],
+                        [
+                            # Check to make sure an older CVE isn't included
+                            "CVE-2006-1058",
+                        ],
+                    ),
+                    (
+                        "test-busy.box-1.18.3.out",
+                        "busybox",
+                        "1.18.3",
+                        [
+                            # Check for known cves in this version
+                            "CVE-2018-20679"
+                        ],
+                        [
+                            # Check to make sure an older CVE isn't included
+                            "CVE-2006-1058",
+                        ],
+                    ),
+                ],
+                [
                     # CVE Mapping tests for bzip2 checker
                     (
                         "test-bzip2-1.0.2.out",
@@ -1621,6 +1650,21 @@ class TestScanner:
                         "binutils-2.27-43.base.el7.x86_64.rpm",
                         "binutils",
                         "2.27",
+                    ),
+                ],
+                [
+                    # Filetests for busybox checker
+                    (
+                        "https://kojipkgs.fedoraproject.org/packages/busybox/1.28.2/1.fc29/x86_64/",
+                        "busybox-1.28.2-1.fc29.x86_64.rpm",
+                        "busybox",
+                        "1.28.2",
+                    ),
+                    (
+                        "http://archive.ubuntu.com/ubuntu/pool/universe/b/busybox/",
+                        "busybox_1.18.5-1ubuntu4_amd64.deb",
+                        "busybox",
+                        "1.18.5",
                     ),
                 ],
                 [


### PR DESCRIPTION
New checker - busybox
CVE Data - https://www.cvedetails.com/product/7452/Busybox-Busybox.html?vendor_id=4282
![busybox_busybox](https://user-images.githubusercontent.com/50541438/82396896-c629e000-9a6c-11ea-94d1-aaeebf776ac8.png)
Strings found used in regex