### PR TITLE
cvedb: Create aiohttp ClientSession with trust_env=True

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -190,7 +190,7 @@ class CVEDB:
             self.LOGGER.info("Checking if there is a newer version.")
             check_latest_version()
         if not self.session:
-            self.session = aiohttp.ClientSession()
+            self.session = aiohttp.ClientSession(trust_env=True)
         self.LOGGER.info("Downloading CVE data...")
         nvd_metadata, curl_metadata = await asyncio.gather(
             self.nist_scrape(self.session), self.get_curl_versions(self.session)

--- a/test/test_cvedb.py
+++ b/test/test_cvedb.py
@@ -22,7 +22,7 @@ class TestCVEDB:
 
     @pytest.mark.asyncio
     async def test_00_getmeta(self):
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             _jsonurl, meta = await self.cvedb.getmeta(
                 session,
                 "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-modified.meta",
@@ -31,7 +31,7 @@ class TestCVEDB:
 
     @pytest.mark.asyncio
     async def test_01_nist_scrape(self):
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             jsonshas = await self.cvedb.nist_scrape(session)
             assert (
                 "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2015.json.gz"
@@ -40,7 +40,7 @@ class TestCVEDB:
 
     @pytest.mark.asyncio
     async def test_02_cache_update(self):
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(trust_env=True) as session:
             jsonurl, meta = await self.cvedb.getmeta(
                 session, "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-2015.meta"
             )


### PR DESCRIPTION
We previously left this out. Without trust_env=True aiohttp won't pick
up proxy environment variables.

Fixes: #922