### PR TITLE
Format files using isort and black

### DIFF
--- a/cve_bin_tool/checkers/sqlite.py
+++ b/cve_bin_tool/checkers/sqlite.py
@@ -21,7 +21,7 @@ from cve_bin_tool.version_signature import VersionSignatureDb
 
 
 def get_version_map():
-    """ Read changelog and get SQLITE_SOURCE_ID to use for versions """
+    """Read changelog and get SQLITE_SOURCE_ID to use for versions"""
     version_map = []
 
     changeurl = "https://www.sqlite.org/changes.html"

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -27,8 +27,8 @@ from cve_bin_tool.error_handler import (
     CVEDataForYearNotInCache,
     ErrorHandler,
     ErrorMode,
-    SHAMismatch,
     NVDRateLimit,
+    SHAMismatch,
 )
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.version import check_latest_version
@@ -208,7 +208,7 @@ class CVEDB:
             await f.write(json.dumps(json_data, indent=4))
 
     async def refresh(self):
-        """ Refresh the cve database and check for new version. """
+        """Refresh the cve database and check for new version."""
         # refresh the database
         if not os.path.isdir(self.cachedir):
             os.makedirs(self.cachedir)
@@ -283,7 +283,7 @@ class CVEDB:
             )
 
     def latest_schema(self, cursor):
-        """ Check database is using latest schema """
+        """Check database is using latest schema"""
         self.LOGGER.info("Check database is using latest schema")
         schema_check = "SELECT * FROM cve_severity WHERE 1=0"
         result = cursor.execute(schema_check)
@@ -295,7 +295,7 @@ class CVEDB:
         return schema_latest
 
     def check_cve_entries(self):
-        """ Report if database has some CVE entries """
+        """Report if database has some CVE entries"""
         self.db_open()
         cursor = self.connection.cursor()
         cve_entries_check = "SELECT COUNT(*) FROM cve_severity"
@@ -308,7 +308,7 @@ class CVEDB:
         return cve_entries > 0
 
     def init_database(self):
