### PR TITLE
Fix OpenSSL version conversion

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -91,6 +91,8 @@ class CVEScanner:
                 versionEndExcluding,
             ) = cve_range
 
+            parsed_version = parse_version(product_info.version)
+
             # pep-440 doesn't include versions of the type 1.1.0g used by openssl
             # so if this is openssl, convert the last letter to a .number
             if product_info.product == "openssl":
@@ -100,8 +102,9 @@ class CVEScanner:
                 versionStartExcluding = self.openssl_convert(versionStartExcluding)
                 versionEndIncluding = self.openssl_convert(versionEndIncluding)
                 versionEndExcluding = self.openssl_convert(versionEndExcluding)
-
-            parsed_version = parse_version(product_info.version)
+                parsed_version = parse_version(
+                    self.openssl_convert(product_info.version)
+                )
 
             # check the start range
             passes_start = False
@@ -219,10 +222,14 @@ class CVEScanner:
         if not version:  # if version is empty return it.
             return version
 
-        lastchar = version[-1]
+        last_char = version[-1]
+        second_last_char = version[-2]
 
-        if lastchar in self.ALPHA_TO_NUM:
-            version = f"{version[:-1]}.{self.ALPHA_TO_NUM[lastchar]}"
+        if last_char in self.ALPHA_TO_NUM and second_last_char in self.ALPHA_TO_NUM:
+            version = f"{version[:-2]}.{self.ALPHA_TO_NUM[second_last_char]}.{self.ALPHA_TO_NUM[last_char]}"
+
+        elif last_char in self.ALPHA_TO_NUM:
+            version = f"{version[:-1]}.{self.ALPHA_TO_NUM[last_char]}"
         return version
 
     def affected(self):


### PR DESCRIPTION
Fixes #990 

OpenSSL sometimes has version strings with two trailing letters (eg 0.9.8.zc). Modified `openssl_convert` to handle this. 
Also added this conversion to `parse_version` if product is OpenSSL.

