### PR TITLE
Append version in .cache files

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -27,14 +27,16 @@ from .error_handler import (
     ErrorMode,
 )
 from .log import LOGGER
-from .version import check_latest_version
+from .version import check_latest_version, VERSION
 
 logging.basicConfig(level=logging.DEBUG)
 
 # database defaults
-DISK_LOCATION_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "cve-bin-tool")
+DISK_LOCATION_DEFAULT = os.path.join(
+    os.path.expanduser("~"), ".cache", f"cve-bin-tool{VERSION}"
+)
 DBNAME = "cve.db"
-OLD_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
+OLD_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", f"cvedb{VERSION}")
 
 
 class CVEDB:

--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -4,8 +4,9 @@ from urllib import request
 from packaging import version
 
 from cve_bin_tool.log import LOGGER
+import fnmatch
 
-VERSION = "1.1"
+VERSION = "2.0-alpha"
 
 
 def check_latest_version():
@@ -31,11 +32,19 @@ def check_latest_version():
                 )
             else:
                 # TODO In future mark me with some color ( prefer yellow or red )
-                LOGGER.info(
-                    f"You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}."
-                )
-                if version.parse(VERSION) < version.parse(pypi_version):
-                    LOGGER.info("Alert: We recommend using the latest stable release.")
+
+                if fnmatch.fnmatch(VERSION, "*alpha"):
+                    LOGGER.info(
+                        f"You are running the development version {VERSION} of {name}.The latest PyPI Version is {pypi_version}."
+                    )
+                else:
+                    LOGGER.info(
+                        f"You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}."
+                    )
+                    if version.parse(VERSION) < version.parse(pypi_version):
+                        LOGGER.info(
+                            "Alert: We recommend using the latest stable release."
+                        )
     except Exception as error:
         LOGGER.warning(
             textwrap.dedent(


### PR DESCRIPTION
#805
I appended the version in .cache files related to cve-bin-tool. Now, we can have multiple copies for different versions and we don't need to overwrite the database.