### PR TITLE
Add manual trigger for CI workflow

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -1,6 +1,14 @@
 name: cve-bin-tool
 
-on: [push, pull_request]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      longTests:
+        description: 'Set true to run long tests manually'     
+        required: false
+        default: 'false'
 
 jobs:
   isort:
@@ -153,6 +161,7 @@ jobs:
           path: ~/.cache/cve-bin-tool
           key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
       - uses: technote-space/get-diff-action@v4
+        if: ${{ github.event.inputs.longTests != 'true' }}
         with:
           PATTERNS: |
             cve_bin_tool/checkers/*.py


### PR DESCRIPTION
This is to allow manual runs on a branch. It is helpful when we suspect something external might be breaking tests, like in #1147.
Also gives the option to run long tests if desired.