### PR TITLE
refactor(scanner): scan strings without splitting the lines

### DIFF
--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -144,9 +144,8 @@ class Checker(metaclass=CheckerMetaClass):
     VENDOR_PRODUCT = []
 
     def guess_contains(self, lines):
-        for line in lines:
-            if any(pattern.search(line) for pattern in self.CONTAINS_PATTERNS):
-                return True
+        if any(pattern.search(lines) for pattern in self.CONTAINS_PATTERNS):
+            return True
         return False
 
     def get_version(self, lines, filename):

--- a/cve_bin_tool/checkers/glibc.py
+++ b/cve_bin_tool/checkers/glibc.py
@@ -55,11 +55,8 @@ class GlibcChecker(Checker):
             recent = ""
             version_list = []
 
-            for line in lines:
-                for pattern in version_patterns:
-                    match = re.search(pattern, line)
-                    if match:
-                        version_list.append(match.group(1).strip())
+            for pattern in version_patterns:
+                version_list.extend(re.findall(pattern, lines))
 
             if version_list:
                 # Find the latest version string pattern

--- a/cve_bin_tool/checkers/libdb.py
+++ b/cve_bin_tool/checkers/libdb.py
@@ -17,7 +17,7 @@ class LibdbChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"libdb-"]
     VERSION_PATTERNS = [
-        r"Berkeley DB ([0-9]+\.[0-9]+\.[0-9]+):",  # short version as backup. we mostly want the long below.
         r"Berkeley DB .+, library version ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+):",
+        r"Berkeley DB ([0-9]+\.[0-9]+\.[0-9]+):",  # short version as backup. we mostly want the long above.
     ]
     VENDOR_PRODUCT = [("oracle", "berkeley_db")]

--- a/cve_bin_tool/checkers/sqlite.py
+++ b/cve_bin_tool/checkers/sqlite.py
@@ -76,10 +76,9 @@ class SqliteChecker(Checker):
         # since the version strings are super unique here, we can guess the version
         # at the same time
 
-        for line in lines:
-            for mapping in self.VERSION_MAP:
-                if mapping[1] in line:
-                    return True
+        for mapping in self.VERSION_MAP:
+            if mapping[1] in lines:
+                return True
 
         # If that fails, find a signature that might indicate presence of sqlite
         return super().guess_contains(lines)
@@ -94,11 +93,10 @@ class SqliteChecker(Checker):
 
         version_info = super().get_version(lines, filename)
 
-        for line in lines:
-            for mapping in self.VERSION_MAP:
-                if mapping[1] in line:
-                    # overwrite version with the version found by sha mapping
-                    version_info["version"] = mapping[0]
+        for mapping in self.VERSION_MAP:
+            if mapping[1] in lines:
+                # overwrite version with the version found by sha mapping
+                version_info["version"] = mapping[0]
 
         return version_info
 

--- a/cve_bin_tool/checkers/systemd.py
+++ b/cve_bin_tool/checkers/systemd.py
@@ -8,6 +8,8 @@ CVE checker for systemd
 https://www.cvedetails.com/product/38088/Freedesktop-Systemd.html?vendor_id=7971
 """
 
+from re import MULTILINE, compile, search
+
 from cve_bin_tool.checkers import Checker
 
 from ..util import regex_find
@@ -22,7 +24,7 @@ class SystemdChecker(Checker):
     FILENAME_PATTERNS = [r"libsystemd.so."]
     VERSION_PATTERNS = [
         r"LIBSYSTEMD_([0-4]+[0-9]+[0-9]+)",
-        r"^systemd (\d{2,4})$",
+        compile(r"^systemd (\d{2,4})$", MULTILINE),
         r"libsystemd-shared-([0-9]+)\.so",  # patterns like this aren't ideal
         r"systemd-[a-z]+-([0-9]+)\.so",  # patterns like this aren't ideal
         r"udev-([0-9]+)\.so",  # patterns like this aren't ideal
@@ -38,29 +40,18 @@ class SystemdChecker(Checker):
     """
 
     def get_version(self, lines, filename):
-        def guess_contains_systemd(lines):
-            """Tries to determine if a file includes systemd"""
-            for line in lines:
-                if "sd_bus_error_copy" in line:
-                    return 1
-                if "sd_bus_error_is_set" in line:
-                    return 1
-                if "sd_bus_error_add_map" in line:
-                    return 1
-            return 0
-
         version_info = {}
 
         if "libsystemd.so." in filename:
             version_info["is_or_contains"] = "is"
 
-        elif guess_contains_systemd(lines):
+        elif search(
+            r"sd_bus_error_copy|sd_bus_error_is_set|sd_bus_error_add_map", lines
+        ):
             version_info["is_or_contains"] = "contains"
 
         if "is_or_contains" in version_info:
             version_info["modulename"] = "systemd"
-            version_info["version"] = regex_find(
-                sorted(lines, reverse=True), self.VERSION_PATTERNS
-            )
+            version_info["version"] = regex_find(lines, self.VERSION_PATTERNS)
 
         return version_info

--- a/cve_bin_tool/checkers/xml2.py
+++ b/cve_bin_tool/checkers/xml2.py
@@ -34,7 +34,7 @@ class Xml2Checker(Checker):
         # fedora 29 string looks like libxml2.so.2.9.8-2.9.8-4.fc29.x86_64.debug
         pattern3 = re.compile(r"libxml2.so.([0-9]+\.[0-9]+\.[0-9]+)")
 
