### PR TITLE
Fix Python Checker

### DIFF
--- a/cve_bin_tool/checkers/python.py
+++ b/cve_bin_tool/checkers/python.py
@@ -38,7 +38,7 @@ class PythonChecker(Checker):
             # we will update our regex to something more precise 3.6.d
             # where d is unknown and we will find d. which will return 3.6.9 or some other version
             version_pattern = [
-                rf"([{version_info['version'][0]}]+\.[{version_info['version'][2]}]+\.[0-9])"
+                rf"([{version_info['version'][0]}]+\.[{version_info['version'][2]}]+\.[0-9]+)"
             ]
             version_regex = list(map(re.compile, version_pattern))
             new_version = regex_find(lines, version_regex)


### PR DESCRIPTION
Fixes wrong detection of newer python2.7 versions

The version pattern of the current checker does not consider python versions
with more than a single digit in the third block of the version string.
Since the latest version of Python 2.7 is 2.7.18, this is falsely reported as
2.7.1.
