### PR TITLE
Raise error when we get a 403 during nvd download

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -131,6 +131,8 @@ class CVEDB:
                 return
         self.LOGGER.debug(f"Updating CVE cache for {filename}")
         async with session.get(url) as response:
+            # raise error if we get a 403 or other error code
+            response.raise_for_status()
             gzip_data = await response.read()
             json_data = gzip.decompress(gzip_data)
             gotsha = hashlib.sha256(json_data).hexdigest().upper()


### PR DESCRIPTION
This PR makes sure we raise errors appropriately if the gzipfile download returns a 403 error.  This won't help with #1081 because it doesn't attempt the download again, but at least we'll get a clearer message and won't try to ungzip files that aren't gzipped.