### PR TITLE
fix(security): Improve SQL in version_signature.py

### DIFF
--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -9,6 +9,10 @@ from datetime import datetime
 from cve_bin_tool.cvedb import DISK_LOCATION_DEFAULT
 
 
+class InvalidVersionSignatureTable(ValueError):
+    """Raised when an invalid table name is given to version_signature"""
+
+
 class VersionSignatureDb:
     """Methods for version signature data stored in sqlite"""
 
@@ -16,7 +20,11 @@ class VersionSignatureDb:
         """Set location on disk data cache will reside.
         Also sets the table name and refresh duration
         """
+        if not table_name.isalnum():
+            # Basic validation here so we can safely ignore Bandit SQL warnings
+            raise InvalidVersionSignatureTable
         self.table_name = table_name
+        self.update_table_name = f"latest_update_{table_name}"
         self.mapping_function = mapping_function
         self.disk_location = DISK_LOCATION_DEFAULT
         self.duration = duration
@@ -58,16 +66,14 @@ class VersionSignatureDb:
         )
 
         self.cursor.execute(
-            "CREATE TABLE IF NOT EXISTS {} (datestamp DATETIME PRIMARY KEY)".format(
-                "latest_update_" + self.table_name
-            )
+            f"CREATE TABLE IF NOT EXISTS {self.update_table_name} (datestamp DATETIME PRIMARY KEY)"
         )
 
         update_required: bool = False
 
         datestamp = self.cursor.execute(
-            "SELECT * FROM {}".format("latest_update_" + self.table_name)
-        ).fetchone()
+            f"SELECT * FROM {self.update_table_name}"
+        ).fetchone() #  update_table_name validated in __init__
 
         if datestamp and type(datestamp) is int:
             # Updates if the difference between current time and the time of last update is greater than duration
@@ -79,22 +85,21 @@ class VersionSignatureDb:
 
         if datestamp is None or update_required:
             # if update is required or database is empty, fetch and insert data into database
-            self.cursor.execute("DELETE FROM ?", self.table_name)
-            self.cursor.execute("DELETE FROM ?", ("latest_update_" + self.table_name))
+            self.cursor.execute(f"DELETE FROM {self.table_name}")  # nosec
+            self.cursor.execute(f"DELETE FROM {self.update_table_name}")  # nosec
             self.cursor.execute(
-                "INSERT INTO ? VALUES (?)",
-                (
-                    ("latest_update_" + self.table_name),
-                    time.time(),
-                ),
+                f"INSERT INTO {self.update_table_name} VALUES (?)",
+                (time.time(),),
             )
 
             for mapping in self.mapping_function():
                 self.cursor.execute(
-                    "INSERT INTO ? (version, sourceId) VALUES (?, ?)",
-                    (self.table_name, mapping[0], mapping[1]),
+                    f"INSERT INTO {self.table_name} (version, sourceId) VALUES (?, ?)",
+                    (mapping[0], mapping[1]),
                 )
 
-        data = self.cursor.execute("SELECT * FROM ?", self.table_name).fetchall()
+        data = self.cursor.execute(
+            f"SELECT * FROM {self.table_name}"
+        ).fetchall()  # table_name validated in __init__
         self.conn.commit()
         return data

--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -73,7 +73,7 @@ class VersionSignatureDb:
 
         datestamp = self.cursor.execute(
             f"SELECT * FROM {self.update_table_name}"
-        ).fetchone() #  update_table_name validated in __init__
+        ).fetchone()  #  update_table_name validated in __init__
 
         if datestamp and type(datestamp) is int:
             # Updates if the difference between current time and the time of last update is greater than duration

--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -22,7 +22,7 @@ class VersionSignatureDb:
         """
         if not table_name.isalnum():
             # Basic validation here so we can safely ignore Bandit SQL warnings
-            raise InvalidVersionSignatureTable
+            raise InvalidVersionSignatureTable(repr(table_name))
         self.table_name = table_name
         self.update_table_name = f"latest_update_{table_name}"
         self.mapping_function = mapping_function

--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -54,9 +54,7 @@ class VersionSignatureDb:
         the data after the specified refresh duration
         """
         self.cursor.execute(
-            "CREATE TABLE IF NOT EXISTS {}(version TEXT , sourceId TEXT PRIMARY KEY)".format(
-                self.table_name
-            )
+            f"CREATE TABLE IF NOT EXISTS {self.table_name}(version TEXT , sourceId TEXT PRIMARY KEY)"
         )
 
         self.cursor.execute(
@@ -81,23 +79,22 @@ class VersionSignatureDb:
 
         if datestamp is None or update_required:
             # if update is required or database is empty, fetch and insert data into database
-            self.cursor.execute(f"DELETE FROM {self.table_name}")
+            self.cursor.execute("DELETE FROM ?", self.table_name)
+            self.cursor.execute("DELETE FROM ?", ("latest_update_" + self.table_name))
             self.cursor.execute(
-                "DELETE FROM {}".format("latest_update_" + self.table_name)
-            )
-            self.cursor.execute(
-                "INSERT INTO {} VALUES (?)".format("latest_update_" + self.table_name),
-                (time.time(),),
+                "INSERT INTO ? VALUES (?)",
+                (
+                    ("latest_update_" + self.table_name),
+                    time.time(),
+                ),
             )
 
             for mapping in self.mapping_function():
                 self.cursor.execute(
-                    "INSERT INTO {} (version, sourceId) VALUES (?, ?)".format(
-                        self.table_name
-                    ),
-                    (mapping[0], mapping[1]),
+                    "INSERT INTO ? (version, sourceId) VALUES (?, ?)",
+                    (self.table_name, mapping[0], mapping[1]),
                 )
 
-        data = self.cursor.execute(f"SELECT * FROM {self.table_name}").fetchall()
+        data = self.cursor.execute("SELECT * FROM ?", self.table_name).fetchall()
         self.conn.commit()
         return data


### PR DESCRIPTION
* improves version_signature.py to align with bandit's guidance
* fixes #1229

You can't use bound parameters for things like table names that aren't technically parameters in sqlite3, but Bandit throws errors due to the string construction in queries.  Added some basic input validation into the init function and marked lines for Bandit.  Because bandit doesn't deal well with multi-lines with `nosec` comments, I've added descriptive comments to some select statements instead of the `# nosec` line that would make the line disappear from future runs of Bandit.

Signed-off-by: Terri Oda <terri.oda@intel.com>