### PR TITLE
Update setup script dependencies and package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,18 @@ setup_kwargs = dict(
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
-    install_requires=["jsonschema>=3.0.2", "pytest"],
+    install_requires=[
+        "rich",
+        "plotly",
+        "jinja2",
+        "beautifulsoup4",
+        "aiohttp[speedups]",
+        "jsonschema>=3.0.2",
+        "pytest",
+        "pytest-xdist",
+        "pytest-cov",
+        "pytest-asyncio",
+    ],
     packages=find_packages(),
     package_data={
         "cve_bin_tool.output_engine": [

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,13 @@ setup_kwargs = dict(
     ],
     install_requires=["jsonschema>=3.0.2", "pytest"],
     packages=find_packages(),
+    package_data={
+        "cve_bin_tool.output_engine": [
+            "html_reports/templates/*.html",
+            "html_reports/css/*.css",
+            "html_reports/js/*.js",
+        ]
+    },
     entry_points={
         "console_scripts": [
             "cve-bin-tool = cve_bin_tool.cli:main",


### PR DESCRIPTION
Fixes two of the three issues mentioned in #808
- [x] An unhandled exception occurs if any of the 4 html templates (base, dashboard, row_cve, row_product) do not exist.

- [x] The default directory for the html templates directory is assumed to be the installation directory but they are not installed as part of the distribution.