### PR TITLE
Add filtering on CVE severity and CVSS score (#730)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,18 @@ Usage:
 
 You can also do `python -m cve_bin_tool.cli <flags> <path to directory>` which is useful if you're trying the latest code from [the cve-bin-tool github](https://github.com/intel/cve-bin-tool/compare).
 
-
 ```
-  -h, --help            show help message and exit
+positional arguments:
+  directory             directory to scan
+
+optional arguments:
+  -h, --help            show this help message and exit
   -V, --version         show program's version number and exit
+  -u {now,daily,never,latest}, --update {now,daily,never,latest}
+                        update schedule for NVD database (default: daily)
+  -x, --extract         autoextract compressed files
 
-
-  Output options:
+  Output:
   -q, --quiet           suppress output
   -l {debug,info,warning,error,critical}, --log {debug,info,warning,error,critical}
                         log level. The default log level is info
@@ -34,18 +39,19 @@ You can also do `python -m cve_bin_tool.cli <flags> <path to directory>` which i
                         provide output filename (default: output to stdout)
   -f {csv,json,console}, --format {csv,json,console}
                         update output format (default: console)
+  -c CVSS, --cvss CVSS  minimum CVSS score (as integer in range 0 to 10) to report (default: 0)
+  -S {low,medium,high,critical}, --severity {low,medium,high,critical}
+                        minimum CVE severity to report (default: low)
 
-
-  Functional options:
-  -x, --extract         autoextract compressed files
+  Checkers:
   -s SKIPS, --skips SKIPS
                         comma-separated list of checkers to disable
   -r CHECKERS, --runs CHECKERS
                         comma-separated list of checkers to enable
-  -m, --multithread     enable multithread
-  -u {now,daily,never}, --update {now,daily,never}
-                        update schedule for NVD database. Default is daily.
+
 ```
+
+Note that if the CVSS and Severity flags are both specified, the CVSS flag takes precedence.
 
 The 0.3.1 release is intended to be the last release to officially support
 python 2.7; please switch to python 3.6+ for future releases and to use the
@@ -134,8 +140,8 @@ On windows systems, you may need:
 * `7z`
 * `Expand`
 
-Windows has `ar` and `Expand` installed in default, but `7z` in particular might need to be installed. 
-If you wan to run our test-suite or scan a zstd compressed file, We recommend installing this [7-zip-zstd](https://github.com/mcmilk/7-Zip-zstd) 
+Windows has `ar` and `Expand` installed in default, but `7z` in particular might need to be installed.
+If you wan to run our test-suite or scan a zstd compressed file, We recommend installing this [7-zip-zstd](https://github.com/mcmilk/7-Zip-zstd)
 fork of 7zip. We are currently using `7z` for extracting `jar`, `apk`, `msi`, `exe` and `rpm` files.
 
 CSV2CVE
@@ -144,7 +150,33 @@ CSV2CVE
 The CVE Binary Tool package also includes a tool called `csv2cve` which is a helper tool that allows you to search the local database for a list of known products.  This can be useful if the list of products is known.
 
 Usage:
-`csv2cve <csv_file>`
+'csv2cve <flags> <csv_file>'
+
+This tool takes a list of software + versions from a CSV file and outputs a list of CVEs known to affect those versions
+
+```
+positional arguments:
+  csv_file              CSV file with product data. Must contain
+                        vendor,product,version, where vendor and product match
+                        entries in the National Vulnerability Database.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -u {now,daily,never,latest}, --update {now,daily,never,latest}
+                        update schedule for NVD database (default: daily)
+
+Output:
+  -l {debug,info,warning,error,critical}, --log {debug,info,warning,error,critical}
+                        log level (default: info)
+  -o OUTPUT_FILE, --output-file OUTPUT_FILE
+                        provide output filename (default: output to stdout)
+  -c CVSS, --cvss CVSS  minimum CVSS score to report (default: 0)
+  -S {low,medium,high,critical}, --severity {low,medium,high,critical}
+                        minimum CVE severity to report (default: low)
+  -f {csv,json,console}, --format {csv,json,console}
+                        update output format (default: console)
+  -q, --quiet           suppress output
+```
 
 The CSV file must contain the following columns: `vendor,product,version` where the vendor and product names are exact matches to the strings in the National Vulnerability Database.  You can read more about how to find the correct string in [the checker documentation](https://github.com/intel/cve-bin-tool/blob/master/cve_bin_tool/checkers/README.md), and the [csv2cve manual](https://github.com/intel/cve-bin-tool/blob/master/CSV2CVE.md) has more information on using this tool.
 
@@ -178,4 +210,3 @@ incident response team via
 
 If in the course of using this tool you discover a security issue with someone
 else's code, please disclose responsibly to the appropriate party.
-

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -87,9 +87,22 @@ def main(argv=None):
         default="console",
         help="update output format (default: console)",
     )
-    parser.add_argument(
-        "-V", "--version", action="version", version=VERSION,
+    output_group.add_argument(
+        "-c",
+        "--cvss",
+        action="store",
+        default=0,
+        help="minimum CVSS score (as integer in range 0 to 10) to report (default: 0)",
     )
+    output_group.add_argument(
+        "-S",
+        "--severity",
+        action="store",
+        choices=["low", "medium", "high", "critical"],
+        default="low",
+        help="minimum CVE severity to report (default: low)",
+    )
+    parser.add_argument("-V", "--version", action="version", version=VERSION)
     parser.add_argument(
         "-u",
         "--update",
@@ -138,6 +151,15 @@ def main(argv=None):
 
     if args.quiet:
         LOGGER.setLevel(logging.CRITICAL)
+
+    if int(args.cvss) > 0:
+        score = int(args.cvss)
+    elif args.severity:
+        # Set minimum CVSS score based on severity
+        cvss_score = {"low": 0, "medium": 4, "high": 7, "critical": 9}
+        score = cvss_score[args.severity]
+    else:
+        score = 0
 
     if platform.system() != "Linux":
         warning_nolinux = """
@@ -197,7 +219,7 @@ def main(argv=None):
     cvedb = CVEDB()
     cvedb.open()
     with cvedb:
-        scanner = Scanner(cvedb, args.extract)
+        scanner = Scanner(cvedb, args.extract, score=score)
         scanner.remove_skiplist(skips)
         LOGGER.info(scanner.print_checkers())
         scanner.recursive_scan(args.directory)

--- a/cve_bin_tool/csv2cve.py
+++ b/cve_bin_tool/csv2cve.py
@@ -20,10 +20,11 @@ class CSV2CVE(object):
     ERR_MISSINGCOLUMN = -2
     ERR_BADFILENAME = -3
 
-    def __init__(self, filename=None, logger=None):
+    def __init__(self, filename=None, logger=None, score=0):
         if logger is None:
             self.logger = LOGGER.getChild(self.__class__.__name__)
         self.filename = filename
+        self.score = score
         self.cvedb = CVEDB()
 
     def db_update(self, update):
@@ -79,7 +80,7 @@ class CSV2CVE(object):
                 # Go row by row and look for CVEs
                 for row in csvdata:
                     cves = self.cvedb.get_cves(
-                        row["vendor"], row["product"], row["version"]
+                        row["vendor"], row["product"], row["version"], self.score
                     )
 
                     if cves:
@@ -159,6 +160,21 @@ def main(argv=None, outfile=None):
         help="provide output filename (default: output to stdout)",
     )
     output_group.add_argument(
+        "-c",
+        "--cvss",
+        action="store",
+        default=0,
+        help="minimum CVSS score (as integer in range 0 to 10) to report (default: 0)",
+    )
+    output_group.add_argument(
+        "-S",
+        "--severity",
+        action="store",
+        choices=["low", "medium", "high", "critical"],
+        default="low",
+        help="minimum CVE severity to report (default: low)",
+    )
+    output_group.add_argument(
         "-f",
         "--format",
         action="store",
@@ -183,9 +199,17 @@ def main(argv=None, outfile=None):
         return 0
 
     args = parser.parse_args(argv[1:])
+    if int(args.cvss) > 0:
+        score = int(args.cvss)
+    elif args.severity:
+        # Set minimum CVSS score based on severity
+        cvss_score = {"low": 0, "medium": 4, "high": 7, "critical": 9}
+        score = cvss_score[args.severity]
+    else:
+        score = 0
 
     # Create a CSV2CVE object
-    csv2cve = CSV2CVE(filename=args.csv_file)
+    csv2cve = CSV2CVE(filename=args.csv_file, score=score)
     csv2cve.db_update(update=args.update)
     if args.quiet:
         csv2cve.update_logLevel(log_level=logging.CRITICAL)

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -256,7 +256,7 @@ class CVEDB(object):
             self.connection = self.init_database()
         self.populate_db()
 
-    def get_cves(self, vendor, product, version):
+    def get_cves(self, vendor, product, version, score):
         """ Get CVEs against a specific version of a package.
 
         Example:
@@ -342,7 +342,9 @@ class CVEDB(object):
 
         # Go through and get all the severities
         if cve_list:
-            query = f'SELECT CVE_number, severity from cve_severity where CVE_number IN ({",".join(["?"]*len(cve_list))}) ORDER BY CVE_number ASC'
+            query = f'SELECT CVE_number, severity from cve_severity where CVE_number IN ({",".join(["?"]*len(cve_list))}) AND score >= ? ORDER BY CVE_number ASC'
+            # Add score parameter to tuple listing CVEs to pass to query
+            cve_list.append(score)
             cursor.execute(query, cve_list)
             # Everything expects a data structure of cve[number] = severity so you can search through keys
             # and do other easy manipulations

--- a/cve_bin_tool/scanner.py
+++ b/cve_bin_tool/scanner.py
@@ -22,7 +22,9 @@ class Scanner(object):
 
     CHECKER_ENTRYPOINT = "cve_bin_tool.checker"
 
-    def __init__(self, cvedb, should_extract=False, checkers=None, logger=None):
+    def __init__(
+        self, cvedb, should_extract=False, checkers=None, logger=None, score=0
+    ):
         if logger is None:
             logger = LOGGER.getChild(self.__class__.__name__)
         # Update egg if installed in development mode
@@ -36,6 +38,7 @@ class Scanner(object):
         self.cvedb = cvedb
         self.checkers = checkers
         self.logger = logger
+        self.score = score
         self.all_cves = defaultdict(dict)
         self.files_with_cve = 0
         exclude_folders = [".git"]
@@ -74,14 +77,14 @@ class Scanner(object):
     def print_checkers(self):
         self.logger.info(f'Checkers: {", ".join(self.checkers.keys())}')
 
-    def get_cves(self, vendor_package_pairs, vers):
+    def get_cves(self, vendor_package_pairs, vers, score):
         """Returns a list of cves affecting a given version of a piece of software
         """
         cves = dict()
 
         # get all cves for each vendor_package_pair
         for vendor, package in vendor_package_pairs:
-            cves.update(self.cvedb.get_cves(vendor, package, vers))
+            cves.update(self.cvedb.get_cves(vendor, package, vers, score))
 
         return cves
 
@@ -131,7 +134,7 @@ class Scanner(object):
             lines = s.parse()
 
         # tko
-        for (dummy_checker_name, checker,) in self.checkers.items():
+        for (dummy_checker_name, checker) in self.checkers.items():
             checker = checker()
             result = checker.get_version(lines, filename)
             # do some magic so we can iterate over all results, even the ones that just return 1 hit
@@ -155,7 +158,9 @@ class Scanner(object):
                         self.logger.error(f"No version info for {modulename}")
 
                     if version != "UNKNOWN":
-                        found_cves = self.get_cves(checker.VENDOR_PACKAGE, version)
+                        found_cves = self.get_cves(
+                            checker.VENDOR_PACKAGE, version, self.score
+                        )
                         if found_cves:
                             self.files_with_cve = self.files_with_cve + 1
                         self.all_cves[modulename][version] = found_cves


### PR DESCRIPTION
Additional command line options to filter on CVSS score or Severity

Severity is translated to a score using CVSS v3 values so that Critical has a score of 9. Any CVEs reported using CVSS v2 does not have a Critical severity so a score of 9 using CVSS v2 will report as High