### PR TITLE
Add rate limiting to address #1081

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -38,6 +38,7 @@ OLD_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
 # Workaround for issue #1081
 RATE_LIMITER = asyncio.BoundedSemaphore(2)
 
+
 class CVEDB:
     """
     Downloads NVD data in json form and stores it on disk in a cache.

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -35,7 +35,8 @@ logging.basicConfig(level=logging.DEBUG)
 DISK_LOCATION_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "cve-bin-tool")
 DBNAME = "cve.db"
 OLD_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
-
+# Workaround for issue #1081
+RATE_LIMITER = asyncio.BoundedSemaphore(2)
 
 class CVEDB:
     """
@@ -130,12 +131,13 @@ class CVEDB:
                 self.LOGGER.debug(f"Correct SHA for {filename}")
                 return
         self.LOGGER.debug(f"Updating CVE cache for {filename}")
-        async with session.get(url) as response:
-            gzip_data = await response.read()
-            json_data = gzip.decompress(gzip_data)
-            gotsha = hashlib.sha256(json_data).hexdigest().upper()
-            async with FileIO(filepath, "wb") as filepath_handle:
-                await filepath_handle.write(gzip_data)
+        async with RATE_LIMITER:
+            async with session.get(url) as response:
+                gzip_data = await response.read()
+        json_data = gzip.decompress(gzip_data)
+        gotsha = hashlib.sha256(json_data).hexdigest().upper()
+        async with FileIO(filepath, "wb") as filepath_handle:
+            await filepath_handle.write(gzip_data)
         # Raise error if there was an issue with the sha
         if gotsha != sha:
             # Remove the file if there was an issue


### PR DESCRIPTION
Workaround for issue #1081. 
Limits max concurrent connections for downloading the CVE tarballs to two at a time. 
Moves non-response related code out of the async block to avoid holding a semaphore permit unnecessarily.