### PR TITLE
Skip invalid files without halting scan (Fixes #651)

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -21,11 +21,8 @@ class CVEData(NamedTuple):
     cves: List[NamedTuple]
 
 
-class InvalidFileError(Exception):
-    """ Filepath is invalid for scanning."""
-
-
 class VersionScanner:
+class Scanner(object):
     """"Scans files for CVEs using CVE checkers"""
 
     CHECKER_ENTRYPOINT = "cve_bin_tool.checker"
@@ -116,7 +113,8 @@ class VersionScanner:
 
         # Ensure filename is a file
         if not os.path.isfile(filename):
-            raise InvalidFileError(filename)
+            self.logger.warning(f"Invalid file {filename} cannot be scanned")
+            return None
 
         # step 1: check if it's an ELF binary file
         if inpath("file"):
@@ -125,7 +123,8 @@ class VersionScanner:
             o = o.decode(sys.stdout.encoding)
 
             if "cannot open" in o:
-                raise InvalidFileError(filename)
+                self.logger.warning(f"Unopenable file {filename} cannot be scanned")
+                return None
 
             if (
                 ("LSB " not in o)

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -22,7 +22,6 @@ class CVEData(NamedTuple):
 
 
 class VersionScanner:
-class Scanner(object):
     """"Scans files for CVEs using CVE checkers"""
 
     CHECKER_ENTRYPOINT = "cve_bin_tool.checker"

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -13,7 +13,7 @@ import pytest
 
 from cve_bin_tool.cve_scanner import CVEScanner
 from cve_bin_tool.cvedb import CVEDB
-from cve_bin_tool.version_scanner import VersionScanner, InvalidFileError
+from cve_bin_tool.version_scanner import VersionScanner
 from .test_data import __all__ as all_test_name
 from .utils import download_file, LONG_TESTS
 
@@ -177,9 +177,7 @@ class TestScanner:
             finally:
                 os.unlink("non-existant-link")
 
-    def test_cannot_open_file(self):
+    def test_cannot_open_file(self, caplog):
         """ Test behaviour when file cannot be opened """
-        with pytest.raises(InvalidFileError):
-            self.scanner.scan_file(
-                os.path.join(self.mapping_test_dir, "non-existant-file")
-            )
+        self.scanner.scan_file(os.path.join(self.mapping_test_dir, "non-existant-file"))
+        assert str.find("Invalid File", caplog.text)


### PR DESCRIPTION
This fixes #651, where the scanner would stop with an exception rather than simply skip the file when it encountered a non-regular file or a file that it couldn't open.  Many thanks to @anthonyharrison for the bug report and initial fix, and @darcyshx for helping me understand the urgency of the request better.