-        """ Initialize db tables used for storing cve/version data """
+        """Initialize db tables used for storing cve/version data"""
         self.db_open()
         cursor = self.connection.cursor()
         cve_data_create = """
@@ -621,12 +621,12 @@ class CVEDB:
             shutil.rmtree(OLD_CACHE_DIR)
 
     def db_open(self):
-        """ Opens connection to sqlite database."""
+        """Opens connection to sqlite database."""
         if not self.connection:
             self.connection = sqlite3.connect(self.dbpath)
 
     def db_close(self):
-        """ Closes connection to sqlite database."""
+        """Closes connection to sqlite database."""
         if self.connection:
             self.connection.close()
             self.connection = None

--- a/cve_bin_tool/error_handler.py
+++ b/cve_bin_tool/error_handler.py
@@ -13,23 +13,23 @@ CONSOLE = Console(file=sys.stderr)
 
 
 class InsufficientArgs(Exception):
-    """ Insufficient command line arguments"""
+    """Insufficient command line arguments"""
 
 
 class InvalidCsvError(Exception):
-    """ Given File is an Invalid CSV """
+    """Given File is an Invalid CSV"""
 
 
 class InvalidCheckerError(Exception):
-    """ Raised when data provided to Checker is not correct """
+    """Raised when data provided to Checker is not correct"""
 
 
 class MissingFieldsError(Exception):
-    """ Missing needed fields """
+    """Missing needed fields"""
 
 
 class InvalidJsonError(Exception):
-    """ Given File is an Invalid JSON """
+    """Given File is an Invalid JSON"""
 
 
 class EmptyCache(Exception):
@@ -77,11 +77,11 @@ class SHAMismatch(Exception):
 
 
 class ExtractionFailed(ValueError):
-    """ Extraction fail """
+    """Extraction fail"""
 
 
 class UnknownArchiveType(ValueError):
-    """ Unknown archive type"""
+    """Unknown archive type"""
 
 
 class UnknownConfigType(Exception):

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -59,7 +59,7 @@ class BaseExtractor:
         }
 
     def can_extract(self, filename):
-        """ Check if the filename is something we know how to extract """
+        """Check if the filename is something we know how to extract"""
         for extension in itertools.chain(*self.file_extractors.values()):
             if filename.endswith(extension):
                 return True
@@ -67,13 +67,13 @@ class BaseExtractor:
 
     @staticmethod
     async def extract_file_tar(filename, extraction_path):
-        """ Extract tar files """
+        """Extract tar files"""
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
             await aio_unpack_archive(filename, extraction_path)
         return e.exit_code
 
     async def extract_file_rpm(self, filename, extraction_path):
-        """ Extract rpm packages """
+        """Extract rpm packages"""
         if sys.platform.startswith("linux"):
             if not await aio_inpath("rpm2cpio") or not await aio_inpath("cpio"):
                 await rpmextract("-xC", extraction_path, filename)
@@ -106,7 +106,7 @@ class BaseExtractor:
         return 0
 
     async def extract_file_deb(self, filename, extraction_path):
-        """ Extract debian packages """
+        """Extract debian packages"""
         if not await aio_inpath("ar"):
             with ErrorHandler(mode=self.error_mode, logger=self.logger):
                 raise Exception("'ar' is required to extract deb files")
@@ -121,7 +121,7 @@ class BaseExtractor:
 
     @staticmethod
     async def extract_file_cab(filename, extraction_path):
-        """ Extract cab files """
+        """Extract cab files"""
         if sys.platform.startswith("linux"):
             if not await aio_inpath("cabextract"):
                 raise Exception("'cabextract' is required to extract cab files")
@@ -141,7 +141,7 @@ class BaseExtractor:
 
     @staticmethod
     async def extract_file_zip(filename, extraction_path):
-        """ Extract zip files """
+        """Extract zip files"""
         if await aio_inpath("unzip"):
             stdout, stderr = await aio_run_command(
                 ["unzip", "-n", "-d", extraction_path, filename]
@@ -168,7 +168,7 @@ class TempDirExtractorContext(BaseExtractor):
         self.raise_failure = raise_failure
 
     async def aio_extract(self, filename):
-        """ Run the extractor """
+        """Run the extractor"""
         # Resolve path in case of cwd change
         filename = os.path.abspath(filename)
         for extractor in self.file_extractors:
@@ -198,12 +198,12 @@ class TempDirExtractorContext(BaseExtractor):
             raise UnknownArchiveType(filename)
 
     async def __aenter__(self):
-        """ Create a temporary directory to extract files to. """
+        """Create a temporary directory to extract files to."""
         self.tempdir = await aio_mkdtemp(prefix="cve-bin-tool-")
         return self
 
     async def __aexit__(self, exc_type, exc, exc_tb):
-        """ Removes all extraction directories that need to be cleaned up."""
+        """Removes all extraction directories that need to be cleaned up."""
         # removing directory can raise exception so wrap it around ErrorHandler.
         with ErrorHandler(mode=self.error_mode, logger=self.logger):
             await aio_rmdir(self.tempdir)

--- a/cve_bin_tool/file.py
+++ b/cve_bin_tool/file.py
@@ -29,21 +29,21 @@ def is_binary(filename):
 
 
 async def read_signature(filename, length=4):
-    """ Read the signature, first length bytes, from filename."""
+    """Read the signature, first length bytes, from filename."""
     async with FileIO(filename, "rb") as file_handle:
         return await file_handle.read(length)
 
 
 def check_elf(_filename, signature):
-    """ Check for an ELF signature."""
+    """Check for an ELF signature."""
     return signature == b"\x7f\x45\x4c\x46"
 
 
 def check_pe(_filename, signature):
-    """ Check for windows/dos PE signature, aka 0x5a4d."""
+    """Check for windows/dos PE signature, aka 0x5a4d."""
     return signature[:4] == b"\x4d\x5a"
 
 
 def check_fake_test(_filename, signature):
-    """ check for fake tests under windows."""
+    """check for fake tests under windows."""
     return signature == b"MZ\x90\x00"

--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -22,7 +22,7 @@ from ..util import ProductInfo
 def output_console(
     all_cve_data: Dict[ProductInfo, CVEData], console=Console(theme=cve_theme)
 ):
-    """ Output list of CVEs in a tabular format with color support """
+    """Output list of CVEs in a tabular format with color support"""
 
     console._width = 120
     now = datetime.now().strftime("%Y-%m-%d  %H:%M:%S")

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -143,7 +143,7 @@ class DirWalk:
         self.yield_folders = yield_folders
 
     def walk(self, roots=None):
-        """ Walk the directory looking for files matching the pattern """
+        """Walk the directory looking for files matching the pattern"""
         if roots is None:
             roots = []
         for root in roots:
@@ -180,7 +180,7 @@ class DirWalk:
 
     @staticmethod
     def pattern_match(text: str, patterns: str) -> bool:
-        """ Match filename patterns """
+        """Match filename patterns"""
         if not patterns:
             return False
         for pattern in patterns.split(";"):

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -17,11 +17,11 @@ from cve_bin_tool.util import DirWalk, ProductInfo, inpath
 
 
 class InvalidFileError(Exception):
-    """ Filepath is invalid for scanning."""
+    """Filepath is invalid for scanning."""
 
 
 class VersionScanner:
-    """"Scans files for CVEs using CVE checkers"""
+    """ "Scans files for CVEs using CVE checkers"""
 
     CHECKER_ENTRYPOINT = "cve_bin_tool.checker"
 
