### PR TITLE
Renamed master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CVE Binary Tool quick start / README
 
-[![Build Status](https://github.com/intel/cve-bin-tool/workflows/cve-bin-tool/badge.svg?branch=master&event=push)](https://github.com/intel/cve-bin-tool/actions)
-[![codecov](https://codecov.io/gh/intel/cve-bin-tool/branch/master/graph/badge.svg)](https://codecov.io/gh/intel/cve-bin-tool)
+[![Build Status](https://github.com/intel/cve-bin-tool/workflows/cve-bin-tool/badge.svg?branch=main&event=push)](https://github.com/intel/cve-bin-tool/actions)
+[![codecov](https://codecov.io/gh/intel/cve-bin-tool/branch/main/graph/badge.svg)](https://codecov.io/gh/intel/cve-bin-tool)
 [![Gitter](https://badges.gitter.im/cve-bin-tool/community.svg)](https://gitter.im/cve-bin-tool/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![On PyPI](https://img.shields.io/pypi/v/cve-bin-tool)](https://pypi.org/project/cve-bin-tool/)
@@ -70,17 +70,17 @@ Note that you can use `-i` or `--input-file` option to produce list of CVEs foun
 > Note: For backward compatibility, we still support `csv2cve` command for producing CVEs from csv but we recommend using new `--input-file` command instead.
 
 You can use `--config` option to provide configuration file for the tool. You can still override options specified in config file with command line arguments. See our sample config files in the 
-[test/config](https://github.com/intel/cve-bin-tool/blob/master/test/config/)
+[test/config](https://github.com/intel/cve-bin-tool/blob/main/test/config/)
 
 The 0.3.1 release is intended to be the last release to officially support
 python 2.7; please switch to python 3.6+ for future releases and to use the
-development tree. You can check [our CI configuration](https://github.com/intel/cve-bin-tool/blob/master/.github/workflows/pythonapp.yml) to see what versions of python we're explicitly testing.
+development tree. You can check [our CI configuration](https://github.com/intel/cve-bin-tool/blob/main/.github/workflows/pythonapp.yml) to see what versions of python we're explicitly testing.
 
 If you want to integrate cve-bin-tool as a part of your github action pipeline. 
-You can checkout our example [github action](https://github.com/intel/cve-bin-tool/blob/master/doc/how_to_guides/cve_scanner_gh_action.yml). 
+You can checkout our example [github action](https://github.com/intel/cve-bin-tool/blob/main/doc/how_to_guides/cve_scanner_gh_action.yml). 
 
 This readme is intended to be a quickstart guide for using the tool.  If you
-require more information, there is also a [user manual](https://github.com/intel/cve-bin-tool/blob/master/doc/MANUAL.md) available.
+require more information, there is also a [user manual](https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md) available.
 
 ## How it works
 

--- a/doc/CONTRIBUTORS.md
+++ b/doc/CONTRIBUTORS.md
@@ -88,7 +88,7 @@ pip install -r requirements.txt
 
 The CVE Binary Tool has a set of tests that can be run using `pytest` command.  Usually all the short tests should pass, although sometimes internet connectivity issues will cause problems.
 
-[There is a README file in the tests directory](https://github.com/intel/cve-bin-tool/blob/master/test/README.md) which contains more info about how to run just specific tests, or how to run the longer tests which involve downloading full software packages to test the tool. The long tests sometimes fail due to package name changes, which may not be your fault unless you modified one of them.
+[There is a README file in the tests directory](https://github.com/intel/cve-bin-tool/blob/main/test/README.md) which contains more info about how to run just specific tests, or how to run the longer tests which involve downloading full software packages to test the tool. The long tests sometimes fail due to package name changes, which may not be your fault unless you modified one of them.
 
 ## Running Black
 
@@ -128,10 +128,10 @@ pre-commit install
 
 Git allows you to have "branches" with variant versions of the code.  You can see what's available using `git branch` and switch to one using `git checkout branch_name`.
 
-To make your life easier, we recommend that the `master` branch always be kept in sync with the repo at `https://github.com/intel/cve-bin-tool`, as in you never check in any code to that branch.  That way, you can use that "clean" master branch as a basis for each new branch you start as follows:
+To make your life easier, we recommend that the `main` branch always be kept in sync with the repo at `https://github.com/intel/cve-bin-tool`, as in you never check in any code to that branch.  That way, you can use that "clean" main branch as a basis for each new branch you start as follows:
 
 ```bash
-git checkout master
+git checkout main
 git pull
 git checkout -b my_new_branch
 ```

--- a/doc/CSV2CVE.md
+++ b/doc/CSV2CVE.md
@@ -4,7 +4,7 @@ This tool takes a comma-delimited file (.csv) with the format `vendor,product,ve
 
 This is meant as a helper tool for folk who know the list of product being used in their software, so that you don't have to rely on binary detection heuristics.  There exist other tools that do this, but it seemed potentially useful to provide both in the same suite of tools, and it also saves users from having to download two copies of the same data.
 
-At the moment, you must use the exact vendor and product strings used in the National Vulnerability Database.  You can read more on how to find the correct string in [the checker documentation](https://github.com/intel/cve-bin-tool/blob/master/cve_bin_tool/checkers/README.md).  Future work could extend this to use the mappings already in the CVE Binary Tool or to use other mappings such as common linux package names for a given distribution.  (Contributions welcome!)
+At the moment, you must use the exact vendor and product strings used in the National Vulnerability Database.  You can read more on how to find the correct string in [the checker documentation](https://github.com/intel/cve-bin-tool/blob/main/cve_bin_tool/checkers/README.md).  Future work could extend this to use the mappings already in the CVE Binary Tool or to use other mappings such as common linux package names for a given distribution.  (Contributions welcome!)
 
 > Note: For backward compatibility, we still support `csv2cve` command for producing CVEs from csv but we recommend using new `--input-file` command instead.
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -106,7 +106,7 @@ As such, it cannot tell if someone has backported fixes to an otherwise
 vulnerable version, it merely provides a mapping between strings, versions, and
 known CVEs.
 
-A [list of currently available checkers](https://github.com/intel/cve-bin-tool/tree/master/cve_bin_tool/checkers)
+A [list of currently available checkers](https://github.com/intel/cve-bin-tool/tree/main/cve_bin_tool/checkers)
 can be found in the checkers directory or using `cve-bin-tool --help` command, as can the
 [instructions on how to add a new checker](cve_bin_tool/checkers/README.md).
 Support for new checkers can be requested via
@@ -181,7 +181,7 @@ supported, as is usage within cygwin on windows.
 This tool does not scan for all possible known public vulnerabilities, it only
 scans for specific commonly vulnerable open source components.   A complete
 list of currently supported library checkers can be found in [the checkers
-directory](https://github.com/intel/cve-bin-tool/tree/master/cve_bin_tool/checkers).
+directory](https://github.com/intel/cve-bin-tool/tree/main/cve_bin_tool/checkers).
 
 As the name implies, this tool is intended for use with binaries. If you have
 access to a known list of product names and versions, we do have an option `--input-file`
@@ -265,7 +265,7 @@ For Example if input_file contains following data:
 | sun           | sunos         | 5.4      | 4         |                                       |                |          |
 | ssh           | ssh2          | 2.0      | Mitigated |                                       |                |          |
 
-You can test it using our [test input file](https://github.com/intel/cve-bin-tool/blob/master/test/json/test_triage.json) with following command:
+You can test it using our [test input file](https://github.com/intel/cve-bin-tool/blob/main/test/json/test_triage.json) with following command:
 
 ```console
 cve-bin-tool -i="test/json/test_triage.json"
@@ -326,7 +326,7 @@ We currently have number of command line options and we understand that it won't
 1. TOML which is popular amongst Python developer and very similar to INI file. If you are not familiar with TOML checkout official [TOML documentation](https://toml.io/en/)
 2. YAML which is popular amongst devops community and since many of our users are devops. We also support YAML as config file format. You can find out more about YAML at [yaml.org](https://yaml.org/)
 
-You can see our sample TOML config file [here](https://github.com/intel/cve-bin-tool/blob/master/test/config/cve_bin_tool_config.toml) and sample YAML config file [here](https://github.com/intel/cve-bin-tool/blob/master/test/config/cve_bin_tool_config.yaml).
+You can see our sample TOML config file [here](https://github.com/intel/cve-bin-tool/blob/main/test/config/cve_bin_tool_config.toml) and sample YAML config file [here](https://github.com/intel/cve-bin-tool/blob/main/test/config/cve_bin_tool_config.yaml).
 
 > You have to specify either a directory to scan and/or an input file containing vendor, product and version fields either in JSON or CSV format.
 


### PR DESCRIPTION
hey, @terriko I have renamed `master` to `main` in the doc/*.md files as mentioned in #979
Since, I have renamed it to `main` from `master`, many links won't be working until we have changed the branch name from `master` to `main`
If I have missed a few files then please let me know.