### PR TITLE
cli: Allow user to update database with `-u now` option without having to specify directory and several small fixes

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -147,6 +147,7 @@ def main(argv=None):
         "-s",
         "--skips",
         dest="skips",
+        default="",
         action="store",
         type=str,
         help="comma-separated list of checkers to disable",
@@ -155,11 +156,13 @@ def main(argv=None):
         "-r",
         "--runs",
         dest="checkers",
+        default="",
         action="store",
         type=str,
         help="comma-separated list of checkers to enable",
     )
 
+    # Output related settings
     with ErrorHandler(mode=ErrorMode.NoTrace):
         args = parser.parse_args(argv[1:])
 
@@ -194,18 +197,7 @@ def main(argv=None):
                           """
         LOGGER.warning(warning_nolinux)
 
-    if not args.directory and not args.input_file:
-        parser.print_usage()
-        with ErrorHandler(logger=LOGGER, mode=ErrorMode.NoTrace):
-            raise InsufficientArgs(
-                "Please specify a directory to scan or an input file required"
-            )
-
-    if args.directory and not os.path.exists(args.directory):
-        parser.print_usage()
-        with ErrorHandler(logger=LOGGER, mode=ErrorMode.NoTrace):
-            raise FileNotFoundError("Directory/File doesn't exist")
-
+    # Database update related settings
     # Connect to the database
     cvedb_orig = CVEDB(
         version_check=not args.disable_version_check, error_mode=error_mode
@@ -233,9 +225,21 @@ def main(argv=None):
             with ErrorHandler(mode=error_mode, logger=LOGGER):
                 raise EmptyCache(cvedb_orig.cachedir)
 
-    skips = ""
-    if args.skips:
-        skips = args.skips
+    # Input validation
+    if not args.directory and not args.input_file:
+        parser.print_usage()
+        with ErrorHandler(logger=LOGGER, mode=ErrorMode.NoTrace):
+            raise InsufficientArgs(
+                "Please specify a directory to scan or an input file required"
+            )
+
+    if args.directory and not os.path.exists(args.directory):
+        parser.print_usage()
+        with ErrorHandler(logger=LOGGER, mode=ErrorMode.NoTrace):
+            raise FileNotFoundError("Directory/File doesn't exist")
+
+    # Checkers related settings
+    skips = args.skips
 
     if args.checkers:
         checkers = args.checkers.split(",")


### PR DESCRIPTION
I have re-ordered execution order so that it will allow user to update database without having to scan a directory.
Fixes: #822 