### PR TITLE
Update dev tree version to be 1.1

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -4,7 +4,7 @@ from urllib import request
 
 from cve_bin_tool.log import LOGGER
 
-VERSION = "1.0"
+VERSION = "1.1"
 
 
 def check_latest_version():


### PR DESCRIPTION
We've diverged pretty far from the 1.0 release, so it makes sense for the current development tree to have its own version.  1.1 is likely only ever going to be a development version number, as I expect our next release to be numbered 2.0 (to reflect major changes in output and general features).  I'm *hoping* to target the 2.0 release in the early fall after GSoC is complete, but that's not a firm date yet.