### PR TITLE
Updated URL to issue page

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ fork of 7zip. We are currently using `7z` for extracting `jar`, `apk`, `msi`, `e
 ## Feedback & Contributions
 
 Bugs and feature requests can be made via [GitHub
-issues](https://github.com/intel/cve-bin-tool).  Be aware that these issues are
+issues](https://github.com/intel/cve-bin-tool/issues).  Be aware that these issues are
 not private, so take care when providing output to make sure you are not
 disclosing security issues in other products.
 


### PR DESCRIPTION
The URL should go to the issue page instead of the main page.