### PR TITLE
package and module now uses Product as their name.

### DIFF
--- a/cve_bin_tool/OutputEngine.py
+++ b/cve_bin_tool/OutputEngine.py
@@ -45,7 +45,7 @@ class OutputEngine(object):
 
     def output_cves(self, outfile, output_type=None):
         """ Output a list of CVEs
-        format self.modules[checker_name][version] = dict{id: severity}
+        format self.products[checker_name][version] = dict{id: severity}
         to other formats like CSV or JSON
         """
         if output_type == "json":

--- a/cve_bin_tool/OutputEngine.py
+++ b/cve_bin_tool/OutputEngine.py
@@ -45,7 +45,7 @@ class OutputEngine(object):
 
     def output_cves(self, outfile, output_type=None):
         """ Output a list of CVEs
-        format self.products[checker_name][version] = dict{id: severity}
+        format self.checkers[checker_name][version] = dict{id: severity}
         to other formats like CSV or JSON
         """
         if output_type == "json":

--- a/cve_bin_tool/checkers/README.md
+++ b/cve_bin_tool/checkers/README.md
@@ -22,7 +22,7 @@ you are making checker for:
 1. CONTAINS_PATTERNS - list of commonly found strings in the binary of the package
 2. FILENAME_PATTERNS - list of different filename for the package
 3. VERSION_PATTERNS - list of version patterns found in binary of the package.
-4. VENDOR_PACKAGE - list of vendor package pairs for the package as they appear in
+4. VENDOR_PRODUCT - list of vendor package pairs for the package as they appear in
 NVD.
 5. MODULE_NAME - Mostly same as package name
 
@@ -145,7 +145,7 @@ VPkg: opensuse, leap
 VPkg: suse, linux_enterprise_debuginfo
 ```
 
-`VENDOR_PACKAGE` attribute should have list of tuples of vendor package pair
+`VENDOR_PRODUCT` attribute should have list of tuples of vendor package pair
 found in the listings. Some of the listings will be with regards to packages
 that include this package. For our example all listings except 
 `libexpat, expat` mearly include the target package (`expat` for the

--- a/cve_bin_tool/checkers/README.md
+++ b/cve_bin_tool/checkers/README.md
@@ -17,14 +17,13 @@ from . import Checker
 class CurlChecker(Checker):
 ```
 
-Every checker must contain following 5 class attributes specific to package(ex: curl) 
+Every checker must contain following 4 class attributes specific to product(ex: curl) 
 you are making checker for:
-1. CONTAINS_PATTERNS - list of commonly found strings in the binary of the package
-2. FILENAME_PATTERNS - list of different filename for the package
-3. VERSION_PATTERNS - list of version patterns found in binary of the package.
-4. VENDOR_PRODUCT - list of vendor package pairs for the package as they appear in
+1. CONTAINS_PATTERNS - list of commonly found strings in the binary of the product
+2. FILENAME_PATTERNS - list of different filename for the product
+3. VERSION_PATTERNS - list of version patterns found in binary of the product.
+4. VENDOR_PRODUCT - list of vendor product pairs for the product as they appear in
 NVD.
-5. MODULE_NAME - Mostly same as package name
 
 `CONTAINS_PATTERN`, `FILENAME_PATTERNS` and `VERSION_PATTERNS` supports regex to cover
 wide range of use cases.
@@ -87,7 +86,7 @@ As you can see, there's a lot of things that will match `X.X.X`:
 * Ubuntu is 18.04.1
 
 So you want something that makes the version string a little more precise to the
-package you're looking for.  For example, if we were *intentionally* looking for
+product you're looking for.  For example, if we were *intentionally* looking for
 glibc (as in, writing a glibc checker), we could use the string `GLIBC_` or 
 `@@GLIBC_` as a prefix and get a regex that would tell us about glibc without 
 also telling us the GCC and Ubuntu versions.
@@ -115,7 +114,7 @@ as strings in the binary.
 
 ### Choosing contains patterns to detect the library
 contains patterns are the string pattern that you commonly found in the binary of the
-package you are looking for. You want a signature that hasn't changed in a large 
+product you are looking for. You want a signature that hasn't changed in a large 
 number of versions so you'll detect the library as long as possible (and if you
 notice that it did change before some version date, you can always add more
 strings to improve the coverage).  If you have a copy of the library you can
@@ -126,11 +125,11 @@ for this, or other tools for other repositories). `CONTAINS_PATTERNS` field supp
 regex pattern so you can use creative signature which remain same for number of 
 versions.
 
-### Finding Vendor Package pairs
+### Finding Vendor Product pairs
 
-Every checker class must contain the vendor and package name pair(s)
+Every checker class must contain the vendor and product name pair(s)
 as they appear in NVD. The best way to do this is to search the cached sqlite
-database of the NVD using a CVE you want to know the vendor package pair(s) for.
+database of the NVD using a CVE you want to know the vendor product pair(s) for.
 
 ```console
 $ sqlite3 ~/.cache/cvedb/cve.db \
@@ -145,10 +144,10 @@ VPkg: opensuse, leap
 VPkg: suse, linux_enterprise_debuginfo
 ```
 
