### PR TITLE
mysql version pattern bug

### DIFF
--- a/cve_bin_tool/checkers/mysql.py
+++ b/cve_bin_tool/checkers/mysql.py
@@ -28,3 +28,12 @@ class MysqlChecker(Checker):
     ]
     VERSION_PATTERNS = [r"mysql\-([0-9]+\.[0-9]+\-[0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("oracle", "mysql"), ("mysql", "mysql")]
+
+    def get_version(self, lines, filename):
+        """Mysql binaries contain version 8.0.20 as 8.0-8.0.20"""
+
+        version_info = super().get_version(lines, filename)
+        if version_info["version"] != "UNKNOWN":
+            version_info["version"] = ".".join(version_info["version"].split(".")[2:])
+
+        return version_info

--- a/cve_bin_tool/checkers/mysql.py
+++ b/cve_bin_tool/checkers/mysql.py
@@ -26,14 +26,5 @@ class MysqlChecker(Checker):
         r"mysql-bench",
         r"dovecot-mysql",
     ]
-    VERSION_PATTERNS = [r"mysql\-([0-9]+\.[0-9]+\-[0-9]+\.[0-9]+\.[0-9]+)"]
+    VERSION_PATTERNS = [r"mysql\-[0-9]+\.[0-9]+\-([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("oracle", "mysql"), ("mysql", "mysql")]
-
-    def get_version(self, lines, filename):
-        """Mysql binaries contain version 8.0.20 as 8.0-8.0.20"""
-
-        version_info = super().get_version(lines, filename)
-        if "is_or_contains" in version_info and version_info["version"] != "UNKNOWN":
-            version_info["version"] = ".".join(version_info["version"].split(".")[2:])
-
-        return version_info

--- a/cve_bin_tool/checkers/mysql.py
+++ b/cve_bin_tool/checkers/mysql.py
@@ -33,7 +33,7 @@ class MysqlChecker(Checker):
         """Mysql binaries contain version 8.0.20 as 8.0-8.0.20"""
 
         version_info = super().get_version(lines, filename)
-        if version_info["version"] != "UNKNOWN":
+        if "is_or_contains" in version_info and version_info["version"] != "UNKNOWN":
             version_info["version"] = ".".join(version_info["version"].split(".")[2:])
 
         return version_info

--- a/test/test_data/mysql.py
+++ b/test/test_data/mysql.py
@@ -1,7 +1,7 @@
 mapping_test_data = [
     {
         "product": "mysql",
-        "version": "8.0.8.0.20",
+        "version": "8.0.20",
         "version_strings": [
             r"mysql-8.0-8.0.20",
             r"To buy MySQL Enterprise support, training, or other products, visit:",
@@ -13,6 +13,6 @@ package_test_data = [
         "url": "http://ports.ubuntu.com/pool/main/m/mysql-8.0/",
         "package_name": "mysql-client-core-8.0_8.0.19-0ubuntu5_arm64.deb",
         "product": "mysql",
-        "version": "8.0.8.0.19",
+        "version": "8.0.19",
     }
 ]


### PR DESCRIPTION
mysql checker was recognizing version syntax 8.0.20 as 8.0.8.0.20. Currently we are only recognising the pattern 
`mysql\-([0-9]+\.[0-9]+\-[0-9]+\.[0-9]+\.[0-9]+)`
These changes will give us the exact version

This will close #954 