### PR TITLE
Added sudo checker

### DIFF
--- a/cve_bin_tool/checkers/README.md
+++ b/cve_bin_tool/checkers/README.md
@@ -120,7 +120,7 @@ as strings in the binary.
 ### Finding FILENAME_PATTERNS
 
 The FILENAME_PATTERNS contains the names of the files in the binary where the above 
-signatures were found. If there are more than one place where the version strngs are
+signatures were found. If there are more than one place where the version strings are
 found, please make sure that you add all the filenames.
 
 

--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -66,6 +66,7 @@ __all__ = [
     "sqlite",
     "strongswan",
     "subversion",
+    "sudo",
     "syslogng",
     "systemd",
     "tcpdump",

--- a/cve_bin_tool/checkers/python.py
+++ b/cve_bin_tool/checkers/python.py
@@ -8,8 +8,8 @@ https://www.cvedetails.com/vulnerability-list/vendor_id-10210/product_id-18230/P
 """
 import re
 
-from cve_bin_tool.util import regex_find
 from cve_bin_tool.checkers import Checker
+from cve_bin_tool.util import regex_find
 
 
 class PythonChecker(Checker):

--- a/cve_bin_tool/checkers/sqlite.py
+++ b/cve_bin_tool/checkers/sqlite.py
@@ -13,9 +13,9 @@ import re
 import urllib.error as error
 import urllib.request as request
 
+from cve_bin_tool.checkers import Checker
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.version_signature import VersionSignatureDb
-from cve_bin_tool.checkers import Checker
 
 
 def get_version_map():

--- a/cve_bin_tool/checkers/sudo.py
+++ b/cve_bin_tool/checkers/sudo.py
@@ -1,0 +1,8 @@
+from cve_bin_tool.checkers import Checker
+
+
+class SudoChecker(Checker):
+    CONTAINS_PATTERNS = []
+    FILENAME_PATTERNS = [r"sudo"]
+    VERSION_PATTERNS = [r"Sudo version %s\n[0-9]\.[0-9]\.[0-9]+[a-z]{0,2}[0-9]{0,2}"]
+    VENDOR_PRODUCT = [("sudo_project", "sudo")]

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -330,9 +330,14 @@ def main(argv=None):
 
         LOGGER.info("")
         LOGGER.info("Overall CVE summary: ")
-        LOGGER.info(
-            f"There are {cve_scanner.products_with_cve} products with known CVEs detected"
-        )
+        if args["input_file"]:
+            LOGGER.info(
+                f"There are {cve_scanner.products_with_cve} products with known CVEs detected"
+            )
+        else:
+            LOGGER.info(
+                f"There are {cve_scanner.products_with_cve} files with known CVEs detected"
+            )
         if cve_scanner.products_with_cve > 0:
             affected_string = ", ".join(
                 map(

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -24,6 +24,7 @@ from cve_bin_tool.async_utils import (
     async_wrap,
     run_coroutine,
 )
+
 from .error_handler import ErrorHandler, ErrorMode, ExtractionFailed, UnknownArchiveType
 from .log import LOGGER
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,14 +6,6 @@ import logging
 import os
 import tempfile
 import unittest
-
-import pytest
-
-from cve_bin_tool.cli import main
-from cve_bin_tool.cvedb import DISK_LOCATION_DEFAULT
-from cve_bin_tool.extractor import Extractor
-from cve_bin_tool.version_scanner import VersionScanner
-
 from test.utils import (
     CURL_7_20_0_RPM,
     CURL_7_20_0_URL,
@@ -23,6 +15,13 @@ from test.utils import (
     TempDirTest,
     download_file,
 )
+
+import pytest
+
+from cve_bin_tool.cli import main
+from cve_bin_tool.cvedb import DISK_LOCATION_DEFAULT
+from cve_bin_tool.extractor import Extractor
+from cve_bin_tool.version_scanner import VersionScanner
 
 
 class TestCLI(TempDirTest):

--- a/test/test_cvedb.py
+++ b/test/test_cvedb.py
@@ -3,13 +3,12 @@ import datetime
 import shutil
 import sys
 import tempfile
+from test.utils import event_loop
 
 import aiohttp
 import pytest
 
 from cve_bin_tool.cvedb import CVEDB
-
-from test.utils import event_loop
 
 
 class TestCVEDB:

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -7,14 +7,13 @@ import tempfile
 import unittest
 import unittest.mock
 from io import BytesIO
+from test.utils import CURL_7_20_0_URL, TMUX_DEB, VMWARE_CAB, download_file, event_loop
 from zipfile import ZipFile, ZipInfo
 
 import pytest
 
 from cve_bin_tool.extractor import Extractor
 from cve_bin_tool.util import inpath
-
-from test.utils import CURL_7_20_0_URL, TMUX_DEB, VMWARE_CAB, download_file, event_loop
 
 # Enable logging if tests are not passing to help you find errors
 # import logging

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -12,14 +12,13 @@ import tarfile
 import tempfile
 import unittest
 import unittest.mock
+from test.test_data import __all__ as all_test_name
+from test.utils import LONG_TESTS, download_file
 
 import pytest
 
 from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.version_scanner import VersionScanner
-
-from test.test_data import __all__ as all_test_name
-from test.utils import LONG_TESTS, download_file
 
 BINARIES_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "binaries")
 # load test data

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -2,13 +2,12 @@
 CVE-bin-tool Strings tests
 """
 import os
+from test.utils import event_loop
 
 import pytest
 
 from cve_bin_tool.async_utils import aio_run_command
 from cve_bin_tool.strings import Strings
-
-from test.utils import event_loop
 
 ASSETS_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets")
 


### PR DESCRIPTION
As mentioned in #1072, a `sudo` checker had been added. Contributing steps mentioned [here](https://cve-bin-tool.readthedocs.io/en/latest/CONTRIBUTORS.html) have been followed and tests mentioned [here](https://github.com/intel/cve-bin-tool/blob/main/cve_bin_tool/checkers/README.md#running-tests) have been done :)

Do let me know if any changes are needed, I shall make them as soon as possible!

@terriko: `sudo` _does_ indeed have version strings in its binary!