@@ -59,7 +59,7 @@ class VersionScanner:
 
     @classmethod
     def load_checkers(cls):
-        """ Loads CVE checkers """
+        """Loads CVE checkers"""
         checkers = dict(
             map(
                 lambda checker: (checker.name, checker.load()),
@@ -187,7 +187,7 @@ class VersionScanner:
         return filepath[start_point:]
 
     def scan_and_or_extract_file(self, ectx, filepath):
-        """ Runs extraction if possible and desired otherwise scans."""
+        """Runs extraction if possible and desired otherwise scans."""
         # Scan the file
         yield from self.scan_file(filepath)
         # Attempt to extract the file and scan the contents

--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -10,7 +10,7 @@ from cve_bin_tool.cvedb import DISK_LOCATION_DEFAULT
 
 
 class VersionSignatureDb:
-    """ Methods for version signature data stored in sqlite """
+    """Methods for version signature data stored in sqlite"""
 
     def __init__(self, table_name, mapping_function, duration) -> None:
         """Set location on disk data cache will reside.
@@ -25,27 +25,27 @@ class VersionSignatureDb:
 
     @property
     def dbname(self):
-        """ SQLite datebase file where the data is stored."""
+        """SQLite datebase file where the data is stored."""
         return os.path.join(self.disk_location, "version_map.db")
 
     def open(self):
-        """ Opens connection to sqlite database."""
+        """Opens connection to sqlite database."""
         self.conn = sqlite3.connect(self.dbname)
         self.cursor = self.conn.cursor()
 
     def close(self):
-        """ Closes connection to sqlite database."""
+        """Closes connection to sqlite database."""
         self.cursor.close()
         self.conn.close()
         self.conn = None
         self.cursor = None
 
     def __enter__(self):
-        """ Opens connection to sqlite database."""
+        """Opens connection to sqlite database."""
         self.open()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        """ Closes connection to sqlite database."""
+        """Closes connection to sqlite database."""
         self.close()
 
     def get_mapping_data(self):

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -103,7 +103,7 @@ class TestCheckerVersionParser:
         ],
     )
     def test_filename_is(self, checker_name, file_name, expected_results):
-        """ Test a checker's filename detection"""
+        """Test a checker's filename detection"""
         checkers = pkg_resources.iter_entry_points("cve_bin_tool.checker")
         for checker in checkers:
             if checker.name == checker_name:

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -28,7 +28,7 @@ from cve_bin_tool.version_scanner import VersionScanner
 
 
 class TestCLI(TempDirTest):
-    """ Tests the CVE Bin Tool CLI"""
+    """Tests the CVE Bin Tool CLI"""
 
     TEST_PATH = os.path.abspath(os.path.dirname(__file__))
 
@@ -41,7 +41,7 @@ class TestCLI(TempDirTest):
         assert main(["cve-bin-tool", "-l", "debug", "-x", self.tempdir]) != 0
 
     def test_binary_curl_7_20_0(self):
-        """ Extracting from rpm and scanning curl-7.20.0 """
+        """Extracting from rpm and scanning curl-7.20.0"""
         with Extractor() as ectx:
             extracted_path = ectx.extract(os.path.join(self.tempdir, CURL_7_20_0_RPM))
             assert (
@@ -57,11 +57,11 @@ class TestCLI(TempDirTest):
             )
 
     def test_no_extraction(self):
-        """ Test scanner against curl-7.20.0 rpm with extraction turned off """
+        """Test scanner against curl-7.20.0 rpm with extraction turned off"""
         assert main(["cve-bin-tool", os.path.join(self.tempdir, CURL_7_20_0_RPM)]) != 0
 
     def test_exclude(self, caplog):
-        """ Test that the exclude paths are not scanned """
+        """Test that the exclude paths are not scanned"""
         test_path = os.path.abspath(os.path.dirname(__file__))
         exclude_path = os.path.join(test_path, "assets/")
         checkers = list(VersionScanner().checkers.keys())
@@ -70,13 +70,13 @@ class TestCLI(TempDirTest):
         self.check_exclude_log(caplog, exclude_path, checkers)
 
     def test_usage(self):
-        """ Test that the usage returns 0 """
+        """Test that the usage returns 0"""
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool"])
         assert e.value.args[0] == -6
 
     def test_invalid_file_or_directory(self):
-        """ Test behaviour with an invalid file/directory """
+        """Test behaviour with an invalid file/directory"""
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "non-existant"])
         assert e.value.args[0] == -3
