### PR TITLE
Add directory to instructions, update master->main in badges/links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CVE Binary Tool quick start / README
 
-[![Build Status](https://github.com/intel/cve-bin-tool/workflows/cve-bin-tool/badge.svg?branch=master&event=push)](https://github.com/intel/cve-bin-tool/actions)
-[![codecov](https://codecov.io/gh/intel/cve-bin-tool/branch/master/graph/badge.svg)](https://codecov.io/gh/intel/cve-bin-tool)
+[![Build Status](https://github.com/intel/cve-bin-tool/workflows/cve-bin-tool/badge.svg?branch=main&event=push)](https://github.com/intel/cve-bin-tool/actions)
+[![codecov](https://codecov.io/gh/intel/cve-bin-tool/branch/main/graph/badge.svg)](https://codecov.io/gh/intel/cve-bin-tool)
 [![Gitter](https://badges.gitter.im/cve-bin-tool/community.svg)](https://gitter.im/cve-bin-tool/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![On ReadTheDocs](https://readthedocs.org/projects/cve-bin-tool/badge/?version=latest&style=flat)](https://cve-bin-tool.readthedocs.io/en/latest/)
 [![On PyPI](https://img.shields.io/pypi/v/cve-bin-tool)](https://pypi.org/project/cve-bin-tool/)
@@ -73,17 +73,17 @@ Note that you can use `-i` or `--input-file` option to produce list of CVEs foun
 > Note: For backward compatibility, we still support `csv2cve` command for producing CVEs from csv but we recommend using new `--input-file` command instead.
 
 You can use `--config` option to provide configuration file for the tool. You can still override options specified in config file with command line arguments. See our sample config files in the 
-[test/config](https://github.com/intel/cve-bin-tool/blob/master/test/config/)
+[test/config](https://github.com/intel/cve-bin-tool/blob/main/test/config/)
 
 The 0.3.1 release is intended to be the last release to officially support
 python 2.7; please switch to python 3.6+ for future releases and to use the
-development tree. You can check [our CI configuration](https://github.com/intel/cve-bin-tool/blob/master/.github/workflows/pythonapp.yml) to see what versions of python we're explicitly testing.
+development tree. You can check [our CI configuration](https://github.com/intel/cve-bin-tool/blob/main/.github/workflows/pythonapp.yml) to see what versions of python we're explicitly testing.
 
 If you want to integrate cve-bin-tool as a part of your github action pipeline. 
-You can checkout our example [github action](https://github.com/intel/cve-bin-tool/blob/master/doc/how_to_guides/cve_scanner_gh_action.yml). 
+You can checkout our example [github action](https://github.com/intel/cve-bin-tool/blob/main/doc/how_to_guides/cve_scanner_gh_action.yml).
 
 This readme is intended to be a quickstart guide for using the tool.  If you
-require more information, there is also a [user manual](https://github.com/intel/cve-bin-tool/blob/master/doc/MANUAL.md) available.
+require more information, there is also a [user manual](https://cve-bin-tool.readthedocs.io/en/latest/MANUAL.html) available.
 
 ## How it works
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ known vulnerabilities., known as CVEs ([Common Vulnerabilities and Exposures](ht
 
 See our [documentation](https://cve-bin-tool.readthedocs.io/en/latest/) and [quickstart guide](https://cve-bin-tool.readthedocs.io/en/latest/README.html)  
 Usage:
-`cve-bin-tool  `
+`cve-bin-tool <directory/file to scan> `
 
 You can also do `python -m cve_bin_tool.cli` 
 which is useful if you're trying the latest code from 


### PR DESCRIPTION
For some reason, the README file recommends running cve-bin-tool without specifying a directory.   Although this *will* just print the help, I think it's better if people know they have to scan something to get it to work.