### PR TITLE
Revert "Enable jinja2 autoescape"

### DIFF
--- a/cve_bin_tool/output_engine/html.py
+++ b/cve_bin_tool/output_engine/html.py
@@ -64,10 +64,7 @@ def output_html(
 
     # Template Directory contains all the html files
     templates_dir = os.path.join(root, "html_reports")
-    templates_env = Environment(
-        loader=FileSystemLoader([theme_dir, templates_dir]),
-        autoescape=select_autoescape(["html"]),
-    )
+    templates_env = Environment(loader=FileSystemLoader([theme_dir, templates_dir]))
 
     temp_base = "templates/base.html"
     temp_dash = "templates/dashboard.html"

--- a/cve_bin_tool/output_engine/print_mode.py
+++ b/cve_bin_tool/output_engine/print_mode.py
@@ -17,10 +17,7 @@ def html_print_mode(
 
     root = os.path.dirname(os.path.abspath(__file__))
     templates_dir = os.path.join(root, "print_mode")
-    templates_env = Environment(
-        loader=FileSystemLoader(templates_dir),
-        autoescape=select_autoescape(["html"]),
-    )
+    templates_env = Environment(loader=FileSystemLoader(templates_dir))
 
     temp_showcase = "templates/showcase.html"
     temp_content = "templates/content.html"


### PR DESCRIPTION
Reverts intel/cve-bin-tool#967

This causes issues in report generation, so we're reverting the change for now and can re-evaluate if this is worth using in the future.

Fixes #988 