### PR TITLE
Updated the info msg in version checker

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -1,6 +1,7 @@
 import json
 import textwrap
 from urllib import request
+from packaging import version
 
 from cve_bin_tool.log import LOGGER
 
@@ -33,7 +34,7 @@ def check_latest_version():
                 LOGGER.info(
                     f"You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}."
                 )
-                if VERSION < pypi_version:
+                if version.parse(VERSION) < version.parse(pypi_version):
                     LOGGER.info("Alert: We recommend using the latest stable release.")
     except Exception as error:
         LOGGER.warning(

--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -31,12 +31,10 @@ def check_latest_version():
             else:
                 # TODO In future mark me with some color ( prefer yellow or red )
                 LOGGER.info(
-                    textwrap.dedent(
-                        f"""You are running version {VERSION} of {name} but the latest is {pypi_version}!
-                    Alert: We recommend using the latest stable release.
-                    """
+                        f"You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}."
                     )
-                )
+                if VERSION < pypi_version:
+                    LOGGER.info("Alert: We recommend using the latest stable release.")
     except Exception as error:
         LOGGER.warning(
             textwrap.dedent(

--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -31,8 +31,8 @@ def check_latest_version():
             else:
                 # TODO In future mark me with some color ( prefer yellow or red )
                 LOGGER.info(
-                        f"You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}."
-                    )
+                    f"You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}."
+                )
                 if VERSION < pypi_version:
                     LOGGER.info("Alert: We recommend using the latest stable release.")
     except Exception as error:


### PR DESCRIPTION
Now we have changed the version to be 1.1 you might have also seen the tool specifying that `we recommend using the latest stable release` but we only want to specify that to those users who are behind the latest version. 

```console
           INFO     cve_bin_tool.CVEDB - Updating CVE data. This will take a few minutes.                              cvedb.py:225
           INFO     cve_bin_tool.CVEDB - Checking if there is a newer version.                                         cvedb.py:187
[18:34:04] INFO     cve_bin_tool - You are running version 1.1 of cve-bin-tool but the latest is 1.0!                 version.py:37
                                        Alert: We recommend using the latest stable release.                                       
           INFO     cve_bin_tool.CVEDB - Downloading CVE data... 
```