### PR TITLE
Move indexing back to init for performance

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -305,8 +305,10 @@ class CVEDB:
             FOREIGN KEY(cve_number) REFERENCES cve_severity(cve_number)
         )
         """
+        index_range = "CREATE INDEX IF NOT EXISTS product_index ON cve_range (cve_number, vendor, product)"
         cursor.execute(cve_data_create)
         cursor.execute(version_range_create)
+        cursor.execute(index_range)
 
         # Check that latest schema is being used
         if not self.latest_schema(cursor):
@@ -443,10 +445,6 @@ class CVEDB:
 
         # supplemental data gets added here
         self.supplement_curl()
-
-        # create index
-        index_range = "CREATE INDEX IF NOT EXISTS product_index ON cve_range (vendor, product, version)"
-        cursor.execute(index_range)
 
         self.db_close()
 


### PR DESCRIPTION
The builds have been timing out since #902 was merged.  I susect the problem is that the indexing as moved to happen after the database was populated, so this moves it back to where it was before (created immediately after the tables are created).