### PR TITLE
Updated Samba checker test URL

### DIFF
--- a/test/test_data/samba.py
+++ b/test/test_data/samba.py
@@ -10,7 +10,7 @@ package_test_data = [
     },
     {
         "url": "http://www.rpmfind.net/linux/fedora/linux/development/rawhide/Everything/aarch64/os/Packages/s/",
-        "package_name": "samba-4.13.3-0.fc34.aarch64.rpm",
+        "package_name": "samba-4.13.3-1.fc34.aarch64.rpm",
         "product": "samba",
         "version": "4.13.3",
     },


### PR DESCRIPTION
As there is a change in the test URL. The test is failing.