### PR TITLE
Fix long tests in CI

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -138,14 +138,14 @@ jobs:
           key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
       - uses: technote-space/get-diff-action@v4
         with:
-          PREFIX_FILTER: |
-            cve_bin_tool/checkers
-            cve_bin_tool/cvedb
-            test/test_scanner
-            test/test_cli
-            test/test_json
-            test/condensed-downloads
-          SUFFIX_FILTER: .py
+          PATTERNS: |
+            cve_bin_tool/checkers/*.py
+            test/condensed-downloads/*
+          FILES: |
+            cvedb.py
+            test_scanner.py
+            test_cli.py
+            test_json.py
           SET_ENV_NAME_COUNT: LONG_TESTS
       - name: Install dependencies
         run: |


### PR DESCRIPTION
[technote-space/get-diff-action](https://github.com/technote-space/get-diff-action) changed syntax (somewhere between v1 and v4) so when it was updated to v4 in 5944c8ec9489f252841d2bc043ae080877dc71c5 filtering was lost and long tests started to run on every change.
![image](https://user-images.githubusercontent.com/12860284/113921914-50974180-97ef-11eb-9825-48dbc88558b6.png)

This PR updates workflow to use PATTERNS/FILES options instead.