### PR TITLE
feat (cvedb): rollback cachedir if cvedb refresh fails

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -308,6 +308,8 @@ def main(argv=None):
         with ErrorHandler(mode=error_mode, logger=LOGGER):
             raise CVEDataMissing("No data in CVE Database")
 
+    cvedb_orig.remove_cache_backup()
+
     # Input validation
     if not args["directory"] and not args["input_file"] and not args["package_list"]:
         parser.print_usage()

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -63,13 +63,16 @@ class CVEDB:
         self,
         feed=None,
         cachedir=None,
+        backup_cachedir=None,
         version_check=True,
         session=None,
         error_mode=ErrorMode.TruncTrace,
     ):
         self.feed = feed if feed is not None else self.FEED
         self.cachedir = cachedir if cachedir is not None else self.CACHEDIR
-        self.backup_cachedir = self.BACKUPCACHEDIR
+        self.backup_cachedir = (
+            backup_cachedir if backup_cachedir is not None else self.BACKUPCACHEDIR
+        )
         self.error_mode = error_mode
         # Will be true if refresh was successful
         self.was_updated = False

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -36,6 +36,9 @@ from cve_bin_tool.version import check_latest_version
 logging.basicConfig(level=logging.DEBUG)
 
 # database defaults
+DISK_LOCATION_BACKUP = os.path.join(
+    os.path.expanduser("~"), ".cache", "cve-bin-tool-backup"
+)
 DISK_LOCATION_DEFAULT = os.path.join(os.path.expanduser("~"), ".cache", "cve-bin-tool")
 DBNAME = "cve.db"
 OLD_CACHE_DIR = os.path.join(os.path.expanduser("~"), ".cache", "cvedb")
@@ -47,6 +50,7 @@ class CVEDB:
     """
 
     CACHEDIR = DISK_LOCATION_DEFAULT
+    BACKUPCACHEDIR = DISK_LOCATION_BACKUP
     FEED = "https://nvd.nist.gov/vuln/data-feeds"
     LOGGER = LOGGER.getChild("CVEDB")
     NVDCVE_FILENAME_TEMPLATE = "nvdcve-1.1-{}.json.gz"
@@ -65,6 +69,7 @@ class CVEDB:
     ):
         self.feed = feed if feed is not None else self.FEED
         self.cachedir = cachedir if cachedir is not None else self.CACHEDIR
+        self.backup_cachedir = self.BACKUPCACHEDIR
         self.error_mode = error_mode
         # Will be true if refresh was successful
         self.was_updated = False
@@ -77,6 +82,9 @@ class CVEDB:
         self.connection = None
         self.session = session
         self.cve_count = -1
+
+        if not os.path.exists(self.dbpath):
+            self.rollback_cache_backup()
 
     def get_cve_count(self):
         if self.cve_count == -1:
@@ -618,8 +626,9 @@ class CVEDB:
         ]
 
     def clear_cached_data(self):
+        self.create_cache_backup()
         if os.path.exists(self.cachedir):
-            self.LOGGER.warning(f"Deleting cachedir {self.cachedir}")
+            self.LOGGER.warning(f"Updating cachedir {self.cachedir}")
             shutil.rmtree(self.cachedir)
         # Remove files associated with pre-1.0 development tree
         if os.path.exists(OLD_CACHE_DIR):
@@ -636,3 +645,29 @@ class CVEDB:
         if self.connection:
             self.connection.close()
             self.connection = None
+
+    def create_cache_backup(self):
+        """Creates a backup of the cachedir in case anything fails"""
+        if os.path.exists(self.cachedir):
+            self.LOGGER.debug(
+                f"Creating backup of cachedir {self.cachedir} at {self.backup_cachedir}"
+            )
+            self.remove_cache_backup()
+            shutil.copytree(self.cachedir, self.backup_cachedir)
+
+    def remove_cache_backup(self):
+        """Removes the backup if database was successfully loaded"""
+        if os.path.exists(self.backup_cachedir):
+            self.LOGGER.debug(f"Removing backup cache from {self.backup_cachedir}")
+            shutil.rmtree(self.backup_cachedir)
+
+    def rollback_cache_backup(self):
+        """Rollback the cachedir backup in case anything fails"""
+        if os.path.exists(os.path.join(self.backup_cachedir, DBNAME)):
+            self.LOGGER.info(f"Rolling back the cache to its previous state")
+            if os.path.exists(self.cachedir):
+                shutil.rmtree(self.cachedir)
+            shutil.move(self.backup_cachedir, self.cachedir)
+
+    def __del__(self):
+        self.rollback_cache_backup()

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -206,7 +206,7 @@ class TestCLI(TempDirTest):
         assert (
             "cve_bin_tool.CVEDB",
             logging.WARNING,
-            f"Deleting cachedir {db_path}",
+            f"Updating cachedir {db_path}",
         ) in caplog.record_tuples and (
             "cve_bin_tool.CVEDB",
             logging.INFO,


### PR DESCRIPTION
BREAKING CHANGE: When NVD scraping fails or a timeout occurs, sometimes the user is left with no database to work with. We can avoid this by creating a temporary local backup and rolling it back in case something fails.
