### PR TITLE
Handle UNKNOWN severity in PDF reports

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -4,6 +4,7 @@
 import csv
 import json
 import os
+import time
 from logging import Logger
 from typing import IO, Dict
 
@@ -56,6 +57,7 @@ def output_pdf(all_cve_data: Dict[ProductInfo, CVEData], outfile):
     pdfdoc = pdfbuilder.PDFBuilder()
     cm = pdfdoc.cm
     severity_colour = {
+        "UNKNOWN": pdfdoc.grey,
         "LOW": pdfdoc.blue,
         "MEDIUM": pdfdoc.green,
         "HIGH": pdfdoc.orange,

--- a/cve_bin_tool/output_engine/pdfbuilder.py
+++ b/cve_bin_tool/output_engine/pdfbuilder.py
@@ -72,6 +72,14 @@ class PDFBuilder:
 
     body = PS(name="body", fontSize=12, fontName="Helvetica", leading=12)
 
+    body_unknown = PS(
+        name="body",
+        fontSize=12,
+        textColor=colors.grey,
+        fontName="Helvetica-Bold",
+        leading=12,
+    )
+
     body_low = PS(
         name="body",
         fontSize=12,
@@ -123,6 +131,7 @@ class PDFBuilder:
         ]
     )
 
+    grey = colors.grey
     blue = colors.blue
     red = colors.red
     green = colors.green


### PR DESCRIPTION
Closes #1151 

Sample PDF:
[output.cve-bin-tool.2021-05-08.11-49-29.pdf](https://github.com/intel/cve-bin-tool/files/6445338/output.cve-bin-tool.2021-05-08.11-49-29.pdf)

pinging @anthonyharrison to take a look since I just followed the pattern in the file to add UNKNOWN severity.