### PR TITLE
refactor: helper script for is_executable() and parse_string()

### DIFF
--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -64,11 +64,7 @@ class HelperScript:
                     # self.logger.warning(f"scanning binaries from {clean_path}")
 
                     # see if the file is ELF binary file and parse for strings
-                    try:
-                        # self.logger.debug(self.version_scanner.is_executable(filepath))
-                        is_exec, output = self.version_scanner.is_executable(filepath)
-                    except:
-                        is_exec = self.version_scanner.is_executable(filepath)
+                    is_exec = self.version_scanner.is_executable(filepath)[0]
                     if is_exec:
                         # self.logger.warning(f"{clean_path} <--- this is an ELF binary")
                         string_list = [

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -22,7 +22,7 @@ from cve_bin_tool.file import is_binary
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.strings import Strings
 from cve_bin_tool.util import DirWalk, inpath
-from cve_bin_tool.version_scanner import (  # using it just for clean_file_path
+from cve_bin_tool.version_scanner import (
     VersionScanner,
 )
 
@@ -54,6 +54,9 @@ class HelperScript:
         self.version_pattern = []
         self.vendor_product = self.find_vendor_product()
 
+        # for scanning files verisons
+        self.version_scanner = VersionScanner()
+
     def extract_and_parse_file(self, filename):
         """extracts and parses the file for common patterns, version strings and common filename patterns"""
 
@@ -61,19 +64,24 @@ class HelperScript:
             if ectx.can_extract(filename):
                 binary_string_list = []
                 for filepath in self.walker([ectx.extract(filename)]):
-                    clean_path = VersionScanner.clean_file_path(filepath)
+                    clean_path = self.version_scanner.clean_file_path(filepath)
                     self.file_stack.append(f"{clean_path}")
                     # self.logger.warning(f"scanning binaries from {clean_path}")
 
                     # see if the file is ELF binary file and parse for strings
                     try:
-                        self.logger.warning(VersionScanner.is_executable(filepath))
-                        is_exec, output = VersionScanner.is_executable(filepath)
+                        self.logger.warning(
+                            self.version_scanner.is_executable(filepath)
+                        )
+                        is_exec, output = self.version_scanner.is_executable(filepath)
                     except:
-                        is_exec = VersionScanner.is_executable(filepath)
+                        is_exec = self.version_scanner.is_executable(filepath)
                     if is_exec:
                         # self.logger.warning(f"{clean_path} <--- this is an ELF binary")
-                        string_list = [i.strip() for i in VersionScanner.parse_strings(filepath)]
+                        string_list = [
+                            i.strip()
+                            for i in self.version_scanner.parse_strings(filepath)
+                        ]
                         matches = self.search_pattern(string_list)
 
                         # searching for version strings in the found matches

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -49,7 +49,7 @@ class HelperScript:
         self.version_pattern = []
         self.vendor_product = self.find_vendor_product()
 
-        # for scanning files verisons
+        # for scanning files versions
         self.version_scanner = VersionScanner()
 
     def extract_and_parse_file(self, filename):

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -66,9 +66,14 @@ class HelperScript:
                     # self.logger.warning(f"scanning binaries from {clean_path}")
 
                     # see if the file is ELF binary file and parse for strings
-                    if self.is_executable(filepath):
+                    try:
+                        self.logger.warning(VersionScanner.is_executable(filepath))
+                        is_exec, output = VersionScanner.is_executable(filepath)
+                    except:
+                        is_exec = VersionScanner.is_executable(filepath)
+                    if is_exec:
                         # self.logger.warning(f"{clean_path} <--- this is an ELF binary")
-                        string_list = [i.strip() for i in self.parse_strings(filepath)]
+                        string_list = [i.strip() for i in VersionScanner.parse_strings(filepath)]
                         matches = self.search_pattern(string_list)
 
                         # searching for version strings in the found matches
@@ -94,43 +99,6 @@ class HelperScript:
                     return self.contain_patterns
                 else:
                     return binary_string_list
-
-    def is_executable(self, filename):
-        """checks if given file is executable/ELF binary file"""
-
-        if inpath("file"):
-            # using system file if available (for performance reasons)
-            o = subprocess.check_output(["file", filename])
-            o = o.decode(sys.stdout.encoding)
-
-            if (
-                ("LSB " not in o)
-                and ("LSB shared" not in o)
-                and ("LSB executable" not in o)
-                and ("PE32 executable" not in o)
-                and ("PE32+ executable" not in o)
-                and ("Mach-O" not in o)
-            ):
-                return False
-        # else using python implementation of file
-        elif not is_binary(filename):
-            return False
-
-        return True
-
-    def parse_strings(self, filename):
-        """parse binary file's strings"""
-
-        # self.logger.debug(f"running for strings over {filepath}")
-        if inpath("strings"):
-            # use "strings" on system if available (for performance)
-            o = subprocess.check_output(["strings", filename])
-            lines = o.decode("utf-8").splitlines()
-        else:
-            # Otherwise, use python implementation
-            s = Strings(filename)
-            lines = s.parse()
-        return lines
 
     def search_pattern(self, string_list):
         """find strings for CONTAIN_PATTERNS with product_name in them"""

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import subprocess
 import sys
 import textwrap
 
@@ -18,13 +17,9 @@ from cve_bin_tool.error_handler import (
     UnknownArchiveType,
 )
 from cve_bin_tool.extractor import Extractor
-from cve_bin_tool.file import is_binary
 from cve_bin_tool.log import LOGGER
-from cve_bin_tool.strings import Strings
-from cve_bin_tool.util import DirWalk, inpath
-from cve_bin_tool.version_scanner import (
-    VersionScanner,
-)
+from cve_bin_tool.util import DirWalk
+from cve_bin_tool.version_scanner import VersionScanner
 
 
 class HelperScript:
@@ -70,9 +65,7 @@ class HelperScript:
 
                     # see if the file is ELF binary file and parse for strings
                     try:
-                        self.logger.warning(
-                            self.version_scanner.is_executable(filepath)
-                        )
+                        # self.logger.debug(self.version_scanner.is_executable(filepath))
                         is_exec, output = self.version_scanner.is_executable(filepath)
                     except:
                         is_exec = self.version_scanner.is_executable(filepath)

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -100,7 +100,7 @@ class VersionScanner:
 
             if "cannot open" in output:
                 self.logger.warning(f"Unopenable file {filename} cannot be scanned")
-                return False
+                return False, None
 
             if (
                 ("LSB " not in output)
@@ -112,10 +112,10 @@ class VersionScanner:
                 and ("PKG-INFO: " not in output)
                 and ("METADATA: " not in output)
             ):
-                return False
+                return False, None
         # otherwise use python implementation of file
         elif not is_binary(filename):
-            return False
+            return False, None
 
         return True, output
 
@@ -152,12 +152,9 @@ class VersionScanner:
             return None
 
         # check if it's an ELF binary file
-        try:
-            t, output = self.is_executable(filename)
-        except:
-            t = self.is_executable(filename)
-
-        if not t:
+        is_exec, output = self.is_executable(filename)
+        
+        if not is_exec:
             return None
 
         # parse binary file's strings

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -153,7 +153,7 @@ class VersionScanner:
 
         # check if it's an ELF binary file
         is_exec, output = self.is_executable(filename)
-        
+
         if not is_exec:
             return None
 


### PR DESCRIPTION
I've been trying to refactor this, but it keeps throwing me this error. I tried calling it `version_scanner.py` and it works fine,  but calling it in `helper_script.py` returns me this error: 

```
Downloads via (venv39_CVE_Binary_tool)
➜ python3 /mnt/d/git_stuff/cve-bin-tool/cve_bin_tool/helper_script.py libmatroska-1.5.0-1.el8.x86_64.rpm
Traceback (most recent call last):
  File "/mnt/d/git_stuff/cve-bin-tool/cve_bin_tool/helper_script.py", line 70, in extract_and_parse_file
    self.logger.warning(VersionScanner.is_executable(filepath))
AttributeError: type object 'VersionScanner' has no attribute 'is_executable'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/mnt/d/git_stuff/cve-bin-tool/cve_bin_tool/helper_script.py", line 324, in <module>
    main(filenames)
  File "/mnt/d/git_stuff/cve-bin-tool/cve_bin_tool/helper_script.py", line 290, in main
    binary_string_list_1 = hs.extract_and_parse_file(filenames[1])
  File "/mnt/d/git_stuff/cve-bin-tool/cve_bin_tool/helper_script.py", line 73, in extract_and_parse_file
    is_exec = VersionScanner.is_executable(filepath)
AttributeError: type object 'VersionScanner' has no attribute 'is_executable'

```