### PR TITLE
remove legacy_windows console option

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -49,7 +49,7 @@ class CVEScanner:
 
     RANGE_UNSET: str = ""
     dbname: str = os.path.join(DISK_LOCATION_DEFAULT, DBNAME)
-    CONSOLE: Console = Console(file=sys.stderr, legacy_windows=False)
+    CONSOLE: Console = Console(file=sys.stderr)
 
     def __init__(self, score: int = 0, logger: Logger = None):
         self.logger = logger or LOGGER.getChild(self.__class__.__name__)

--- a/cve_bin_tool/log.py
+++ b/cve_bin_tool/log.py
@@ -21,7 +21,7 @@ logging.basicConfig(
     level="INFO",
     format="%(name)s - %(message)s",
     datefmt="[%X]",
-    handlers=[RichHandler(console=Console(legacy_windows=False))],
+    handlers=[RichHandler(console=Console())],
 )
 
 # Add the handlers to the root logger

--- a/cve_bin_tool/output_engine.py
+++ b/cve_bin_tool/output_engine.py
@@ -113,7 +113,7 @@ class OutputEngine(object):
         writer.writeheader()
         writer.writerows(formatted_output)
 
-    def output_console(self, console=Console(legacy_windows=False)):
+    def output_console(self, console=Console()):
         """ Output list of CVEs in a tabular format with color support """
 
         now = datetime.now().strftime("%Y-%m-%d  %H:%M:%S")


### PR DESCRIPTION
We don't need to specify this anymore since it's fixed in newer version of rich.