### PR TITLE
Docstring update for render_cves and group_cve_by_remark

### DIFF
--- a/cve_bin_tool/output_engine/html.py
+++ b/cve_bin_tool/output_engine/html.py
@@ -5,6 +5,7 @@ from typing import Dict
 
 import plotly.graph_objects as go
 from jinja2 import Environment, FileSystemLoader
+from jinja2.environment import Template
 
 from .util import group_cve_by_remark
 from ..log import LOGGER
@@ -12,7 +13,20 @@ from ..util import ProductInfo, CVEData, Remarks
 from ..version import VERSION
 
 
-def render_cves(hid, cve_row, tag, cves):
+def render_cves(
+    hid: str, cve_row: Template, tag: str, cves: List[Dict[str, str]]
+) -> str:
+    """Return rendered form of CVEs using cve_row template
+
+    Args:
+        hid (str): Unique id for each product
+        cve_row (Template): JinjaTemplate to be used for rendering
+        tag (str): Marked by user. (default: New) Can be anything [NEW, MITIGATED, IGNORED, UNEXPLORED]
+        cves (List[Dict[str, str]]): List of CVEs present in the products.
+
+    Returns:
+        str: CVE(s) in rendered form
+    """
     list_cves = []
     for i, cve in enumerate(cves):
         # render CVE template with data and add to list_cves

--- a/cve_bin_tool/output_engine/html.py
+++ b/cve_bin_tool/output_engine/html.py
@@ -1,7 +1,7 @@
 import os
 from collections import Counter, defaultdict
 from datetime import datetime
-from typing import Dict
+from typing import Dict, List
 
 import plotly.graph_objects as go
 from jinja2 import Environment, FileSystemLoader

--- a/cve_bin_tool/output_engine/util.py
+++ b/cve_bin_tool/output_engine/util.py
@@ -5,9 +5,9 @@ output_engine/util.py - Provides helper functions for OutputEngine.
 import os
 from collections import defaultdict
 from datetime import datetime
-from typing import List, Dict
+from typing import List, Dict, DefaultDict
 
-from ..util import ProductInfo, Remarks, CVEData
+from ..util import ProductInfo, Remarks, CVEData, CVE
 
 
 def generate_filename(extension: str) -> str:
@@ -83,8 +83,32 @@ def add_extension_if_not(filename: str, output_type: str) -> str:
         return filename
 
 
-def group_cve_by_remark(cve_by_product):
-    cve_by_remarks: defaultdict[Remarks, List[Dict[str, str]]] = defaultdict(list)
+def group_cve_by_remark(
+    cve_by_product: List[CVE],
+) -> DefaultDict[Remarks, List[Dict[str, str]]]:
+    """Return a dict containing CVE details dict mapped to Remark as Key. 
+
+    Example:
+    cve_by_remark = {
+            "NEW":[
+                {
+                    "cve_number": "CVE-XXX-XXX", 
+                    "severity": "High",
+                    "decription: "Lorem Ipsm", 
+                },
+                {...}
+            ],
+            "IGNORED": [{...},{..}],
+        }
+
+
+    Args:
+        cve_by_product (List[CVE]): List of CVE(s) that needs to be grouped
+
+    Returns:
+        DefaultDict[Remarks, List[Dict[str, str]]]: CVEs grouped by remark stored in default dict
+    """
+    cve_by_remarks: DefaultDict[Remarks, List[Dict[str, str]]] = defaultdict(list)
     for cve in cve_by_product:
         cve_by_remarks[cve.remarks].append(
             {


### PR DESCRIPTION
Changes
------------
Added Docstring for `output_engine/html.py -> render_cves` and `output_engine/util.py -> group_cve_by_remark`. I had previously added those but I think Niraj's PR has removed that. So Pushing it again. 

