### PR TITLE
test_checker: remove unnecessary comments and use pytest instead of unittest

### DIFF
--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -1,16 +1,15 @@
 #!python
 import re
-import unittest
 
-import pytest
 import pkg_resources
+import pytest
 
 from cve_bin_tool.checkers import Checker, VendorProductPair
 
 Pattern = type(re.compile("", 0))
 
 
-class TestCheckerClass(unittest.TestCase):
+class TestCheckerClass:
     def test_valid_checker(self):
         class MyChecker(Checker):
             CONTAINS_PATTERNS = [r"look"]
@@ -18,28 +17,21 @@ class TestCheckerClass(unittest.TestCase):
             FILENAME_PATTERNS = [r"myproduct"]
             VENDOR_PRODUCT = [("myvendor", "myproduct")]
 
-        self.assertEqual(type(MyChecker.CONTAINS_PATTERNS[0]), Pattern)
-        self.assertEqual(type(MyChecker.VERSION_PATTERNS[0]), Pattern)
-        self.assertEqual(type(MyChecker.FILENAME_PATTERNS[0]), Pattern)
-        self.assertEqual(type(MyChecker.VENDOR_PRODUCT[0]), VendorProductPair)
-
-    # def test_no_module_name(self):
-    #     with self.assertRaisesRegex(AssertionError, "product name"):
-
-    #         class MyChecker(Checker):
-    #             CONTAINS_PATTERNS = [r"look"]
-    #             VERSION_PATTERNS = [r"for"]
-    #             FILENAME_PATTERNS = [r"mypackage"]
-    #             VENDOR_PACKAGE = [("myvendor", "myproduct")]
+        assert type(MyChecker.CONTAINS_PATTERNS[0]) == Pattern
+        assert type(MyChecker.VERSION_PATTERNS[0]) == Pattern
+        assert type(MyChecker.FILENAME_PATTERNS[0]) == Pattern
+        assert type(MyChecker.VENDOR_PRODUCT[0]) == VendorProductPair
 
     def test_no_vpkg(self):
-        with self.assertRaisesRegex(AssertionError, "at least one vendor"):
+        with pytest.raises(AssertionError) as e:
 
             class MyChecker(Checker):
                 CONTAINS_PATTERNS = [r"look"]
                 VERSION_PATTERNS = [r"for"]
                 FILENAME_PATTERNS = [r"myproduct"]
                 PRODUCT_NAME = "mychecker"
+
+        assert e.value.args[0] == "MyChecker needs at least one vendor product pair"
 
 
 class TestCheckerVersionParser:


### PR DESCRIPTION
I just noticed commented leftover code. So, I thought to clean it and also convert unittest to pytest for consistency.