### PR TITLE
Remove regex that was catching false positive versions in python checker

### DIFF
--- a/cve_bin_tool/checkers/python.py
+++ b/cve_bin_tool/checkers/python.py
@@ -49,7 +49,6 @@ class PythonChecker(Checker):
         # else guess was unknown so we update our regex
         elif version_info:
             version_pattern = [
-                r"Version: ([23]+\.[0-9]+\.[0-9])+",
                 r"version: ([23]+\.[0-9]+\.[0-9])+",
                 r"Python ([23]+\.[0-9]+\.[0-9])+",
             ]


### PR DESCRIPTION
Fix #1201 