### PR TITLE
feat: Add recommdended dev tools list

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -32,6 +32,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade wheel setuptools
           python -m pip install -r requirements.txt -r doc/requirements.txt
+          python -m pip install -r dev-recommended.txt
       - uses: isort/isort-action@master
         with:
             configuration: --profile black --check-only

--- a/dev-recommended.txt
+++ b/dev-recommended.txt
@@ -1,0 +1,2 @@
+black==20.8b1
+pre-commit

--- a/dev-recommended.txt
+++ b/dev-recommended.txt
@@ -1,2 +1,3 @@
 black==20.8b1
+isort
 pre-commit

--- a/requirements.csv
+++ b/requirements.csv
@@ -8,7 +8,6 @@ pytest_not_in_db,pytest
 pytest_not_in_db,pytest-xdist
 pytest_not_in_db,pytest-cov
 pytest_not_in_db,pytest-asyncio
-pycqa_not_in_db,isort
 willmcgugan_not_in_db,rich
 crummy_not_in_db,beautifulsoup4
 uiri_not_in_db,toml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-isort
 rich
 plotly
 jinja2>=2.11.3


### PR DESCRIPTION
This adds what is basically requirements.txt file for developers, including the specific version of black that we're currently using and pre-commit (which will help you run black and isort)

We may want to move isort into this list, since I believe it's also only needed for developers.