### PR TITLE
Skipping CAB extract test in GitHub Actions

### DIFF
--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -146,8 +146,9 @@ class TestExtractFileCab(TestExtractorBase):
     def setup_method(self):
         download_file(VMWARE_CAB, os.path.join(self.tempdir, "test.cab"))
 
-    @unittest.skipUnless(
-        os.getenv("ACTIONS") != "1", "Skipping tests that cannot pass in github actions"
+    @pytest.mark.skipif(
+        os.getenv("ACTIONS") == "1",
+        reason="Skipping tests that cannot pass in github actions",
     )
     @pytest.mark.asyncio
     async def test_extract_file_cab(self):


### PR DESCRIPTION
Per #936, I'm disabling the CAB extraction test in github actions, because there seems to be a problem with fetching the URL.