### PR TITLE
Produce error if signature of cve_scanner change

### DIFF
--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,18 +1,36 @@
 """
 CVE-bin-tool util tests
 """
-import unittest
+import inspect
+from typing import DefaultDict
 
-from cve_bin_tool.util import inpath
+from cve_bin_tool.cve_scanner import CVEScanner
+from cve_bin_tool.util import inpath, CVEData, ProductInfo
 
 
-class TestUtil(unittest.TestCase):
+class TestUtil:
     """ Test the util functions """
 
     def test_inpath(self):
         """ Test the check to see if a command line utility is installed
         and in path before we try to run it. """
-        self.assertTrue(inpath("python"))
+        assert inpath("python")
 
     def test_not_inpath(self):
-        self.assertFalse(inpath("cve_bin_tool_test_for_not_in_path"))
+        assert not inpath("cve_bin_tool_test_for_not_in_path")
+
+
+class TestSignature:
+    """ Tests signature of critical class and functions"""
+
+    def test_cve_scanner(self):
+        sig = inspect.signature(CVEScanner.get_cves)
+        expected_args = {"product_info", "triage_data", "self"}
+        assert (
+            set(sig.parameters) - expected_args == set()
+        ), "Parameters of get_cves has been changed. Make sure it isn't breaking InputEngine!"
+
+        instance_attrs = vars(CVEScanner)["__annotations__"]
+        assert (
+            instance_attrs["all_cve_data"] == DefaultDict[ProductInfo, CVEData]
+        ), "Type of all_cve_data has been changed. Make sure it isn't breaking OutputEngine!"


### PR DESCRIPTION
Since, CVEScanner is the glue that interact with both InputEngine and OutputEngine if it's signature changes it can break whole build. Since it has happened previously, it would be nice to throw an error if someone change signature of this critical part.