### PR TITLE
Python 2 cleanup

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -45,6 +45,23 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jpetrucciani/black-check@master
 
+  pyupgrade:
+    name: pyupgrade check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+          pre-commit install
+      - name: Run pyupgrade
+        run: |
+          pre-commit run pyupgrade --all-files
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,3 +9,9 @@ repos:
     rev: 20.8b1
     hooks:
     - id: black
+
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v2.19.1
+    hooks:
+    - id: pyupgrade
+      args: ["--py36-plus"]

--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -101,13 +101,13 @@ class CheckerMetaClass(type):
 
     def __new__(cls, name, bases, props):
         # Create the class
-        cls = super(CheckerMetaClass, cls).__new__(cls, name, bases, props)
+        cls = super().__new__(cls, name, bases, props)
         # HACK Skip validation is this class is the base class
         if name == "Checker":
             return cls
         # Validate that we have at least one vendor product pair
         if len(cls.VENDOR_PRODUCT) < 1:
-            raise AssertionError("%s needs at least one vendor product pair" % (name,))
+            raise AssertionError(f"{name} needs at least one vendor product pair")
         # Validate that each vendor product pair is of length 2
         cls.VENDOR_PRODUCT = list(
             map(lambda vpkg: VendorProductPair(*vpkg), cls.VENDOR_PRODUCT)

--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -102,7 +102,7 @@ class CheckerMetaClass(type):
     def __new__(cls, name, bases, props):
         # Create the class
         cls = super().__new__(cls, name, bases, props)
-        # HACK Skip validation is this class is the base class
+        # HACK Skip validation if this class is the base class
         if name == "Checker":
             return cls
         # Validate that we have at least one vendor product pair

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -2,8 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 #!/usr/bin/python3
-# pylint: disable=invalid-name, useless-object-inheritance
-# useless-object-inheritance kept for python2 compatibility
+# pylint: disable=invalid-name
 
 """
 This tool scans for a number of common, vulnerable open source components

--- a/cve_bin_tool/config.py
+++ b/cve_bin_tool/config.py
@@ -30,11 +30,11 @@ class ConfigParser:
             with ErrorHandler(mode=self.error_mode):
                 raise FileNotFoundError(self.filename)
         if self.filename.endswith(".toml"):
-            with open(self.filename, "r") as f:
+            with open(self.filename) as f:
                 raw_config_data = toml.load(f)
                 self.config_data = ChainMap(*raw_config_data.values())
         elif self.filename.endswith(".yaml"):
-            with open(self.filename, "r") as f:
+            with open(self.filename) as f:
                 raw_config_data = yaml.safe_load(f)
                 self.config_data = ChainMap(*raw_config_data.values())
         else:

--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -244,7 +244,7 @@ class CVEScanner:
         """Returns list of product name and version tuples identified from
         scan"""
         return sorted(
-            [(cve_data.product, cve_data.version) for cve_data in self.all_cve_data]
+            (cve_data.product, cve_data.version) for cve_data in self.all_cve_data
         )
 
     def __enter__(self):

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -27,8 +27,8 @@ from cve_bin_tool.error_handler import (
     CVEDataForYearNotInCache,
     ErrorHandler,
     ErrorMode,
-    SHAMismatch,
     NVDRateLimit,
+    SHAMismatch,
 )
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.version import check_latest_version

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -108,10 +108,10 @@ class CVEDB:
             json_meta_links = self.META_REGEX.findall(page)
             return dict(
                 await asyncio.gather(
-                    *[
+                    *(
                         self.getmeta(session, f"{self.META_LINK}{meta_url}")
                         for meta_url in json_meta_links
-                    ]
+                    )
                 )
             )
 
@@ -235,10 +235,10 @@ class CVEDB:
         # each version) have been downloaded
         tasks.append(
             asyncio.gather(
-                *[
+                *(
                     self.download_curl_version(self.session, version)
                     for version in curl_metadata
-                ]
+                )
             )
         )
         total_tasks = len(tasks)

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -574,12 +574,10 @@ class CVEDB:
         Return the years we have NVD data for.
         """
         return sorted(
-            [
-                int(filename.split(".")[-3].split("-")[-1])
-                for filename in glob.glob(
-                    os.path.join(self.cachedir, "nvdcve-1.1-*.json.gz")
-                )
-            ]
+            int(filename.split(".")[-3].split("-")[-1])
+            for filename in glob.glob(
+                os.path.join(self.cachedir, "nvdcve-1.1-*.json.gz")
+            )
         )
 
     def load_curl_version(self, version):

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-# pylint: disable=useless-object-inheritance, keyword-arg-before-vararg
+# pylint: disable=keyword-arg-before-vararg
 # disabled for python2 compatibility reasons
 """
 Extraction of archives

--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -81,7 +81,7 @@ class VersionSignatureDb:
 
         if datestamp is None or update_required:
             # if update is required or database is empty, fetch and insert data into database
-            self.cursor.execute("DELETE FROM {}".format(self.table_name))
+            self.cursor.execute(f"DELETE FROM {self.table_name}")
             self.cursor.execute(
                 "DELETE FROM {}".format("latest_update_" + self.table_name)
             )
@@ -98,8 +98,6 @@ class VersionSignatureDb:
                     (mapping[0], mapping[1]),
                 )
 
-        data = self.cursor.execute(
-            "SELECT * FROM {}".format(self.table_name)
-        ).fetchall()
+        data = self.cursor.execute(f"SELECT * FROM {self.table_name}").fetchall()
         self.conn.commit()
         return data

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,10 +16,9 @@
 import ast
 import os
 import sys
-from io import open
 
 # -- Project information -----------------------------------------------------
-with open(os.path.join(os.path.abspath(".."), "cve_bin_tool", "version.py"), "r") as f:
+with open(os.path.join(os.path.abspath(".."), "cve_bin_tool", "version.py")) as f:
     for line in f:
         if line.startswith("VERSION"):
             VERSION = ast.literal_eval(line.strip().split("=")[-1].strip())

--- a/setup.py
+++ b/setup.py
@@ -3,17 +3,16 @@
 
 import ast
 import os
-from io import open
 
 from setuptools import find_packages, setup
 
-with open("README.md", "r", encoding="utf-8") as f:
+with open("README.md", encoding="utf-8") as f:
     readme = f.read()
 
-with open("requirements.txt", "r", encoding="utf-8") as f:
+with open("requirements.txt", encoding="utf-8") as f:
     requirements = f.read().split("\n")
 
-with open(os.path.join("cve_bin_tool", "version.py"), "r") as f:
+with open(os.path.join("cve_bin_tool", "version.py")) as f:
     for line in f:
         if line.startswith("VERSION"):
             VERSION = ast.literal_eval(line.strip().split("=")[-1].strip())

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -75,7 +75,7 @@ class TestExtractFileTar(TestExtractorBase):
         ]:
             tarpath = os.path.join(self.tempdir, filename)
             tar = tarfile.open(tarpath, mode=tarmode)
-            data = "feedface".encode("utf-8")
+            data = b"feedface"
             addfile = BytesIO(data)
             info = tarfile.TarInfo(name="test.txt")
             info.size = len(data)
@@ -113,7 +113,7 @@ class TestExtractFileRpm(TestExtractorBase):
 
     @classmethod
     def setup_class(cls):
-        super(TestExtractFileRpm, cls).setup_class()
+        super().setup_class()
         download_file(CURL_7_20_0_URL, os.path.join(cls.tempdir, "test.rpm"))
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This is intended to close #642

First commit is just the result of running [pyupgrade](https://github.com/asottile/pyupgrade) with `--py36-plus` flag.
What it did:

- [`.encode()` to bytes literals](https://github.com/asottile/pyupgrade#encode-to-bytes-literals)
- [`super()` calls](https://github.com/asottile/pyupgrade#super-calls)
- Our favorite [f-strings](https://github.com/asottile/pyupgrade#f-strings)
- [Redundant `open` modes](https://github.com/asottile/pyupgrade#redundant-open-modes), in our case it's only `"r"`
- [Unnecessary py3-compat imports](https://github.com/asottile/pyupgrade#remove-unnecessary-py3-compat-imports), in our case it's `from io import open`
- [Generator expressions for some built-in functions](https://github.com/asottile/pyupgrade#generator-expressions-for-some-built-in-functions-pep-289) (added in another commit as it was added to pyupgrade recently)
- [Unpacking argument list comprehensions](https://github.com/asottile/pyupgrade#unpacking-argument-list-comprehensions)  (added in another commit as it was added to pyupgrade recently)

pyupgrade also has a more conservative flag `--py3-plus` and #642 says Python 2.7 but because cve-bin-tool supports only Python 3.6+ by this point I went ahead to enforce 3.6+.

~~Would it be worth it to add pyupgrade in CI and to pre-commit hook?~~ Decided to do it.