### PR TITLE
linkify CVEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.vscode/
+.mypy_cache/
 *.swp
 *.pyc
 __pycache__/

--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -14,6 +14,8 @@ from rich.panel import Panel
 from .cvedb import DISK_LOCATION_DEFAULT, DBNAME
 from .error_handler import ErrorMode
 from .input_engine import TriageData
+from .linkify import linkify_cve
+from .theme import cve_theme
 from .log import LOGGER
 from .util import ProductInfo, CVE, CVEData
 
@@ -29,7 +31,7 @@ class CVEScanner:
 
     RANGE_UNSET: str = ""
     dbname: str = os.path.join(DISK_LOCATION_DEFAULT, DBNAME)
-    CONSOLE: Console = Console(file=sys.stderr)
+    CONSOLE: Console = Console(file=sys.stderr, theme=cve_theme)
     ALPHA_TO_NUM: Dict[str, int] = dict(zip(ascii_lowercase, range(26)))
 
     def __init__(
@@ -173,14 +175,25 @@ class CVEScanner:
                 self.logger.info(f"Known CVEs in {product_info}")
                 # error_mode.value will only be greater than 1 if quiet mode.
                 if self.error_mode.value > 1:
-                    self.CONSOLE.print(
-                        Columns(
-                            [
-                                Panel(f"[yellow]{cve.cve_number}[/yellow]")
-                                for cve in cves
-                            ]
+                    title = f"[default][b]{len(cves)}[/b] CVE(s) in [b]{product_info.vendor}.{product_info.product}[/b] v[b]{product_info.version}[/b]"
+                    self.CONSOLE.log()
+                    self.CONSOLE.log(
+                        Panel(
+                            Columns(
+                                (
+                                    linkify_cve(
+                                        f"[{cve.severity.lower()}]{cve.cve_number}"
+                                    )
+                                    for cve in cves
+                                ),
+                                padding=(0, 2),
+                            ),
+                            padding=1,
+                            border_style="red",
+                            title=title,
                         ),
                     )
+                    self.CONSOLE.log()
             else:
                 # No cves found for (product, vendor, version) tuple in the NVD database.
                 self.products_without_cve += 1

--- a/cve_bin_tool/linkify.py
+++ b/cve_bin_tool/linkify.py
@@ -8,7 +8,7 @@ def linkify_cve(text_str: TextType) -> Text:
     """Apply a link to anything that looks like a CVE."""
 
     def make_link(cve: str) -> Style:
-        return Style(link=f"https://cve.mitre.org/cgi-bin/cvename.cgi?name={cve}")
+        return Style(link=f"https://nvd.nist.gov/vuln/detail/{cve}")
 
     text = Text.from_markup(text_str) if isinstance(text_str, str) else text_str
     text.highlight_regex(RE_CVE, style=make_link)

--- a/cve_bin_tool/linkify.py
+++ b/cve_bin_tool/linkify.py
@@ -1,0 +1,15 @@
+from rich.style import Style
+from rich.text import Text, TextType
+
+RE_CVE = r"CVE\-\d{4}\-\d+"
+
+
+def linkify_cve(text_str: TextType) -> Text:
+    """Apply a link to anything that looks like a CVE."""
+
+    def make_link(cve: str) -> Style:
+        return Style(link=f"https://cve.mitre.org/cgi-bin/cvename.cgi?name={cve}")
+
+    text = Text.from_markup(text_str) if isinstance(text_str, str) else text_str
+    text.highlight_regex(RE_CVE, style=make_link)
+    return text

--- a/cve_bin_tool/log.py
+++ b/cve_bin_tool/log.py
@@ -1,7 +1,6 @@
 """Logging"""
 import logging
 
-from rich.console import Console
 from rich.logging import RichHandler
 
 
@@ -21,7 +20,7 @@ logging.basicConfig(
     level="INFO",
     format="%(name)s - %(message)s",
     datefmt="[%X]",
-    handlers=[RichHandler(console=Console())],
+    handlers=[RichHandler()],
 )
 
 # Add the handlers to the root logger

--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -1,19 +1,25 @@
 import textwrap
 from collections import defaultdict
 from datetime import datetime
-from typing import List, Dict
+from typing import List, DefaultDict, Dict
 
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.table import Table
+from rich.text import Text
+
 
 from ..cve_scanner import CVEData
+from ..linkify import linkify_cve
+from ..theme import cve_theme
 from ..input_engine import Remarks
 from ..util import ProductInfo
 
 
-def output_console(all_cve_data: Dict[ProductInfo, CVEData], console=Console()):
+def output_console(
+    all_cve_data: Dict[ProductInfo, CVEData], console=Console(theme=cve_theme)
+):
     """ Output list of CVEs in a tabular format with color support """
 
     now = datetime.now().strftime("%Y-%m-%d  %H:%M:%S")
@@ -29,15 +35,6 @@ def output_console(all_cve_data: Dict[ProductInfo, CVEData], console=Console()):
         )
     )
 
-    # colors provide color name according to the severity
-    colors = {
-        "CRITICAL": "red",
-        "HIGH": "blue",
-        "MEDIUM": "yellow",
-        "LOW": "green",
-        "UNKNOWN": "white",
-    }
-
     remarks_colors = {
         Remarks.Mitigated: "green",
         Remarks.Confirmed: "red",
@@ -46,7 +43,7 @@ def output_console(all_cve_data: Dict[ProductInfo, CVEData], console=Console()):
         Remarks.Ignored: "white",
     }
 
-    cve_by_remarks: defaultdict[Remarks, List[Dict[str, str]]] = defaultdict(list)
+    cve_by_remarks: DefaultDict[Remarks, List[Dict[str, str]]] = defaultdict(list)
     # group cve_data by its remarks
     for product_info, cve_data in all_cve_data.items():
         for cve in cve_data["cves"]:
@@ -74,13 +71,13 @@ def output_console(all_cve_data: Dict[ProductInfo, CVEData], console=Console()):
         table.add_column("Severity")
 
         for cve_data in cve_by_remarks[remarks]:
-            color = colors[cve_data["severity"]]
+            color = cve_data["severity"].lower()
             table.add_row(
-                f'[{color}]{cve_data["vendor"]} [/{color}]',
-                f'[{color}]{cve_data["product"]} [/{color}]',
-                f'[{color}]{cve_data["version"]} [/{color}]',
-                f'[{color}]{cve_data["cve_number"]} [/{color}]',
-                f'[{color}]{cve_data["severity"]} [/{color}]',
+                Text.styled(cve_data["vendor"], color),
+                Text.styled(cve_data["product"], color),
+                Text.styled(cve_data["version"], color),
+                linkify_cve(Text.styled(cve_data["cve_number"], color)),
+                Text.styled(cve_data["severity"], color),
             )
         # Print the table to the console
         console.print(table)

--- a/cve_bin_tool/theme.py
+++ b/cve_bin_tool/theme.py
@@ -1,0 +1,12 @@
+from rich.theme import Theme
+
+# Rich theme to colorize in the terminal
+cve_theme = Theme(
+    {
+        "critical": "red",
+        "high": "blue",
+        "medium": "yellow",
+        "low": "green",
+        "unknown": "white",
+    }
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jsonschema
-rich==4.0.0
+rich==5.1.2
 plotly
 jinja2
 beautifulsoup4

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -108,7 +108,7 @@ class TestOutputEngine(unittest.TestCase):
         console = Console(file=self.mock_file)
         output_console(self.MOCK_OUTPUT, console=console)
 
-        expected_output = "╭───────────────╮\n│ NewFound CVEs │\n╰───────────────╯\n┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┓\n┃ Vendor      ┃ Product      ┃ Version ┃ CVE Number    ┃ Severity ┃\n┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━┩\n│ vendorname0 │ productname0 │ 1.0     │ CVE-1234-1234 │ MEDIUM   │\n│ vendorname0 │ productname0 │ 1.0     │ CVE-1234-9876 │ LOW      │\n│ vendorname0 │ productname0 │ 2.8.6   │ CVE-1234-1111 │ LOW      │\n│ vendorname1 │ productname1 │ 3.2.1.0 │ CVE-1234-5678 │ HIGH     │\n└─────────────┴──────────────┴─────────┴───────────────┴──────────┘\n"
+        expected_output = "│ vendorname0 │ productname0 │ 1.0     │ CVE-1234-1234 │ MEDIUM   │\n│ vendorname0 │ productname0 │ 1.0     │ CVE-1234-9876 │ LOW      │\n│ vendorname0 │ productname0 │ 2.8.6   │ CVE-1234-1111 │ LOW      │\n│ vendorname1 │ productname1 │ 3.2.1.0 │ CVE-1234-5678 │ HIGH     │\n└─────────────┴──────────────┴─────────┴───────────────┴──────────┘\n"
         self.mock_file.seek(0)  # reset file position
         result = self.mock_file.read()
         self.assertIn(expected_output, result)

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -107,9 +107,11 @@ class TestOutputEngine(unittest.TestCase):
 
         console = Console(file=self.mock_file)
         output_console(self.MOCK_OUTPUT, console=console)
-        expected_output = "│ vendorname0  │ productname0  │ 1.0      │ CVE-1234-1234  │ MEDIUM   │\n│ vendorname0  │ productname0  │ 1.0      │ CVE-1234-9876  │ LOW      │\n│ vendorname0  │ productname0  │ 2.8.6    │ CVE-1234-1111  │ LOW      │\n│ vendorname1  │ productname1  │ 3.2.1.0  │ CVE-1234-5678  │ HIGH     │\n└──────────────┴───────────────┴──────────┴────────────────┴──────────┘\n"
+
+        expected_output = "╭───────────────╮\n│ NewFound CVEs │\n╰───────────────╯\n┏━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━┓\n┃ Vendor      ┃ Product      ┃ Version ┃ CVE Number    ┃ Severity ┃\n┡━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━┩\n│ vendorname0 │ productname0 │ 1.0     │ CVE-1234-1234 │ MEDIUM   │\n│ vendorname0 │ productname0 │ 1.0     │ CVE-1234-9876 │ LOW      │\n│ vendorname0 │ productname0 │ 2.8.6   │ CVE-1234-1111 │ LOW      │\n│ vendorname1 │ productname1 │ 3.2.1.0 │ CVE-1234-5678 │ HIGH     │\n└─────────────┴──────────────┴─────────┴───────────────┴──────────┘\n"
         self.mock_file.seek(0)  # reset file position
-        self.assertIn(expected_output, self.mock_file.read())
+        result = self.mock_file.read()
+        self.assertIn(expected_output, result)
 
     def test_output_file(self):
         """Test file generation logic in output_file"""


### PR DESCRIPTION
Hi, 

I'm the author of Rich. I noticed you've used Rich to great effect, and I thought I could suggest some other things you could do with it.

Main change is a function to turn CVE references in to links that go to https://cve.mitre.org. So for terminals that support links a click (or cmd+click) on the CVE will jump straight to the appropriate page.

<img width="644" alt="Screen Shot 2020-08-13 at 13 33 30" src="https://user-images.githubusercontent.com/554369/90156758-bc222f80-dd84-11ea-93ea-a9376b16a789.png">

I've also made some changes to the found CVE references that were written in the logs. I find it a little easier to read this way...

<img width="1328" alt="Screen Shot 2020-08-13 at 13 33 14" src="https://user-images.githubusercontent.com/554369/90156930-ff7c9e00-dd84-11ea-8f9f-4da36cc4e75c.png">
