### PR TITLE
Small doc fixes in prepration for 2.0

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1,5 +1,3 @@
-## Table of Contents
-
 - [CVE Binary Tool User Manual](#cve-binary-tool-user-manual)
   - [How it works](#how-it-works)
   - [Installing](#installing)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,7 +22,7 @@ copyright = "2020, Terri Oda"
 author = "Terri Oda"
 
 # The full version, including alpha/beta/rc tags
-release = "1.1"
+release = "2.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/doc/how_to_guides/customize_html_report.md
+++ b/doc/how_to_guides/customize_html_report.md
@@ -1,5 +1,5 @@
 
-# How to create a custom theme for the HTML Report?
+# How do I create a custom theme for the HTML Report?
 
 CVE Binary Tool provides HTML Report as an output type and although the Report design will work for most of the users it might be the case that we want to update the Report Design according to our needs. So in this tutorial, we will be discussing on how to customise the HTML Report.
 

--- a/doc/how_to_guides/index.rst
+++ b/doc/how_to_guides/index.rst
@@ -12,3 +12,4 @@ How To Guides
 
    customize_html_report
    scan_docker_image
+   offline

--- a/doc/how_to_guides/offline.md
+++ b/doc/how_to_guides/offline.md
@@ -1,4 +1,5 @@
-# Use in an offline environment
+# How do I use CVE Binary Tool in an offline environment?
+
 The cve-bin-tool can be used in offline environments which do not have direct access to the internet to download the latest vulnerability databases.
 
 ## Prepare the vulnerability database for offline use

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,13 +19,6 @@ The CVE Binary Tool helps you determine if your system includes known vulnerabil
    RELEASE.md
    CONTRIBUTORS.md
 
-   1.0/index
-   0.3.1/index
-   0.3.0/index
-   0.2.0/index
-   
-
-
 Indices and tables
 ==================
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 recommonmark==0.6.0
 Sphinx==3.2.1
+sphinx_markdown_tables


### PR DESCRIPTION
* Improved titles in how to documents
* linked offline how to
* removed links to older documentation (the old docs remain in tree, but won't be picked up by readthedocs unless I push tags for them)