### PR TITLE
Fix  Tests

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -253,6 +253,7 @@ def main(argv=None):
         cvedb_orig.get_cvelist_if_stale()
     else:
         LOGGER.warning("Not verifying CVE DB cache")
+        cvedb_orig.get_db_update_date()
         if not cvedb_orig.nvd_years():
             with ErrorHandler(mode=error_mode, logger=LOGGER):
                 raise EmptyCache(cvedb_orig.cachedir)

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -85,10 +85,11 @@ class CVEDB:
         return self.cve_count
 
     def get_db_update_date(self):
-        return os.path.getmtime(self.dbpath)
-
         # last time when CVE data was updated
-        self.time_of_last_update = datetime.datetime.now()
+        self.time_of_last_update = datetime.datetime.fromtimestamp(
+            os.path.getmtime(self.dbpath)
+        )
+        return os.path.getmtime(self.dbpath)
 
     async def getmeta(self, session, meta_url):
         async with session.get(meta_url) as response:

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -98,7 +98,7 @@ class TestOutputEngine(unittest.TestCase):
             scanned_dir="",
             filename="",
             themes_dir="",
-            time_of_last_update=datetime.datetime.today(),
+            time_of_last_update=datetime.today(),
         )
         self.mock_file = tempfile.NamedTemporaryFile("w+", encoding="utf-8")
 
@@ -130,7 +130,7 @@ class TestOutputEngine(unittest.TestCase):
         output_console(
             self.MOCK_OUTPUT,
             console=console,
-            time_of_last_update=datetime.datetime.today(),
+            time_of_last_update=datetime.today(),
         )
 
         expected_output = "│ vendor0 │ product0 │ 1.0     │ CVE-1234-1234 │ MEDIUM   │ 4.2 (v2)             │\n│ vendor0 │ product0 │ 1.0     │ CVE-1234-1234 │ LOW      │ 1.2 (v2)             │\n│ vendor0 │ product0 │ 2.8.6   │ CVE-1234-1234 │ LOW      │ 2.5 (v3)             │\n│ vendor1 │ product1 │ 3.2.1.0 │ CVE-1234-1234 │ HIGH     │ 7.5 (v2)             │\n└─────────┴──────────┴─────────┴───────────────┴──────────┴──────────────────────┘\n"


### PR DESCRIPTION
There was a mismatch in the way `datetime` was imported in c6d71c6d335ec57972ca58544de9c2cc22183ba4 and 585e578bbe5216366daf081510b9f9d3eaee7609 in the `test_output_engine.py` file leading to failing tests