### PR TITLE
Switch PDX url to https #1104

### DIFF
--- a/test/utils.py
+++ b/test/utils.py
@@ -23,8 +23,7 @@ CURL_7_20_0_URL = (
 )
 VMWARE_CAB = "https://master.dl.sourceforge.net/project/winpe/VmWare%20Drivers/VmWare%20Drivers%20v1.1/vmware-1.1.cab"
 TMUX_DEB_NAME = "tmux_1.8-5_amd64.deb"
-# TODO: switch back to https when cert is renewed
-TMUX_DEB = "http://mirrors.cat.pdx.edu/ubuntu/pool/main/t/tmux/" + TMUX_DEB_NAME
+TMUX_DEB = "https://mirrors.cat.pdx.edu/ubuntu/pool/main/t/tmux/" + TMUX_DEB_NAME
 
 
 class TempDirTest:


### PR DESCRIPTION
I think its best practice to switch it back to https now that the pdx.edu site's SSL certificate is renewed
![image](https://user-images.githubusercontent.com/62283475/112934620-ce988000-913f-11eb-82a9-4cfa18857eb0.png)
