### PR TITLE
Include config file examples, fix linter issues

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1,36 +1,38 @@
+# CVE Binary Tool User Manual
+
 - [CVE Binary Tool User Manual](#cve-binary-tool-user-manual)
   - [How it works](#how-it-works)
   - [Installing](#installing)
   - [Fixing Known Issues / What should I do if it finds something?](#fixing-known-issues--what-should-i-do-if-it-finds-something)
   - [Limitations](#limitations)
-  - [Optional Arguments:](#optional-arguments)
+  - [Optional Arguments](#optional-arguments)
     - [-u {now,daily,never}, --update {now,daily,never}](#-u-nowdailynever---update-nowdailynever)
     - [-e EXCLUDE, --exclude EXCLUDE](#-e-exclude---exclude-exclude)
     - [-h, --help](#-h---help)
-    - [-V, --version ](#-V---version)
+    - [-V, --version](#-v---version)
     - [--disable-version-check](#--disable-version-check)
-  - [Checkers Arguments:](#checkers-arguments)
+  - [Checkers Arguments](#checkers-arguments)
     - [-s SKIPS, --skips SKIPS](#-s-skips---skips-skips)
     - [-r CHECKERS, --runs CHECKERS](#-r-checkers---runs-checkers)
-  - [Input Arguments:](#input-arguments)
+  - [Input Arguments](#input-arguments)
     - [directory (positional argument)](#directory-positional-argument)
     - [-i INPUT_FILE, --input-file INPUT_FILE](#-i-input_file---input-file-input_file)
     - [-C CONFIG, --config CONFIG](#-c-config---config-config)
-  - [Output Arguments:](#output-arguments)
+      - [Yaml example file](#yaml-example-file)
+      - [Toml example file](#toml-example-file)
+  - [Output Arguments](#output-arguments)
     - [-o OUTPUT_FILE, --output-file OUTPUT_FILE](#-o-output_file---output-file-output_file)
     - [--html-theme HTML_THEME](#--html-theme-html_theme)
     - [-f {csv,json,console,html}, --format {csv,json,console,html}](#-f-csvjsonconsolehtml---format-csvjsonconsolehtml)
     - [-c CVSS, --cvss CVSS](#-c-cvss---cvss-cvss)
-    - [-S {low,medium,high,critical}, --severity {low,medium,high,critical}](#S-lowmediumhighcritical---severity-lowmediumhighcritical)
+    - [-S {low,medium,high,critical}, --severity {low,medium,high,critical}](#-s-lowmediumhighcritical---severity-lowmediumhighcritical)
     - [Output verbosity](#output-verbosity)
       - [Quiet Mode](#quiet-mode)
       - [Logging modes](#logging-modes)
-  - [Deprecated Arguments:](#deprecated-arguments)
+  - [Deprecated Arguments](#deprecated-arguments)
     - [-x, --extract](#-x---extract)
   - [Feedback & Contributions](#feedback--contributions)
   - [Security Issues](#security-issues)
-
-# CVE Binary Tool User Manual
 
 The CVE Binary Tool scans for a number of common, vulnerable open source
 components like openssl, libpng, libxml2, expat etc. to let you know
@@ -137,20 +139,20 @@ pip install -U git+https://github.com/intel/cve-bin-tool
 CVE Binary Tool relies on a few command line utilities which are usually present
 on GNU/Linux systems but you may need to install.
 
--   `file`
--   `strings`
--   `tar`
--   `unzip`
--   `rpm2cpio`
--   `cpio`
--   `ar`
--   `cabextract`
+- `file`
+- `strings`
+- `tar`
+- `unzip`
+- `rpm2cpio`
+- `cpio`
+- `ar`
+- `cabextract`
 
 On Windows, it requires
 
--   `ar`
--   `7z`
--   `Expand`
+- `ar`
+- `7z`
+- `Expand`
 
 Windows has `ar` and `Expand` installed in default, but `7z` in particular might need to be installed.
 If you wan to run our test-suite or scan a zstd compressed file, We recommend installing this [7-zip-zstd](https://github.com/mcmilk/7-Zip-zstd)
@@ -186,8 +188,7 @@ access to a known list of product names and versions, we do have an option `--in
 that can be used to look up known vulnerabilities given a CSV or JSON file.
 See the detailed description of [`--input-file`](#-i-input_file---input-file-input_file) for more details.
 
-## Optional Arguments:
-
+## Optional Arguments
 
 ### -u {now,daily,never}, --update {now,daily,never}
 
@@ -209,7 +210,7 @@ This option shows program's version number and exits.
 
 This option skips checking for a new version of the program.
 
-## Checkers Arguments:
+## Checkers Arguments
 
 ### -s SKIPS, --skips SKIPS
 
@@ -219,7 +220,7 @@ This option allows one to skip (disable) a comma-separated list of checkers.  Th
 
 This option allows one to enable a comma-separated list of checkers.
 
-## Input Arguments:
+## Input Arguments
 
 ### directory (positional argument)
 
@@ -231,19 +232,19 @@ This option extends functionality of *csv2cve* for other formats like JSON and a
 
 You can provide either CSV or JSON file as input_file with vendor, product and version fields. You can also add optional fields like remarks, comments, cve_number, severity. Here's the detailed description and usecase of each fields:
 
-1.  **vendor, product, version** - To query locally stored CVE database and give you a list of CVEs that affect each vendor, product, version listed.
-2.  **remarks** - remarks help you categorized different CVEs into different categories like:
-    -   NewFound (1, n, N)
-    -   Unexplored (2, u, U)
-    -   Confirmed (3, c, C)
-    -   Mitigated, (4, m, M)
-    -   Ignored (5, i, I)
+1. **vendor, product, version** - To query locally stored CVE database and give you a list of CVEs that affect each vendor, product, version listed.
+2. **remarks** - remarks help you categorized different CVEs into different categories like:
+    - NewFound (1, n, N)
+    - Unexplored (2, u, U)
+    - Confirmed (3, c, C)
+    - Mitigated, (4, m, M)
+    - Ignored (5, i, I)
 
--   All the characters denoted in parenthesis are aliases for that specific value. Output will be displayed in the same order as priority given to the remarks.
+- All the characters denoted in parenthesis are aliases for that specific value. Output will be displayed in the same order as priority given to the remarks.
 
-3.  **comments** - You can write any comments you want to write in this field. This will be ignored in the console output but will be propagated as it is in CSV, JSON or HTML formats.
-4.  **severity** - This field allows you to adjust severity score of specific product or CVE. This can be useful in the case where CVE affects a portion of  the library that you aren't using currently but you don't want to ignore it completely. In that case, you can reduce severity for this CVE.
-5.  **cve_number** - This field give you fine grained control over output of specific CVE. You can change remarks, comments and severity for specific CVE instead of whole product.
+3. **comments** - You can write any comments you want to write in this field. This will be ignored in the console output but will be propagated as it is in CSV, JSON or HTML formats.
+4. **severity** - This field allows you to adjust severity score of specific product or CVE. This can be useful in the case where CVE affects a portion of  the library that you aren't using currently but you don't want to ignore it completely. In that case, you can reduce severity for this CVE.
+5. **cve_number** - This field give you fine grained control over output of specific CVE. You can change remarks, comments and severity for specific CVE instead of whole product.
 
 You can use `-i` or `--input-file` option to produce list of CVEs found in given vendor, product and version fields (Usage: `cve-bin-tool -i=test.csv`) or supplement extra triage data like remarks, comments etc. while scanning directory so that output will reflect this triage data and you can save time of re-triaging (Usage: `cve-bin-tool -i=test.csv /path/to/scan`).
 
@@ -265,9 +266,11 @@ For Example if input_file contains following data:
 | ssh           | ssh2          | 2.0      | Mitigated |                                       |                |          |
 
 You can test it using our [test input file](https://github.com/intel/cve-bin-tool/blob/master/test/json/test_triage.json) with following command:
+
 ```console
 cve-bin-tool -i="test/json/test_triage.json"
 ```
+
 The output will look like following:
 
     ╔══════════════════════════════════════════════════════════════════════════════╗
@@ -319,6 +322,7 @@ The output will look like following:
 ### -C CONFIG, --config CONFIG
 
 We currently have number of command line options and we understand that it won't be feasible to type all the option everytime you want to run a scan. You can use `--config` option to provide configuration file for the tool. You can still override options specified in config file with command line arguments. We support 2 most popular config file format:
+
 1. TOML which is popular amongst Python developer and very similar to INI file. If you are not familiar with TOML checkout official [TOML documentation](https://toml.io/en/)
 2. YAML which is popular amongst devops community and since many of our users are devops. We also support YAML as config file format. You can find out more about YAML at [yaml.org](https://yaml.org/)
 
@@ -326,7 +330,113 @@ You can see our sample TOML config file [here](https://github.com/intel/cve-bin-
 
 > You have to specify either a directory to scan and/or an input file containing vendor, product and version fields either in JSON or CSV format.
 
-## Output Arguments:
+
+#### Yaml example file
+
+```yaml
+input:
+  # Directory to scan
+  directory: test/assets
+  # To supplement triage data of previous scan or run standalone as csv2cve
+  # Currently we only support csv and json file.
+  input_file: test/csv/triage.csv
+
+checker:
+  # list of checkers you want to skip
+  skips:
+    - python
+    - bzip2
+  # list of checkers you want to run
+  runs:
+    - curl
+    - binutils
+
+output:
+  # specify output verbosity from [debug, info, warning, error, critical]
+  # verbosity will decreases as you go left to right (default: info)
+  log_level: debug
+  # if true then we don't display any output and
+  # only exit-code with number of cves get returned
+  # overwrites setting specified in log_level
+  # Note: it's lowercase true or false
+  quiet: false
+  # specify one of an output format: [csv, json, html, console] (default: console)
+  format: console
+  # provide output filename (optional)
+  # if not specified we will generate one according to output format specified
+  output_file: ''
+  # specify minimum CVE severity level to report from [low, medium, high, critical] (default: low)
+  severity: low
+  # specify minimum CVSS score to report from integer range 0 to 10 (default: 0)
+  cvss: 0
+other:
+  # set true if you want to skip checking for newer version
+  disable_version_check: false
+  # update schedule for NVD database (default: daily)
+  update: daily
+  # set true if you want to autoextract archive files. (default: true)
+  extract: true
+```
+
+#### Toml example file
+
+```toml
+[input]
+
+# Directory to scan
+directory = "test/assets"
+
+# To supplement triage data of previous scan or run standalone as csv2cve
+# Currently we only support csv and json file.
+input_file = "test/csv/triage.csv"
+
+[checker]
+
+# list of checkers you want to skip
+skips = ["python", "bzip2"]
+
+# list of checkers you want to run
+runs = ["curl", "binutils"]
+
+[output]
+
+# specify output verbosity from ["debug", "info", "warning", "error", "critical"]
+# verbosity will decreases as you go left to right (default: "info")
+log_level = "debug"
+
+# if true then we don't display any output and
+# only exit-code with number of cves get returned
+# overwrites setting specified in log_level
+# Note: it's lowercase true or false
+quiet = false
+
+# specify one of an output format: ["csv", "json", "html", "console"] (default: "console")
+format = "console"
+
+# provide output filename (optional)
+# if not specified we will generate one according to output format specified
+output_file = ""
+
+# specify minimum CVE severity level to report from ["low", "medium", "high", "critical"] (default: "low")
+severity = "low"
+
+# specify minimum CVSS score to report from integer range 0 to 10 (default: 0)
+cvss = 0
+
+[other]
+# set true if you want to skip checking for newer version
+disable_version_check = false
+
+# update schedule for NVD database (default: daily)
+update = "daily"
+
+# set true if you want to autoextract archive files. (default: true)
+extract = true
+```
+
+
+
+## Output Arguments
 
 Although the examples in this section show results for a single library to make them shorter and easier to read, the tool was designed to be run on entire directories and will scan all files in a directory if one is supplied.
 
@@ -342,7 +452,7 @@ This option specifies the theme directory to be used in formatting the HTML repo
 
 This option allows the CVE Binary Tool to produce a report in an alternate format. This is useful if you have other tools which only take a specific format. The default is `console` which prints category wise beautiful tables of CVEs on terminal.
 
-1.  `--format csv` - write output file in csv (comma separated) format.
+1. `--format csv` - write output file in csv (comma separated) format.
 
 ```csv
 vendor,product,version,cve_number,severity,remarks,comments
@@ -351,7 +461,7 @@ haxx,curl,7.34.0,CVE-2014-0138,MEDIUM,NewFound,
 haxx,curl,7.34.0,CVE-2014-0139,MEDIUM,Unexplored,
 ```
 
-2.  `--format json` - write output file in json (javascript object notation) format.
+2. `--format json` - write output file in json (javascript object notation) format.
 
 ```json
 [
@@ -376,14 +486,15 @@ haxx,curl,7.34.0,CVE-2014-0139,MEDIUM,Unexplored,
 ]
 ```
 
-3.  `--format console` - prints in nice colored tabular format.
+3. `--format console` - prints in nice colored tabular format.
+
 <figure>
   <img src="https://i.imgur.com/UwH6vA7.png"
     alt="
     cve-bin-tool: Report Generated: 2020-07-31  17:49:56
     1. NewFound CVEs:
     Vendor, Product, Version, CVE Number   , Severity
-    haxx  , curl   , 7.34.0 , CVE-2014-0138, HIGH      
+    haxx  , curl   , 7.34.0 , CVE-2014-0138, HIGH
     haxx  , curl   , 7.34.0 , CVE-2014-0139, CRITICAL
     haxx  , curl   , 7.34.0 , CVE-2014-0015, MEDIUM
     "
@@ -391,8 +502,7 @@ haxx,curl,7.34.0,CVE-2014-0139,MEDIUM,Unexplored,
   <figcaption>formated console output</figcaption>
 </figure>
 
-
-4.  `--format html` - creates a report in html format according to the specified HTML theme.
+4. `--format html` - creates a report in html format according to the specified HTML theme.
 
 ### -c CVSS, --cvss CVSS
 
@@ -402,14 +512,14 @@ This option specifies the minimum CVSS score (as integer in range 0 to 10) of th
 
 This option specifies the minimum CVE severity to report. The default value is low which results in all CVEs being reported.
 
-Note that this option is overridden by `--cvss` parameter if this is also specified.
+Note that this option is overridden by `--cvss` parameter if this is also specified. 
 
 ### Output verbosity
 
 As well as the modes above, there are two other output options to decrease or increase the number of messages printed:
 
-1.  **Quiet mode (-q)** suppresses all output but exits with an error number indicating the number of files with known CVEs.  This is intended for continuous integration and headless tests, while the other modes are all more human-friendly.
-2.  **Log mode (-l log_level)** prints logs of the specified log_level and above. The default log level is info. The logs can be suppressed by using quiet mode.
+1. **Quiet mode (-q)** suppresses all output but exits with an error number indicating the number of files with known CVEs.  This is intended for continuous integration and headless tests, while the other modes are all more human-friendly.
+2. **Log mode (-l log_level)** prints logs of the specified log_level and above. The default log level is info. The logs can be suppressed by using quiet mode.
 
 #### Quiet Mode
 
@@ -431,7 +541,7 @@ indicates that CVEs may be present in the code.  A good result here is 0.
 
 The logging modes provide additional fine-grained control for debug information.
 
-## Deprecated Arguments:
+## Deprecated Arguments
 
 ### -x, --extract
 


### PR DESCRIPTION
This is meant to partially address #957 by pulling the configuration examples (which are reasonably self-documenting through comments) into the MANUAL.md file.  I think we could probably do more, but this should be sufficient for the 2.0 release.