### PR TITLE
Fix relative import in docs

### DIFF
--- a/cve_bin_tool/checkers/README.md
+++ b/cve_bin_tool/checkers/README.md
@@ -12,7 +12,7 @@ checker with `Checker` suffix at the end. Ex: if you are creating a checker for
 `curl` binary then filename of checker should be `curl.py` and class definition
 should be:
 ```python
-from . import Checker
+from cve_bin_tool.checkers import Checker
 
 class CurlChecker(Checker):
 ```


### PR DESCRIPTION
There is only one relative import in the documentation. 
Fixes #1064 