### PR TITLE
Removed from __future__ import print

### DIFF
--- a/cve_bin_tool/csv2cve.py
+++ b/cve_bin_tool/csv2cve.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+from __future__ import print_function
 
 import argparse
 import csv

--- a/cve_bin_tool/csv2cve.py
+++ b/cve_bin_tool/csv2cve.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python3
-from __future__ import print_function
 
 import argparse
 import csv


### PR DESCRIPTION
Python 3.xx doesn't require the above dependency