### PR TITLE
Add color to latest version message

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -34,12 +34,15 @@ def check_latest_version():
                     )
                 )
             else:
-                # TODO In future mark me with some color ( prefer yellow or red )
                 LOGGER.info(
-                    f"You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}."
+                    f"[bold red]You are running version {VERSION} of {name} but the latest PyPI Version is {pypi_version}.[/]",
+                    extra={"markup": True},
                 )
                 if version.parse(VERSION) < version.parse(pypi_version):
-                    LOGGER.info("Alert: We recommend using the latest stable release.")
+                    LOGGER.info(
+                        "[bold yellow]Alert: We recommend using the latest stable release.[/]",
+                        extra={"markup": True},
+                    )
     except Exception as error:
         LOGGER.warning(
             textwrap.dedent(


### PR DESCRIPTION
This completes the  TODO of mark the 'Update to latest stable version' with some colour.
![image](https://user-images.githubusercontent.com/62283475/112935865-410a5f80-9142-11eb-8c52-4f39848ce77a.png)

Please tell me if the colors are not stylistically consistent with the project.