-`VENDOR_PRODUCT` attribute should have list of tuples of vendor package pair
-found in the listings. Some of the listings will be with regards to packages
-that include this package. For our example all listings except 
-`libexpat, expat` mearly include the target package (`expat` for the
+`VENDOR_PRODUCT` attribute should have list of tuples of vendor product pair
+found in the listings. Some of the listings will be with regards to products
+that include this product. For our example all listings except 
+`libexpat, expat` mearly include the target product (`expat` for the
 example SQL query).
 
 ## Adding tests
@@ -175,7 +174,7 @@ in question, is a copy of the library in question, and if either of those are
 true it also returns a version string. If the binary does not contain the
 library, this function returns an empty dictionary.
 
-If `curl` package is being scanned, get_version method of CurlChecker will
+If `curl` product is being scanned, get_version method of CurlChecker will
 return following dictionary.
 
 ```json
@@ -188,4 +187,4 @@ return following dictionary.
 
 In most of the cases, Just providing above five class attributes will be enough.
 But sometimes, you need to override this method to correctly detect version of 
-the package. We have done this in the checkers of `python`, `sqlite` and `kerberos`.
+the product. We have done this in the checkers of `python`, `sqlite` and `kerberos`.

--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -6,7 +6,7 @@ from ..util import regex_find
 
 __all__ = [
     "Checker",
-    "VendorPackagePair",
+    "VendorProductPair",
     "bash",
     "binutils",
     "bluez",
@@ -62,7 +62,7 @@ __all__ = [
     "zlib",
 ]
 
-VendorPackagePair = collections.namedtuple("VendorPackagePair", ["vendor", "package"])
+VendorProductPair = collections.namedtuple("VendorProductPair", ["vendor", "product"])
 
 
 class CheckerMetaClass(type):
@@ -78,12 +78,12 @@ class CheckerMetaClass(type):
         # HACK Skip validation is this class is the base class
         if name == "Checker":
             return cls
-        # Validate that we have at least one vendor package pair
-        if len(cls.VENDOR_PACKAGE) < 1:
-            raise AssertionError("%s needs at least one vendor package pair" % (name,))
-        # Validate that each vendor package pair is of length 2
-        cls.VENDOR_PACKAGE = list(
-            map(lambda vpkg: VendorPackagePair(*vpkg), cls.VENDOR_PACKAGE)
+        # Validate that we have at least one vendor product pair
+        if len(cls.VENDOR_PRODUCT) < 1:
+            raise AssertionError("%s needs at least one vendor product pair" % (name,))
+        # Validate that each vendor product pair is of length 2
+        cls.VENDOR_PRODUCT = list(
+            map(lambda vpkg: VendorProductPair(*vpkg), cls.VENDOR_PRODUCT)
         )
         # Compile regex
         cls.CONTAINS_PATTERNS = list(map(re.compile, cls.CONTAINS_PATTERNS))
@@ -97,7 +97,7 @@ class Checker(metaclass=CheckerMetaClass):
     CONTAINS_PATTERNS = []
     VERSION_PATTERNS = []
     FILENAME_PATTERNS = []
-    VENDOR_PACKAGE = []
+    VENDOR_PRODUCT = []
 
     def guess_contains(self, lines):
         for line in lines:

--- a/cve_bin_tool/checkers/bash.py
+++ b/cve_bin_tool/checkers/bash.py
@@ -13,4 +13,4 @@ class BashChecker(Checker):
     CONTAINS_PATTERNS = [r"Bash version ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"bash"]
     VERSION_PATTERNS = [r"Bash version ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("gnu", "bash")]
+    VENDOR_PRODUCT = [("gnu", "bash")]

--- a/cve_bin_tool/checkers/binutils.py
+++ b/cve_bin_tool/checkers/binutils.py
@@ -78,4 +78,4 @@ class BinutilsChecker(Checker):
         r"ld.bfd",  # as seen on ubuntu
     ]
     VERSION_PATTERNS = [r"libbfd-((\d+\.)*\d+)[\d\w.-]*so"]
-    VENDOR_PACKAGE = [("gnu", "binutils")]
+    VENDOR_PRODUCT = [("gnu", "binutils")]

--- a/cve_bin_tool/checkers/bluez.py
+++ b/cve_bin_tool/checkers/bluez.py
@@ -19,4 +19,4 @@ class BluezChecker(Checker):
         r"bluetoothctl: ([5]+\.[0-9]+\.[0-9]+)",
         r"bluetoothctl: ([5]+\.[0-9]+)",
     ]
-    VENDOR_PACKAGE = [("bluez", "bluez")]
+    VENDOR_PRODUCT = [("bluez", "bluez")]

--- a/cve_bin_tool/checkers/busybox.py
+++ b/cve_bin_tool/checkers/busybox.py
@@ -13,4 +13,4 @@ class BusyboxChecker(Checker):
     CONTAINS_PATTERNS = [r"BusyBox v([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"busybox"]
     VERSION_PATTERNS = [r"BusyBox v([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("busybox", "busybox")]
+    VENDOR_PRODUCT = [("busybox", "busybox")]

--- a/cve_bin_tool/checkers/bzip2.py
+++ b/cve_bin_tool/checkers/bzip2.py
@@ -14,4 +14,4 @@ class Bzip2Checker(Checker):
     CONTAINS_PATTERNS = [r"bzip2-([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"bzip2"]
     VERSION_PATTERNS = [r"bzip2-([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("bzip", "bzip2")]
+    VENDOR_PRODUCT = [("bzip", "bzip2")]

--- a/cve_bin_tool/checkers/cups.py
+++ b/cve_bin_tool/checkers/cups.py
@@ -15,4 +15,4 @@ class CupsChecker(Checker):
     CONTAINS_PATTERNS = [r"CUPS v([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"cupsd"]
     VERSION_PATTERNS = [r"CUPS v([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("easy_software_products", "cups")]
+    VENDOR_PRODUCT = [("easy_software_products", "cups")]

--- a/cve_bin_tool/checkers/curl.py
+++ b/cve_bin_tool/checkers/curl.py
@@ -19,4 +19,4 @@ class CurlChecker(Checker):
     CONTAINS_PATTERNS = [r"curl ([678]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"curl"]
     VERSION_PATTERNS = [r"curl ([678]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("haxx", "curl")]
+    VENDOR_PRODUCT = [("haxx", "curl")]

--- a/cve_bin_tool/checkers/dovecot.py
+++ b/cve_bin_tool/checkers/dovecot.py
@@ -13,4 +13,4 @@ class DovecotChecker(Checker):
     CONTAINS_PATTERNS = [r"Dovecot v([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"dovecot"]
     VERSION_PATTERNS = [r"Dovecot v([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("dovecot", "dovecot")]
+    VENDOR_PRODUCT = [("dovecot", "dovecot")]

--- a/cve_bin_tool/checkers/expat.py
+++ b/cve_bin_tool/checkers/expat.py
@@ -39,4 +39,4 @@ class ExpatChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"expat"]
     VERSION_PATTERNS = [r"expat_([012]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("libexpat", "expat"), ("libexpat_project", "libexpat")]
+    VENDOR_PRODUCT = [("libexpat", "expat"), ("libexpat_project", "libexpat")]

--- a/cve_bin_tool/checkers/ffmpeg.py
+++ b/cve_bin_tool/checkers/ffmpeg.py
@@ -20,4 +20,4 @@ class FfmpegChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"ffmpeg"]
     VERSION_PATTERNS = [r"%s version ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("ffmpeg", "ffmpeg")]
+    VENDOR_PRODUCT = [("ffmpeg", "ffmpeg")]

--- a/cve_bin_tool/checkers/freeradius.py
+++ b/cve_bin_tool/checkers/freeradius.py
@@ -13,4 +13,4 @@ class FreeradiusChecker(Checker):
     CONTAINS_PATTERNS = [r"FreeRADIUS Version ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"radiusd"]
     VERSION_PATTERNS = [r"FreeRADIUS Version ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("freeradius", "freeradius")]
+    VENDOR_PRODUCT = [("freeradius", "freeradius")]

--- a/cve_bin_tool/checkers/gimp.py
+++ b/cve_bin_tool/checkers/gimp.py
@@ -13,4 +13,4 @@ class GimpChecker(Checker):
     CONTAINS_PATTERNS = [r"GIMP ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"gimp"]
     VERSION_PATTERNS = [r"GIMP ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("gimp", "gimp")]
+    VENDOR_PRODUCT = [("gimp", "gimp")]

--- a/cve_bin_tool/checkers/gnutls.py
+++ b/cve_bin_tool/checkers/gnutls.py
@@ -23,4 +23,4 @@ class GnutlsChecker(Checker):
         r"gnutls-cli ([0-9]+\.[0-9]+\.[0-9]+)",
         r"gnutls-serv ([0-9]+\.[0-9]+\.[0-9]+)",
     ]
-    VENDOR_PACKAGE = [("gnutls", "gnutls"), ("gnu", "gnutls")]
+    VENDOR_PRODUCT = [("gnutls", "gnutls"), ("gnu", "gnutls")]

--- a/cve_bin_tool/checkers/gstreamer.py
+++ b/cve_bin_tool/checkers/gstreamer.py
@@ -12,4 +12,4 @@ class GstreamerChecker(Checker):
     CONTAINS_PATTERNS = [r"http://bugzilla.gnome.org/enter_bug.cgi?product=GStreamer"]
     FILENAME_PATTERNS = [r"gstreamer"]
     VERSION_PATTERNS = [r"libgstreamer-((\d+\.)+\d+)"]
-    VENDOR_PACKAGE = [("gstreamer_project", "gstreamer")]
+    VENDOR_PRODUCT = [("gstreamer_project", "gstreamer")]

--- a/cve_bin_tool/checkers/haproxy.py
+++ b/cve_bin_tool/checkers/haproxy.py
@@ -13,4 +13,4 @@ class HaproxyChecker(Checker):
     CONTAINS_PATTERNS = [r"HA-Proxy version ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"haproxy"]
     VERSION_PATTERNS = [r"HA-Proxy version ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("haproxy", "haproxy")]
+    VENDOR_PRODUCT = [("haproxy", "haproxy")]

--- a/cve_bin_tool/checkers/hostapd.py
+++ b/cve_bin_tool/checkers/hostapd.py
@@ -14,4 +14,4 @@ class HostapdChecker(Checker):
     CONTAINS_PATTERNS = [r"hostapd v([0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"hostapd"]
     VERSION_PATTERNS = [r"hostapd v([0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("w1.fi", "hostapd")]
+    VENDOR_PRODUCT = [("w1.fi", "hostapd")]

--- a/cve_bin_tool/checkers/icecast.py
+++ b/cve_bin_tool/checkers/icecast.py
@@ -13,4 +13,4 @@ class IcecastChecker(Checker):
     CONTAINS_PATTERNS = [r"Icecast ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"icecast"]
     VERSION_PATTERNS = [r"Icecast ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("icecast", "icecast")]
+    VENDOR_PRODUCT = [("icecast", "icecast")]

--- a/cve_bin_tool/checkers/icu.py
+++ b/cve_bin_tool/checkers/icu.py
@@ -18,4 +18,4 @@ class IcuChecker(Checker):
         r"ICU ([0-9]+\.[0-9]+\.[0-9]+)",
         r"icu[_-][relas-]*((0*(?:[1-6][0-9]?))+(\-[0-9]+)*)",
     ]
-    VENDOR_PACKAGE = [("icu-project", "international_components_for_unicode")]
+    VENDOR_PRODUCT = [("icu-project", "international_components_for_unicode")]

--- a/cve_bin_tool/checkers/irssi.py
+++ b/cve_bin_tool/checkers/irssi.py
@@ -13,4 +13,4 @@ class IrssiChecker(Checker):
     CONTAINS_PATTERNS = [r"irssi ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"irssi"]
     VERSION_PATTERNS = [r"irssi ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("irssi", "irssi")]
+    VENDOR_PRODUCT = [("irssi", "irssi")]

--- a/cve_bin_tool/checkers/kerberos.py
+++ b/cve_bin_tool/checkers/kerberos.py
@@ -16,7 +16,7 @@ class KerberosChecker(Checker):
         r"KRB5_BRAND: krb5-(\d+\.\d+\.?\d?)-final",
         r"kerberos 5[_-][apl-]*(1+\.[0-9]+(\.[0-9]+)*)",
     ]
-    VENDOR_PACKAGE = [("mit", "kerberos"), ("mit", "kerberos_5")]
+    VENDOR_PRODUCT = [("mit", "kerberos"), ("mit", "kerberos_5")]
 
     def get_version(self, lines, filename):
         version_info = super().get_version(lines, filename)

--- a/cve_bin_tool/checkers/kerberos.py
+++ b/cve_bin_tool/checkers/kerberos.py
@@ -28,7 +28,7 @@ class KerberosChecker(Checker):
             version_info5[0] = version_info
             version_info5[1] = dict()
             version_info5[1]["is_or_contains"] = version_info["is_or_contains"]
-            version_info5[1]["modulename"] = "kerberos_5"
+            version_info5[1]["productname"] = "kerberos_5"
 
             # strip the leading "5-" off the version for 'kerberos_5' if there is one
             # or conversely, add one to the 'kerberos' listing if there isn't

--- a/cve_bin_tool/checkers/libcurl.py
+++ b/cve_bin_tool/checkers/libcurl.py
@@ -22,4 +22,4 @@ class LibcurlChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"libcurl.so."]
     VERSION_PATTERNS = [r"CLIENT libcurl ([678]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("haxx", "curl"), ("haxx", "libcurl")]
+    VENDOR_PRODUCT = [("haxx", "curl"), ("haxx", "libcurl")]

--- a/cve_bin_tool/checkers/libdb.py
+++ b/cve_bin_tool/checkers/libdb.py
@@ -18,4 +18,4 @@ class LibdbChecker(Checker):
         r"Berkeley DB ([0-9]+\.[0-9]+\.[0-9]+):",  # short version as backup. we mostly want the long below.
         r"Berkeley DB .+, library version ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):",
     ]
-    VENDOR_PACKAGE = [("oracle", "berkeley_db")]
+    VENDOR_PRODUCT = [("oracle", "berkeley_db")]

--- a/cve_bin_tool/checkers/libgcrypt.py
+++ b/cve_bin_tool/checkers/libgcrypt.py
@@ -15,4 +15,4 @@ class LibgcryptChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"libgcrypt.so."]
     VERSION_PATTERNS = [r"Libgcrypt ([01]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("gnupg", "libgcrypt")]
+    VENDOR_PRODUCT = [("gnupg", "libgcrypt")]

--- a/cve_bin_tool/checkers/libjpeg.py
+++ b/cve_bin_tool/checkers/libjpeg.py
@@ -25,4 +25,4 @@ class LibjpegChecker(Checker):
         r"LIBJPEGTURBO_([0-9]+\.[0-9]+\.?[0-9]?)",
         r"LIBJPEG_([0-9]+\.[0-9]+\.?[0-9]?)",
     ]
-    VENDOR_PACKAGE = [("libjpeg-turbo", "libjpeg-turbo")]
+    VENDOR_PRODUCT = [("libjpeg-turbo", "libjpeg-turbo")]

--- a/cve_bin_tool/checkers/libjpeg.py
+++ b/cve_bin_tool/checkers/libjpeg.py
@@ -5,7 +5,7 @@
 CVE checker for libjpg-turbo
 
 Note that this file is named libjpeg.py instead of libjpeg-turbo.py to avoid an issue
-with loading the product.
+with loading the checker.
 
 References:
 https://www.cvedetails.com/vulnerability-list/vendor_id-17075/product_id-40849/Libjpeg-turbo-Libjpeg-turbo.html

--- a/cve_bin_tool/checkers/libjpeg.py
+++ b/cve_bin_tool/checkers/libjpeg.py
@@ -5,7 +5,7 @@
 CVE checker for libjpg-turbo
 
 Note that this file is named libjpeg.py instead of libjpeg-turbo.py to avoid an issue
-with loading the module.
+with loading the product.
 
 References:
 https://www.cvedetails.com/vulnerability-list/vendor_id-17075/product_id-40849/Libjpeg-turbo-Libjpeg-turbo.html

--- a/cve_bin_tool/checkers/libnss.py
+++ b/cve_bin_tool/checkers/libnss.py
@@ -32,4 +32,4 @@ class LibnssChecker(Checker):
         r"\@\(#\)NSS ([01234]+\.[0-9]+\.[0-9]+) Basic",
         r"\@\(#\)NSS ([01234]+\.[0-9]+\.[0-9]+)\.[0-9]+ Basic",
     ]
-    VENDOR_PACKAGE = [("mozilla", "network_security_services")]
+    VENDOR_PRODUCT = [("mozilla", "network_security_services")]

--- a/cve_bin_tool/checkers/libtiff.py
+++ b/cve_bin_tool/checkers/libtiff.py
@@ -18,4 +18,4 @@ class LibtiffChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"libtiff.so."]
     VERSION_PATTERNS = [r"LIBTIFF, Version ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("libtiff", "libtiff")]
+    VENDOR_PRODUCT = [("libtiff", "libtiff")]

--- a/cve_bin_tool/checkers/libvirt.py
+++ b/cve_bin_tool/checkers/libvirt.py
@@ -16,4 +16,4 @@ class LibvirtChecker(Checker):
         r"libvirt.so",
     ]
     VERSION_PATTERNS = [r"LIBVIRT_PRIVATE_([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("libvirt", "libvirt")]
+    VENDOR_PRODUCT = [("libvirt", "libvirt")]

--- a/cve_bin_tool/checkers/lighttpd.py
+++ b/cve_bin_tool/checkers/lighttpd.py
@@ -19,4 +19,4 @@ class LighttpdChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"lighttpd"]
     VERSION_PATTERNS = [r"lighttpd/([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("lighttpd", "lighttpd")]
+    VENDOR_PRODUCT = [("lighttpd", "lighttpd")]

--- a/cve_bin_tool/checkers/memcached.py
+++ b/cve_bin_tool/checkers/memcached.py
@@ -13,4 +13,4 @@ class MemcachedChecker(Checker):
     CONTAINS_PATTERNS = [r"memcached ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"memcached"]
     VERSION_PATTERNS = [r"memcached ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("memcached", "memcached")]
+    VENDOR_PRODUCT = [("memcached", "memcached")]

--- a/cve_bin_tool/checkers/ncurses.py
+++ b/cve_bin_tool/checkers/ncurses.py
@@ -29,4 +29,4 @@ class NcursesChecker(Checker):
         r"libpanelw",
     ]
     VERSION_PATTERNS = [r"ncurses ([0-9]+\.[0-9]+)", r"infocmp-([0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("gnu", "ncurses")]
+    VENDOR_PRODUCT = [("gnu", "ncurses")]

--- a/cve_bin_tool/checkers/nessus.py
+++ b/cve_bin_tool/checkers/nessus.py
@@ -21,4 +21,4 @@ class NessusChecker(Checker):
         r"Nessus ([0-9]+\.[0-9]+\.[0-9]+)",
         r"libnessus.so.([0-9]+\.[0-9]+\.[0-9]+)",
     ]
-    VENDOR_PACKAGE = [("tenable", "nessus")]
+    VENDOR_PRODUCT = [("tenable", "nessus")]

--- a/cve_bin_tool/checkers/nginx.py
+++ b/cve_bin_tool/checkers/nginx.py
@@ -19,4 +19,4 @@ class NginxChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"nginx"]
     VERSION_PATTERNS = [r"nginx/([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("nginx", "nginx")]
+    VENDOR_PRODUCT = [("nginx", "nginx")]

--- a/cve_bin_tool/checkers/node.py
+++ b/cve_bin_tool/checkers/node.py
@@ -22,4 +22,4 @@ class NodeChecker(Checker):
         r"https\:\/\/nodejs.org\/download\/release\/v([0-9]+\.[0-9]+\.[0-9]+)\/",
         r"node v([0-9]+\.[0-9]+\.[0-9]+)",
     ]
-    VENDOR_PACKAGE = [("nodejs", "node.js")]
+    VENDOR_PRODUCT = [("nodejs", "node.js")]

--- a/cve_bin_tool/checkers/openafs.py
+++ b/cve_bin_tool/checkers/openafs.py
@@ -13,4 +13,4 @@ class OpenafsChecker(Checker):
     CONTAINS_PATTERNS = [r"OpenAFS ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"afsd"]
     VERSION_PATTERNS = [r"OpenAFS ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("openafs", "openafs")]
+    VENDOR_PRODUCT = [("openafs", "openafs")]

--- a/cve_bin_tool/checkers/openssh_client.py
+++ b/cve_bin_tool/checkers/openssh_client.py
@@ -27,4 +27,4 @@ class OpensshClientChecker(Checker):
         r"slogin",
     ]
     VERSION_PATTERNS = [r"OpenSSH_([0-9]+\.[0-9]+[0-9a-z\s]*)"]
-    VENDOR_PACKAGE = [("openbsd", "openssh")]
+    VENDOR_PRODUCT = [("openbsd", "openssh")]

--- a/cve_bin_tool/checkers/openssh_server.py
+++ b/cve_bin_tool/checkers/openssh_server.py
@@ -14,4 +14,4 @@ class OpensshServerChecker(Checker):
     CONTAINS_PATTERNS = []
     FILENAME_PATTERNS = [r"sshd"]
     VERSION_PATTERNS = [r"OpenSSH_([0-9]+\.[0-9]+[0-9a-z\s]*)"]
-    VENDOR_PACKAGE = [("openbsd", "openssh")]
+    VENDOR_PRODUCT = [("openbsd", "openssh")]

--- a/cve_bin_tool/checkers/openssl.py
+++ b/cve_bin_tool/checkers/openssl.py
@@ -19,4 +19,4 @@ class OpensslChecker(Checker):
         r"part of OpenSSL ([01]+\.[0-9]+\.[0-9]+[a-z]*) ",
         r"OpenSSL ([01]+\.[0-9]+\.[0-9]+[a-z]*) ",
     ]
-    VENDOR_PACKAGE = [("openssl", "openssl")]
+    VENDOR_PRODUCT = [("openssl", "openssl")]

--- a/cve_bin_tool/checkers/openswan.py
+++ b/cve_bin_tool/checkers/openswan.py
@@ -23,4 +23,4 @@ class OpenswanChecker(Checker):
         r"rsasigkey",
     ]
     VERSION_PATTERNS = [r"Openswan ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("xelerance", "openswan")]
+    VENDOR_PRODUCT = [("xelerance", "openswan")]

--- a/cve_bin_tool/checkers/openvpn.py
+++ b/cve_bin_tool/checkers/openvpn.py
@@ -13,4 +13,4 @@ class OpenvpnChecker(Checker):
     CONTAINS_PATTERNS = [r"OpenVPN ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"openvpn"]
     VERSION_PATTERNS = [r"OpenVPN ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("openvpn", "openvpn")]
+    VENDOR_PRODUCT = [("openvpn", "openvpn")]

--- a/cve_bin_tool/checkers/png.py
+++ b/cve_bin_tool/checkers/png.py
@@ -19,4 +19,4 @@ class PngChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"libpng.so.", r"libpng16.so."]
     VERSION_PATTERNS = [r"libpng version ([0-9]+\.[0-9]+\.[0-9]+) -"]
-    VENDOR_PACKAGE = [("libpng", "libpng")]
+    VENDOR_PRODUCT = [("libpng", "libpng")]

--- a/cve_bin_tool/checkers/polarssl_fedora.py
+++ b/cve_bin_tool/checkers/polarssl_fedora.py
@@ -16,4 +16,4 @@ class PolarsslFedoraChecker(Checker):
     CONTAINS_PATTERNS = [r"libpolarssl.so.([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"libpolarssl.so."]
     VERSION_PATTERNS = [r"libpolarssl.so.([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("polarssl", "polarssl")]
+    VENDOR_PRODUCT = [("polarssl", "polarssl")]

--- a/cve_bin_tool/checkers/postgresql.py
+++ b/cve_bin_tool/checkers/postgresql.py
@@ -14,4 +14,4 @@ class PostgresqlChecker(Checker):
     CONTAINS_PATTERNS = [r"PostgreSQL ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"psql"]
     VERSION_PATTERNS = [r"PostgreSQL ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("postgresql", "postgresql")]
+    VENDOR_PRODUCT = [("postgresql", "postgresql")]

--- a/cve_bin_tool/checkers/python.py
+++ b/cve_bin_tool/checkers/python.py
@@ -20,7 +20,7 @@ class PythonChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"python"]
     VERSION_PATTERNS = [r"python([23]+\.[0-9])"]
-    VENDOR_PACKAGE = [("python_software_foundation", "python"), ("python", "python")]
+    VENDOR_PRODUCT = [("python_software_foundation", "python"), ("python", "python")]
 
     def get_version(self, lines, filename):
         # we will try to find python3+ as well as python2+

--- a/cve_bin_tool/checkers/radare2.py
+++ b/cve_bin_tool/checkers/radare2.py
@@ -13,4 +13,4 @@ class Radare2Checker(Checker):
     CONTAINS_PATTERNS = [r"rafind2 v([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"rafind2"]
     VERSION_PATTERNS = [r"rafind2 v([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("radare", "radare2")]
+    VENDOR_PRODUCT = [("radare", "radare2")]

--- a/cve_bin_tool/checkers/rsyslog.py
+++ b/cve_bin_tool/checkers/rsyslog.py
@@ -12,4 +12,4 @@ class RsyslogChecker(Checker):
     CONTAINS_PATTERNS = [r"rsyslog ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"rsyslogd"]
     VERSION_PATTERNS = [r"rsyslog ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("rsyslog", "rsyslog")]
+    VENDOR_PRODUCT = [("rsyslog", "rsyslog")]

--- a/cve_bin_tool/checkers/sqlite.py
+++ b/cve_bin_tool/checkers/sqlite.py
@@ -59,7 +59,7 @@ class SqliteChecker(Checker):
         r"ESCAPE expression must be a single character",
         r"SQLite version %s",
     ]
-    VENDOR_PACKAGE = [("sqlite", "sqlite")]
+    VENDOR_PRODUCT = [("sqlite", "sqlite")]
     VERSION_PATTERNS = [r"Id: SQLite version (\d+\.\d+\.\d+)", r"sqlite(\d+)\.debug"]
     FILENAME_PATTERNS = [r"sqlite", r"sqlite3"]
 

--- a/cve_bin_tool/checkers/strongswan.py
+++ b/cve_bin_tool/checkers/strongswan.py
@@ -13,4 +13,4 @@ class StrongswanChecker(Checker):
     CONTAINS_PATTERNS = [r"strongSwan ([0-9]+\.[0-9]+\.[0-9])"]
     FILENAME_PATTERNS = [r"libcharon.so"]
     VERSION_PATTERNS = [r"strongSwan ([0-9]+\.[0-9]+\.[0-9])"]
-    VENDOR_PACKAGE = [("strongswan", "strongswan")]
+    VENDOR_PRODUCT = [("strongswan", "strongswan")]

--- a/cve_bin_tool/checkers/syslogng.py
+++ b/cve_bin_tool/checkers/syslogng.py
@@ -18,4 +18,4 @@ class SyslogngChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"syslog-ng"]
     VERSION_PATTERNS = [r"syslog-ng-([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("balabit", "syslog-ng"), ("oneidentity", "syslog-ng")]
+    VENDOR_PRODUCT = [("balabit", "syslog-ng"), ("oneidentity", "syslog-ng")]

--- a/cve_bin_tool/checkers/systemd.py
+++ b/cve_bin_tool/checkers/systemd.py
@@ -23,4 +23,4 @@ class SystemdChecker(Checker):
         r"systemd v([0-9]+).* running in ",
         r"pam_systemd.so-([0-9]+)\.",
     ]
-    VENDOR_PACKAGE = [("freedesktop", "systemd")]
+    VENDOR_PRODUCT = [("freedesktop", "systemd")]

--- a/cve_bin_tool/checkers/varnish.py
+++ b/cve_bin_tool/checkers/varnish.py
@@ -11,4 +11,4 @@ class VarnishChecker(Checker):
     CONTAINS_PATTERNS = [r"varnish-([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"varnish"]
     VERSION_PATTERNS = [r"varnish-([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("varnish-cache", "varnish")]
+    VENDOR_PRODUCT = [("varnish-cache", "varnish")]

--- a/cve_bin_tool/checkers/wireshark.py
+++ b/cve_bin_tool/checkers/wireshark.py
@@ -13,4 +13,4 @@ class WiresharkChecker(Checker):
     CONTAINS_PATTERNS = [r"Wireshark ([0-9]+\.[0-9]+\.[0-9]+)"]
     FILENAME_PATTERNS = [r"rawshark"]
     VERSION_PATTERNS = [r"Wireshark ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PACKAGE = [("wireshark", "wireshark")]
+    VENDOR_PRODUCT = [("wireshark", "wireshark")]

--- a/cve_bin_tool/checkers/xerces.py
+++ b/cve_bin_tool/checkers/xerces.py
@@ -19,4 +19,4 @@ class XercesChecker(Checker):
         r"\/xerces-c-src_([0-9]+_[0-9]+_[0-9]+)\/",
         r"xercesc_([0-9]+\_[0-9]+):",
     ]
-    VENDOR_PACKAGE = [("apache", "xerces-c")]
+    VENDOR_PRODUCT = [("apache", "xerces-c")]

--- a/cve_bin_tool/checkers/xml2.py
+++ b/cve_bin_tool/checkers/xml2.py
@@ -20,7 +20,7 @@ class Xml2Checker(Checker):
     ]
     FILENAME_PATTERNS = [r"libxml2.so."]
     VERSION_PATTERNS = []
-    VENDOR_PACKAGE = [("xmlsoft", "libxml2")]
+    VENDOR_PRODUCT = [("xmlsoft", "libxml2")]
 
     @staticmethod
     def guess_xml2_version(lines):

--- a/cve_bin_tool/checkers/zlib.py
+++ b/cve_bin_tool/checkers/zlib.py
@@ -24,4 +24,4 @@ class ZlibChecker(Checker):
         r"deflate ([01]+\.[0-9]+\.[0-9]+) ",
         r"inflate ([01]+\.[0-9]+\.[0-9]+) ",
     ]
-    VENDOR_PACKAGE = [("gnu", "zlib")]
+    VENDOR_PRODUCT = [("gnu", "zlib")]

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -238,7 +238,7 @@ def main(argv=None):
         if scanner.files_with_cve > 0:
             affected_string = ", ".join(
                 map(
-                    lambda module_version: "".join(str(module_version)),
+                    lambda product_version: "".join(str(product_version)),
                     scanner.affected(),
                 )
             )

--- a/cve_bin_tool/csv2cve.py
+++ b/cve_bin_tool/csv2cve.py
@@ -49,7 +49,7 @@ class CSV2CVE(object):
 
     def get_cves(self):
         """Summary: Returns Dictionary containing Product_Name, Version,
-        CVE_Number and Severity associated with each module
+        CVE_Number and Severity associated with each product
 
         Returns:
         Example --> [

--- a/cve_bin_tool/scanner.py
+++ b/cve_bin_tool/scanner.py
@@ -97,7 +97,7 @@ class Scanner(object):
     def get_cves(self, vendor_product_pairs, version, score):
         """Returns a list of cves affecting a given version of a piece of software
         """
-        # get all cves for each vendor_package_pair
+        # get all cves for each vendor_product_pair
         for vendor, product in vendor_product_pairs:
             cves = self.cvedb.get_cves(vendor, product, version, score)
             cve_data = CVEData(vendor, product, version, cves)
@@ -184,7 +184,7 @@ class Scanner(object):
                             f'{filename} {result["is_or_contains"]} {dummy_checker_name} {version}'
                         )
                         self.get_cves(
-                            checker.VENDOR_PACKAGE, version, self.score,
+                            checker.VENDOR_PRODUCT, version, self.score,
                         )
 
         self.logger.debug(f"Done scanning file: {filename}")
@@ -213,6 +213,6 @@ class Scanner(object):
                 self.scan_and_or_extract_file(ectx, scan_path)
 
     def affected(self):
-        """ Returns list of module name and version tuples identified from
+        """ Returns list of product name and version tuples identified from
         scan"""
         return [(cve_data.product, cve_data.version) for cve_data in self.all_cves]

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -120,7 +120,7 @@ On Windows, it requires
 Fixing Known Issues / What should I do if it finds something?
 -------------------------------------------------------------
 
-The most recommended way to fix a given CVE is to upgrade the product to a
+The most recommended way to fix a given CVE is to upgrade the package to a
 non-vulnerable version.  Ideally, a CVE is only made public after a fix is
 available, although this is not always the case.
 
@@ -190,19 +190,19 @@ libgcrypt,1.6.0,CVE-2018-6829,HIGH
 ```json
 [
     {
-        "product": "libgcrypt",
+        "package": "libgcrypt",
         "version": "1.6.0",
         "cve_number": "CVE-2017-9526",
         "severity": "MEDIUM"
     },
     {
-        "product": "libgcrypt",
+        "package": "libgcrypt",
         "version": "1.6.0",
         "cve_number": "CVE-2018-0495",
         "severity": "MEDIUM"
     },
     {
-        "product": "libgcrypt",
+        "package": "libgcrypt",
         "version": "1.6.0",
         "cve_number": "CVE-2018-6829",
         "severity": "HIGH"

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -120,7 +120,7 @@ On Windows, it requires
 Fixing Known Issues / What should I do if it finds something?
 -------------------------------------------------------------
 
-The most recommended way to fix a given CVE is to upgrade the package to a
+The most recommended way to fix a given CVE is to upgrade the product to a
 non-vulnerable version.  Ideally, a CVE is only made public after a fix is
 available, although this is not always the case.
 
@@ -190,19 +190,19 @@ libgcrypt,1.6.0,CVE-2018-6829,HIGH
 ```json
 [
     {
-        "package": "libgcrypt",
+        "product": "libgcrypt",
         "version": "1.6.0",
         "cve_number": "CVE-2017-9526",
         "severity": "MEDIUM"
     },
     {
-        "package": "libgcrypt",
+        "product": "libgcrypt",
         "version": "1.6.0",
         "cve_number": "CVE-2018-0495",
         "severity": "MEDIUM"
     },
     {
-        "package": "libgcrypt",
+        "product": "libgcrypt",
         "version": "1.6.0",
         "cve_number": "CVE-2018-6829",
         "severity": "HIGH"

--- a/example/oot-checker/oot_checker/checker_name.py
+++ b/example/oot-checker/oot_checker/checker_name.py
@@ -36,9 +36,9 @@ def guess_curl_version_from_content(lines):
 def get_version(lines, filename):
     """returns version information for curl as found in a given file.
     The version info is returned as a tuple:
-        [modulename, is_or_contains, version]
+        [productname, is_or_contains, version]
 
-    modulename will be curl if curl is found (and blank otherwise)
+    productname will be curl if curl is found (and blank otherwise)
     is_or_contains idicates if the file is a copy of curl or contains one
     version gives the actual version number
 
@@ -49,7 +49,7 @@ def get_version(lines, filename):
         version_info["is_or_contains"] = "is"
 
     if "is_or_contains" in version_info:
-        version_info["modulename"] = "curl"
+        version_info["productname"] = "curl"
         version_info["version"] = guess_curl_version_from_content(lines)
 
     return version_info

--- a/test/csv/bad_vendor.csv
+++ b/test/csv/bad_vendor.csv
@@ -1,1 +1,1 @@
-nope,package,version
+nope,product,version

--- a/test/csv/bad_version.csv
+++ b/test/csv/bad_version.csv
@@ -1,1 +1,1 @@
-vendor,package,bueller?
+vendor,product,bueller?

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -5,7 +5,7 @@ import unittest
 import pytest
 import pkg_resources
 
-from cve_bin_tool.checkers import Checker, VendorPackagePair
+from cve_bin_tool.checkers import Checker, VendorProductPair
 
 Pattern = type(re.compile("", 0))
 
@@ -15,22 +15,22 @@ class TestCheckerClass(unittest.TestCase):
         class MyChecker(Checker):
             CONTAINS_PATTERNS = [r"look"]
             VERSION_PATTERNS = [r"for"]
-            FILENAME_PATTERNS = [r"mypackage"]
-            VENDOR_PACKAGE = [("myvendor", "mypackage")]
+            FILENAME_PATTERNS = [r"myproduct"]
+            VENDOR_PRODUCT = [("myvendor", "myproduct")]
 
         self.assertEqual(type(MyChecker.CONTAINS_PATTERNS[0]), Pattern)
         self.assertEqual(type(MyChecker.VERSION_PATTERNS[0]), Pattern)
         self.assertEqual(type(MyChecker.FILENAME_PATTERNS[0]), Pattern)
-        self.assertEqual(type(MyChecker.VENDOR_PACKAGE[0]), VendorPackagePair)
+        self.assertEqual(type(MyChecker.VENDOR_PRODUCT[0]), VendorProductPair)
 
     # def test_no_module_name(self):
-    #     with self.assertRaisesRegex(AssertionError, "module name"):
+    #     with self.assertRaisesRegex(AssertionError, "product name"):
 
     #         class MyChecker(Checker):
     #             CONTAINS_PATTERNS = [r"look"]
     #             VERSION_PATTERNS = [r"for"]
     #             FILENAME_PATTERNS = [r"mypackage"]
-    #             VENDOR_PACKAGE = [("myvendor", "mypackage")]
+    #             VENDOR_PACKAGE = [("myvendor", "myproduct")]
 
     def test_no_vpkg(self):
         with self.assertRaisesRegex(AssertionError, "at least one vendor"):
@@ -38,8 +38,8 @@ class TestCheckerClass(unittest.TestCase):
             class MyChecker(Checker):
                 CONTAINS_PATTERNS = [r"look"]
                 VERSION_PATTERNS = [r"for"]
-                FILENAME_PATTERNS = [r"mypackage"]
-                MODULE_NAME = "mychecker"
+                FILENAME_PATTERNS = [r"myproduct"]
+                PRODUCT_NAME = "mychecker"
 
 
 class TestCheckerVersionParser:

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -74,7 +74,7 @@ class TestOutputEngine(unittest.TestCase):
         self.mock_file.close()
 
     def test_formatted_output(self):
-        """ Test reformatting modules """
+        """ Test reformatting products """
         self.assertEqual(self.output_engine.formatted_output, self.FORMATTED_OUTPUT)
 
     def test_output_json(self):


### PR DESCRIPTION
Changes
-------------
I have changed almost every file to use `product` instead of `package` and `module`.
I haven't changed any documentation. But I updated documentation for checker because that was important. 