### PR TITLE
Fixed Table in --input-file section on readthedocs

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -252,6 +252,7 @@ Note that `--input-file`, unlike `cve-bin-tool directory` scan, will work on *an
 > Note: For backward compatibility, we still support `csv2cve` command for producing CVEs from csv but we recommend using new `--input-file` command instead.
 
 For Example if input_file contains following data:
+
 | vendor        | product       | version  | remarks   | comments                              | cve_number     | severity |
 | ------------- | ------------- | -------- | --------- | ------------------------------------- | -------------- | -------- |
 | libjpeg-turbo | libjpeg-turbo | 2.0.1    | 3         | High priority need to resolve fast    | CVE-2018-19664 | CRITICAL |


### PR DESCRIPTION
The problem was the Table was getting merged with the `<p>` tag in the above line. I added a simple space between them.