@@ -224,7 +224,7 @@ class TestCLI(TempDirTest):
         caplog.clear()
 
     def test_unknown_warning(self, caplog):
-        """ Test that an "UNKNOWN" file generates a warning """
+        """Test that an "UNKNOWN" file generates a warning"""
 
         # build the unknown test file in test/binaries
         with tempfile.NamedTemporaryFile(
@@ -253,7 +253,7 @@ class TestCLI(TempDirTest):
         assert f"png was detected with version UNKNOWN in file {filename}" in warnings
 
     def test_quiet_mode(self, capsys, caplog):
-        """ Test that an quite mode isn't generating any output """
+        """Test that an quite mode isn't generating any output"""
 
         with tempfile.NamedTemporaryFile(
             "w+b", suffix="strong-swan-4.6.3.out", delete=False

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -42,7 +42,7 @@ class TestExtractorBase:
 
     @pytest.mark.asyncio
     async def extract_files(self, filenames):
-        """ Make sure all test files are present """
+        """Make sure all test files are present"""
         for filename in filenames:
             assert os.path.exists(
                 os.path.join(self.tempdir, filename)
@@ -54,17 +54,17 @@ class TestExtractorBase:
 
 
 class TestExtractor(TestExtractorBase):
-    """ Test methods for the extractor functionality """
+    """Test methods for the extractor functionality"""
 
     def test_can_extract(self):
-        """ Test that the can_extract function knows what it can do """
+        """Test that the can_extract function knows what it can do"""
         assert self.extractor.can_extract(".tar.bz2")
         assert self.extractor.can_extract(".zip")
         assert self.extractor.can_extract(".deb")
 
 
 class TestExtractFileTar(TestExtractorBase):
-    """ Tetss for tar file extraction """
+    """Tetss for tar file extraction"""
 
     def setup_method(self):
         for filename, tarmode in [
@@ -88,7 +88,7 @@ class TestExtractFileTar(TestExtractorBase):
 
     @pytest.mark.asyncio
     async def test_extract_file_tar(self):
-        """ Test the tar file extraction """
+        """Test the tar file extraction"""
         async for path in self.extract_files(
             [
                 "test" + e
@@ -99,7 +99,7 @@ class TestExtractFileTar(TestExtractorBase):
 
     @pytest.mark.asyncio
     async def test_extract_cleanup(self):
-        """ Make sure tar extractor cleans up after itself """
+        """Make sure tar extractor cleans up after itself"""
         async with self.extractor as ectx:
             extracted_path = await ectx.aio_extract(
                 os.path.join(self.tempdir, "test.tar")
@@ -109,7 +109,7 @@ class TestExtractFileTar(TestExtractorBase):
 
 
 class TestExtractFileRpm(TestExtractorBase):
-    """ Tests for the rpm file extractor """
+    """Tests for the rpm file extractor"""
 
     @classmethod
     def setup_class(cls):
@@ -118,7 +118,7 @@ class TestExtractFileRpm(TestExtractorBase):
 
     @pytest.mark.asyncio
     async def test_extract_file_rpm(self):
-        """ Test the rpm file extraction """
+        """Test the rpm file extraction"""
         async for extracted_path in self.extract_files(
             [
                 "test" + e
@@ -129,7 +129,7 @@ class TestExtractFileRpm(TestExtractorBase):
 
     @pytest.mark.asyncio
     async def test_extract_file_rpm_no_rpm2cipo(self):
-        """ Test rpm extraction using rpmfile """
+        """Test rpm extraction using rpmfile"""
         with unittest.mock.patch(
             "cve_bin_tool.async_utils.aio_inpath",
             return_value=False,
@@ -141,7 +141,7 @@ class TestExtractFileRpm(TestExtractorBase):
 
 
 class TestExtractFileDeb(TestExtractorBase):
-    """ Tests for deb file extractor """
+    """Tests for deb file extractor"""
 
     def setup_method(self):
         assert inpath("ar"), "Required tool 'ar' not found"
@@ -153,7 +153,7 @@ class TestExtractFileDeb(TestExtractorBase):
 
     @pytest.mark.asyncio
     async def test_extract_file_deb(self):
-        """ Test the deb file extraction """
+        """Test the deb file extraction"""
         async for extracted_path in self.extract_files(
             [
                 "test" + e
@@ -164,14 +164,14 @@ class TestExtractFileDeb(TestExtractorBase):
 
 
 class TestExtractFileCab(TestExtractorBase):
-    """ Tests for the cab file extractor """
+    """Tests for the cab file extractor"""
 
     def setup_method(self):
         shutil.copyfile(CAB_TEST_FILE_PATH, os.path.join(self.tempdir, "test.cab"))
 
     @pytest.mark.asyncio
     async def test_extract_file_cab(self):
-        """ Test the cab file extraction """
+        """Test the cab file extraction"""
         async for extracted_path in self.extract_files(
             [
                 "test" + e
@@ -208,7 +208,7 @@ class TestExtractFileZip(TestExtractorBase):
 
     @pytest.mark.asyncio
     async def test_extract_file_zip(self):
-        """ Test the zip file extraction """
+        """Test the zip file extraction"""
         async for path in self.extract_files(
             [
                 "test" + e

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -16,7 +16,7 @@ ASSETS_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets")
 
 
 class TestFile:
-    """ Tests the CVE Bin Tool file binary checker."""
+    """Tests the CVE Bin Tool file binary checker."""
 
     @pytest.mark.asyncio
     async def _check_test(self, file_type):

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -37,7 +37,7 @@ class TestJSON:
     )
     # NVD database started in 2002, so range then to now.
     def test_json_validation(self, year):
-        """ Validate latest nvd json file against their published schema """
+        """Validate latest nvd json file against their published schema"""
         # Open the latest nvd file on disk
         with gzip.open(
             os.path.join(DISK_LOCATION_DEFAULT, f"nvdcve-1.1-{year}.json.gz"),

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -20,7 +20,7 @@ from cve_bin_tool.util import CVE, CVEData, ProductInfo
 
 
 class TestOutputEngine(unittest.TestCase):
-    """ Test the OutputEngine class functions """
+    """Test the OutputEngine class functions"""
 
     MOCK_OUTPUT = {
         ProductInfo("vendor0", "product0", "1.0"): CVEData(
@@ -99,17 +99,17 @@ class TestOutputEngine(unittest.TestCase):
         self.mock_file.close()
 
     def test_formatted_output(self):
-        """ Test reformatting products """
+        """Test reformatting products"""
         self.assertEqual(format_output(self.MOCK_OUTPUT), self.FORMATTED_OUTPUT)
 
     def test_output_json(self):
-        """ Test formatting output as JSON """
+        """Test formatting output as JSON"""
         output_json(self.MOCK_OUTPUT, self.mock_file)
         self.mock_file.seek(0)  # reset file position
         self.assertEqual(json.load(self.mock_file), self.FORMATTED_OUTPUT)
 
     def test_output_csv(self):
-        """ Test formatting output as CSV """
+        """Test formatting output as CSV"""
         output_csv(self.MOCK_OUTPUT, self.mock_file)
         self.mock_file.seek(0)  # reset file position
         reader = csv.DictReader(self.mock_file)

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -260,7 +260,7 @@ class TestScanner:
         assert version in list_versions
 
     def test_does_not_scan_symlinks(self):
-        """ Test that the scanner doesn't scan symlinks """
+        """Test that the scanner doesn't scan symlinks"""
         if sys.platform.startswith("linux"):
             # we can only do this in linux since symlink is privilege operation in windows
             os.symlink("non-existant-file", "non-existant-link")
@@ -275,7 +275,7 @@ class TestScanner:
                 os.unlink("non-existant-link")
 
     def test_cannot_open_file(self, caplog):
-        """ Test behaviour when file cannot be opened """
+        """Test behaviour when file cannot be opened"""
         with pytest.raises(StopIteration):
             next(
                 self.scanner.scan_file(

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -16,7 +16,7 @@ ASSETS_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets")
 
 
 class TestStrings:
-    """ Tests the CVE Bin Tool Strings"""
+    """Tests the CVE Bin Tool Strings"""
 
     @classmethod
     def setup_class(cls):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -12,7 +12,7 @@ from cve_bin_tool.util import CVEData, ProductInfo, inpath
 
 
 class TestUtil:
-    """ Test the util functions """
+    """Test the util functions"""
 
     def test_inpath(self):
         """Test the check to see if a command line utility is installed
@@ -24,7 +24,7 @@ class TestUtil:
 
 
 class TestSignature:
-    """ Tests signature of critical class and functions"""
+    """Tests signature of critical class and functions"""
 
     def test_cve_scanner(self):
         sig = inspect.signature(CVEScanner.get_cves)

--- a/test/utils.py
+++ b/test/utils.py
@@ -26,7 +26,7 @@ TMUX_DEB = "https://mirrors.cat.pdx.edu/ubuntu/pool/main/t/tmux/" + TMUX_DEB_NAM
 
 
 class TempDirTest:
-    """ For tests that need a temp directory """
+    """For tests that need a temp directory"""
 
     @classmethod
     def setup_class(cls):
@@ -38,7 +38,7 @@ class TempDirTest:
 
 
 def download_file(url, target):
-    """ helper method to download a file """
+    """helper method to download a file"""
     download = urlopen(url)
     with open(target, "wb") as target_file:
         target_file.write(download.read())


### PR DESCRIPTION
The [cvedb.py](https://github.com/intel/cve-bin-tool/tree/main/cve_bin_tool/cvedb.py) file has isort issues and made all CI checks fail and also while working on a PR I ran black on the entire directory and found that black formatted 19 files (had to restore files one by one since my work was uncommited).