### PR TITLE
Proper decoding of stdout in condensed download committed or not test

### DIFF
--- a/test/test_condensed_downloads.py
+++ b/test/test_condensed_downloads.py
@@ -2,16 +2,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """
-Condensed Downloads Test
+Test to check if condensed downloads are committed
 """
 import importlib
 import subprocess
 from test.test_data import __all__ as all_test_name
 
-import pytest
 
-
-# Test to check condensed files are commited according to the package test data of checkers
+# Test to check condensed files are committed according to the package test data of checkers
 def test_condensed_downloads():
     test_data = list(
         map(lambda x: importlib.import_module(f"test.test_data.{x}"), all_test_name)
@@ -30,8 +28,8 @@ def test_condensed_downloads():
         stdout=subprocess.PIPE,
     )
 
-    condensed_downloads = str(condensed_downloads.stdout)[2:-1].split("\\n")
+    condensed_downloads = condensed_downloads.stdout.decode("utf-8")
 
     assert all(
         item in condensed_downloads for item in package_names
-    ), "Condensed downloads not commited"
+    ), "Condensed downloads are not commited"


### PR DESCRIPTION
While working on #1165 I noticed that improper decoding of stdout could cause problems in different platforms (had issues on windows). Instead of splitting the string for parsing of the stdout it is properly decoded now.