### PR TITLE
Fixed link to user manual in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you want to integrate cve-bin-tool as a part of your github action pipeline.
 You can checkout our example [github action](https://github.com/intel/cve-bin-tool/blob/master/doc/how_to_guides/cve_scanner_gh_action.yml). 
 
 This readme is intended to be a quickstart guide for using the tool.  If you
-require more information, there is also a [user manual](MANUAL.md) available.
+require more information, there is also a [user manual](https://github.com/intel/cve-bin-tool/blob/master/doc/MANUAL.md) available.
 
 ## How it works
 


### PR DESCRIPTION
The link to the user manual in the README.md file is not working