### PR TITLE
Specify black version in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 -   repo: https://github.com/python/black
-    rev: stable
+    rev: 20.8b1
     hooks:
     - id: black


### PR DESCRIPTION
This isn't a perfect solution to #909, because I think I should probably change the github action to match, but it *should* resolve issues for folk using the pre-commit hook and getting conflicts with what's in Github Actions for now.