-        for line in lines:
+        for line in lines.splitlines():
             match = pattern1.search(line)
             if match:
                 new_guess2 = match.group(1).strip()

--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -20,7 +20,7 @@ class Strings:
 
     def __init__(self, filename=""):
         self.filename = filename
-        self.output = [""]
+        self.output = ""
 
     async def aio_parse(self):
         async with FileIO(self.filename, "rb") as f:
@@ -31,7 +31,7 @@ class Strings:
                     if char in Strings.PRINTABLE:
                         tmp.append(chr(char))
                     elif tmp:
-                        self.output.append("".join(tmp))
+                        self.output += "".join(tmp) + "\n"
                         tmp = []
         return self.output
 

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -79,13 +79,11 @@ def regex_find(lines, version_patterns) -> str:
     """Search a set of lines to find a match for the given regex"""
     new_guess = ""
 
-    for line in lines:
-        for pattern in version_patterns:
-            match = pattern.search(line)
-            if match:
-                new_guess2 = match.group(1).strip()
-                if len(new_guess2) > len(new_guess):
-                    new_guess = new_guess2
+    for pattern in version_patterns:
+        match = pattern.search(lines)
+        if match:
+            new_guess = match.group(1).strip()
+            break
     if new_guess != "":
         new_guess = new_guess.replace("_", ".")
         return new_guess.replace("-", ".")

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -133,20 +133,13 @@ class VersionScanner:
         # parse binary file's strings
         if inpath("strings"):
             # use "strings" on system if available (for performance)
-            lines = (
-                subprocess.check_output(["strings", filename])
-                .decode("utf-8")
-                .splitlines()
-            )
+            lines = subprocess.check_output(["strings", filename]).decode("utf-8")
         else:
             # Otherwise, use python implementation
             lines = Strings(filename).parse()
         #  If python package then strip the lines to avoid detecting other product strings
         if "PKG-INFO: " in output or "METADATA: " in output:
-            lines = lines[1:3]
-            lines[0] = (
-                "--generated pattern for cve-bin-tool " + lines[0] + " " + lines[1]
-            )
+            lines = lines[:3]
             yield from self.run_python_package_checkers(filename, lines)
 
         yield from self.run_checkers(filename, lines)
@@ -157,10 +150,8 @@ class VersionScanner:
         There are no actual checkers.
         The ProductInfo is computed without the help of any checkers from PKG-INFO or METADATA.
         """
-        product = search(
-            r"--generated pattern for cve-bin-tool Name: (.+?) Version:", lines[0]
-        ).group(1)
-        version = search(r"Version: (.+?)$", lines[1]).group(1)
+        product = search(r"Name: (.+?)$", lines).group(1)
+        version = search(r"Version: (.+?)$", lines).group(1)
 
         with VendorFetch() as vendor_fetch:
             vendor_package_pair = vendor_fetch.get_vendor_product_pairs(product)

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -4,7 +4,7 @@
 import os
 import subprocess
 import sys
-from re import search
+from re import MULTILINE, compile, search
 
 import pkg_resources
 
@@ -139,19 +139,19 @@ class VersionScanner:
             lines = Strings(filename).parse()
         #  If python package then strip the lines to avoid detecting other product strings
         if "PKG-INFO: " in output or "METADATA: " in output:
-            lines = lines[:3]
-            yield from self.run_python_package_checkers(filename, lines)
+            py_lines = "\n".join(lines.splitlines()[:3])
+            yield from self.run_python_package_checkers(filename, py_lines)
 
         yield from self.run_checkers(filename, lines)
 
     def run_python_package_checkers(self, filename, lines):
         """
-        This function runs only for python packages.
+        This generator runs only for python packages.
         There are no actual checkers.
         The ProductInfo is computed without the help of any checkers from PKG-INFO or METADATA.
         """
-        product = search(r"Name: (.+?)$", lines).group(1)
-        version = search(r"Version: (.+?)$", lines).group(1)
+        product = search(compile(r"^Name: (.+)$", MULTILINE), lines).group(1)
+        version = search(compile(r"^Version: (.+)$", MULTILINE), lines).group(1)
 
         with VendorFetch() as vendor_fetch:
             vendor_package_pair = vendor_fetch.get_vendor_product_pairs(product)

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -160,7 +160,7 @@ class TestCheckerVersionParser:
                 Checker = checker.load()
                 checker = Checker()
 
-                result = checker.get_version(common_versions, file_name)
+                result = checker.get_version("".join(common_versions), file_name)
 
         if "is_or_contains" in result:
             assert result["version"] not in versions_not_considered

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -110,7 +110,7 @@ class TestCheckerVersionParser:
                 Checker = checker.load()
                 checker = Checker()
 
-                result = checker.get_version([""], file_name)
+                result = checker.get_version("", file_name)
 
                 if "is_or_contains" in result:
                     results = [dict()]


### PR DESCRIPTION
~~Attemp to add multiline regex support for #1200 and possibly other checkers which may need multiline regex.~~

The strings obtained by scanning the binaries are further splitted and iterated to scan for versions in our tool using regex. Instead of splitting the lines we could directly employ regex to find the version in the string which will increase the performance by a lot.

Benchmark: https://github.com/intel/cve-bin-tool/pull/1227#issuecomment-881434989