### PR TITLE
Quick fix for platforms that don't include lsb_release

### DIFF
--- a/test/test_package_list_parser.py
+++ b/test/test_package_list_parser.py
@@ -21,11 +21,16 @@ from cve_bin_tool.util import ProductInfo
 class TestPackageListParser:
     TXT_PATH = join(dirname(__file__), "txt")
 
-    DISTRO = (
-        subprocess.run(["lsb_release", "-sd"], stdout=subprocess.PIPE)
-        if platform == "linux"
-        else ""
-    )
+    DISTRO = ""
+    try:
+        DISTRO = (
+                subprocess.run(["lsb_release", "-sd"], stdout=subprocess.PIPE)
+            if platform == "linux"
+            else ""
+        )
+    except:
+        # lsb_release didn't exist, so it's likely not ubuntu
+        DISTRO = "Non-ubuntu"
 
     REQ_PARSED_TRIAGE_DATA = {
         ProductInfo(vendor="httplib2_project", product="httplib2", version="0.18.1"): {

--- a/test/test_package_list_parser.py
+++ b/test/test_package_list_parser.py
@@ -24,7 +24,7 @@ class TestPackageListParser:
     DISTRO = ""
     try:
         DISTRO = (
-                subprocess.run(["lsb_release", "-sd"], stdout=subprocess.PIPE)
+            subprocess.run(["lsb_release", "-sd"], stdout=subprocess.PIPE)
             if platform == "linux"
             else ""
         )


### PR DESCRIPTION
Fixes #1195 

We might want something more elegant here as we support more linux platforms, but this at least allows pytest to run if lsb_release is not installed.