### PR TITLE
Add support for python package checkers

### DIFF
--- a/cve_bin_tool/checkers/README.md
+++ b/cve_bin_tool/checkers/README.md
@@ -277,6 +277,16 @@ that include this product. For our example all listings except
 `libexpat, expat` mearly include the target product (`expat` for the
 example SQL query).
 
+### For PyPI packages
+
+Reading through the above sections before this section is highly recommended.
+
+1. `CONTAINS_PATTERN` can be any unique string in the whole package and can be found through the same process as in **Choosing contains patterns to detect the library**.
+2. `FILENAME_PATTERNS` should be `[r"METADATA", r"PKG-INFO"]`.
+3. `VERSION_PATTERNS` should be `[r"--generated pattern for cve-bin-tool Name: <package-name> Version: ([0-9]+\.[0-9]+\.[0-9]+)"]`. The strings in `METADATA` and `PKG-INFO` are converted similar to above string for version pattern detection.  
+ Note: The version pattern can change depending on the version convention of the package
+5. `VENDOR_PRODUCT` can be found through the same process as in **Finding Vendor Product pairs section**.
+
 ## Adding tests
 There are two types of tests you want to add to prove that your checker works as expected:
 

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -140,7 +140,7 @@ class VersionScanner:
         #  If python package then strip the lines to avoid detecting other product strings
         if "PKG-INFO: " in o or "METADATA: " in o:
             lines = lines[1:3]
-            lines[0] += lines[1]
+            lines[0] = "--generated pattern for cve-bin-tool " + lines[0] + " " + lines[1]
 
         yield from self.run_checkers(filename, lines)
 

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -140,7 +140,9 @@ class VersionScanner:
         #  If python package then strip the lines to avoid detecting other product strings
         if "PKG-INFO: " in o or "METADATA: " in o:
             lines = lines[1:3]
-            lines[0] = "--generated pattern for cve-bin-tool " + lines[0] + " " + lines[1]
+            lines[0] = (
+                "--generated pattern for cve-bin-tool " + lines[0] + " " + lines[1]
+            )
 
         yield from self.run_checkers(filename, lines)
 

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -107,22 +107,22 @@ class VersionScanner:
         # step 1: check if it's an ELF binary file
         if inpath("file"):
             # use system file if available (for performance reasons)
-            o = subprocess.check_output(["file", filename])
-            o = o.decode(sys.stdout.encoding)
+            output = subprocess.check_output(["file", filename])
+            output = output.decode(sys.stdout.encoding)
 
-            if "cannot open" in o:
+            if "cannot open" in output:
                 self.logger.warning(f"Unopenable file {filename} cannot be scanned")
                 return None
 
             if (
-                ("LSB " not in o)
-                and ("LSB shared" not in o)
-                and ("LSB executable" not in o)
-                and ("PE32 executable" not in o)
-                and ("PE32+ executable" not in o)
-                and ("Mach-O" not in o)
-                and ("PKG-INFO: " not in o)
-                and ("METADATA: " not in o)
+                ("LSB " not in output)
+                and ("LSB shared" not in output)
+                and ("LSB executable" not in output)
+                and ("PE32 executable" not in output)
+                and ("PE32+ executable" not in output)
+                and ("Mach-O" not in output)
+                and ("PKG-INFO: " not in output)
+                and ("METADATA: " not in output)
             ):
                 return None
         # otherwise use python implementation of file
@@ -131,14 +131,16 @@ class VersionScanner:
         # parse binary file's strings
         if inpath("strings"):
             # use "strings" on system if available (for performance)
-            s = subprocess.check_output(["strings", filename])
-            lines = s.decode("utf-8").splitlines()
+            lines = (
+                subprocess.check_output(["strings", filename])
+                .decode("utf-8")
+                .splitlines()
+            )
         else:
             # Otherwise, use python implementation
-            s = Strings(filename)
-            lines = s.parse()
+            lines = Strings(filename).parse()
         #  If python package then strip the lines to avoid detecting other product strings
-        if "PKG-INFO: " in o or "METADATA: " in o:
+        if "PKG-INFO: " in output or "METADATA: " in output:
             lines = lines[1:3]
             lines[0] = (
                 "--generated pattern for cve-bin-tool " + lines[0] + " " + lines[1]

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -121,6 +121,8 @@ class VersionScanner:
                 and ("PE32 executable" not in o)
                 and ("PE32+ executable" not in o)
                 and ("Mach-O" not in o)
+                and ("PKG-INFO: " not in o)
+                and ("METADATA: " not in o)
             ):
                 return None
         # otherwise use python implementation of file
@@ -129,12 +131,16 @@ class VersionScanner:
         # parse binary file's strings
         if inpath("strings"):
             # use "strings" on system if available (for performance)
-            o = subprocess.check_output(["strings", filename])
-            lines = o.decode("utf-8").splitlines()
+            s = subprocess.check_output(["strings", filename])
+            lines = s.decode("utf-8").splitlines()
         else:
             # Otherwise, use python implementation
             s = Strings(filename)
             lines = s.parse()
+        #  If python package then strip the lines to avoid detecting other product strings
+        if "PKG-INFO: " in o or "METADATA: " in o:
+            lines = lines[1:3]
+            lines[0] += lines[1]
 
         yield from self.run_checkers(filename, lines)
 


### PR DESCRIPTION
This PR would enable support for python package checkers that only have version strings present in PKG-INFO or METADATA files. 