### PR TITLE
Temporary fix for ssl certificate error

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -20,7 +20,8 @@ CURL_7_20_0_URL = (
 )
 VMWARE_CAB = "https://master.dl.sourceforge.net/project/winpe/VmWare%20Drivers/VmWare%20Drivers%20v1.1/vmware-1.1.cab"
 TMUX_DEB_NAME = "tmux_1.8-5_amd64.deb"
-TMUX_DEB = "https://mirrors.cat.pdx.edu/ubuntu/pool/main/t/tmux/" + TMUX_DEB_NAME
+# TODO: switch back to https when cert is renewed
+TMUX_DEB = "http://mirrors.cat.pdx.edu/ubuntu/pool/main/t/tmux/" + TMUX_DEB_NAME
 
 
 class TempDirTest:


### PR DESCRIPTION
The original URL's SSL certificate isn't functioning properly. (NET::ERR_CERT_DATE_INVALID). 
Temporarily changed it to use HTTP instead of HTTPS.

original URL: https://mirrors.cat.pdx.edu/ubuntu/pool/main/t/tmux/
temp URL: http://mirrors.cat.pdx.edu/ubuntu/pool/main/t/tmux/