### PR TITLE
Extractor: Added support for wheel and egg archive

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -46,7 +46,15 @@ class BaseExtractor:
             self.extract_file_rpm: {".rpm"},
             self.extract_file_deb: {".deb", ".ipk"},
             self.extract_file_cab: {".cab"},
-            self.extract_file_zip: {".exe", ".zip", ".jar", ".apk", ".msi"},
+            self.extract_file_zip: {
+                ".exe",
+                ".zip",
+                ".jar",
+                ".apk",
+                ".msi",
+                ".egg",
+                ".whl",
+            },
         }
 
     def can_extract(self, filename):

--- a/test/test_data/openssl.py
+++ b/test/test_data/openssl.py
@@ -16,5 +16,11 @@ package_test_data = [
         "package_name": "openssl-1.0.2g-1.1.mga5.i586.rpm",
         "product": "openssl",
         "version": "1.0.2g",
-    }
+    },
+    {
+        "url": "https://files.pythonhosted.org/packages/ba/91/84a29d6a27fd6dfc21f475704c4d2053d58ed7a4033c2b0ce1b4ca4d03d9/",
+        "package_name": "cryptography-3.0-cp35-abi3-manylinux2010_x86_64.whl",
+        "product": "openssl",
+        "version": "1.1.1.6",
+    },
 ]

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -167,7 +167,15 @@ class TestExtractFileZip(TestExtractorBase):
         when the exe is a self-extracting zipfile """
 
     def setup_method(self):
-        for filename in ["test.exe", "test.zip", "test.jar", "test.apk", "test.msi"]:
+        for filename in [
+            "test.exe",
+            "test.zip",
+            "test.jar",
+            "test.apk",
+            "test.msi",
+            "test.egg",
+            "test.whl",
+        ]:
             zippath = os.path.join(self.tempdir, filename)
             with ZipFile(zippath, "w") as zipfile:
                 zipfile.writestr(ZipInfo("test.txt"), "feedface")


### PR DESCRIPTION
Note: It wheel only scan compiled C/C++ extension file because cve-bin-tool only support binary file scan.