### PR TITLE
test: change way pytest is run in CI

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       longTests:
-        description: 'Set true to run long tests manually'     
+        description: 'Set true to run long tests manually'
         required: false
         default: 'false'
 
@@ -36,7 +36,7 @@ jobs:
         with:
             configuration: --profile black --check-only
             requirementsFiles: "requirements.txt doc/requirements.txt"
-      
+
   check:
     name: Black check
     runs-on: ubuntu-latest
@@ -131,23 +131,9 @@ jobs:
         run: |
           python -m pip install -e .
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
-      - name: Run Synchronous test
+      - name: Run pytest
         run: >
-          pytest -v
-          test/test_json.py
-          test/test_scanner.py
-          test/test_checkers.py
-          test/test_file.py
-          test/test_strings.py
-          test/test_input_engine.py
-          test/test_output_engine.py
-          test/test_util.py
-          test/test_cvedb.py
-          test/test_cli.py
-          test/test_extractor.py
-          test/test_condensed_downloads.py
-          test/test_package_list_parser.py
-          test/test_merge.py
+          pytest -v -n 4
 
   long_tests:
     name: Long tests on python3.8
@@ -201,26 +187,9 @@ jobs:
         run: |
           python -m pip install -e .
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
-      - name: Run parallel test
+      - name: Run pytest
         run: >
-          pytest --cov --cov-append -n 4 -v
-          test/test_json.py
-          test/test_scanner.py
-          test/test_checkers.py
-          test/test_extractor.py
-          test/test_file.py
-          test/test_strings.py
-          test/test_input_engine.py
-          test/test_output_engine.py
-          test/test_util.py
-          test/test_condensed_downloads.py
-          test/test_package_list_parser.py
-          test/test_merge.py
-      - name: Run Synchronous test
-        run: >
-          pytest -v --cov --cov-append --cov-report=xml
-          test/test_cvedb.py
-          test/test_cli.py
+          pytest --cov --cov-append -n 4 -v --cov-report=xml
       - name: upload code coverage to codecov
         uses: codecov/codecov-action@v1
         with:
@@ -269,27 +238,9 @@ jobs:
         run: |
           python -m pip install -e .
           python -m cve_bin_tool.cli test/assets
-      - name: Run parallel test
+      - name: Run pytest
         run: >
           pytest -n 4 -v
-          test/test_json.py
-          test/test_scanner.py
-          test/test_checkers.py
-          test/test_extractor.py
-          test/test_file.py
-          test/test_strings.py
-          test/test_input_engine.py
-          test/test_output_engine.py
-          test/test_util.py
-          test/test_condensed_downloads.py
-          test/test_async_utils.py
-          test/test_package_list_parser.py
-          test/test_merge.py
-      - name: Run Synchronous test
-        run: >
-          pytest -v
-          test/test_cvedb.py
-          test/test_cli.py
 
   cve_scan:
     name: CVE Scan on dependencies

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -133,7 +133,7 @@ jobs:
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py
+          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.txt --ignore=test/test_helper_script.py --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v
@@ -194,7 +194,7 @@ jobs:
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest ---cov --cov-append -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py
+          pytest --cov --cov-append -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.txt --ignore=test/test_helper_script.py --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v --cov --cov-append --cov-report=xml
@@ -250,7 +250,7 @@ jobs:
           python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py
+          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.txt --ignore=test/test_helper_script.py --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -133,7 +133,12 @@ jobs:
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.py --ignore=test/test_helper_script.py --ignore=test/test_config.py
+          pytest -n 4 -v
+          --ignore=test/test_cli.py
+          --ignore=test/test_cvedb.py
+          --ignore=test/test_requirements.py
+          --ignore=test/test_helper_script.py
+          --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v
@@ -194,12 +199,17 @@ jobs:
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest --cov --cov-append -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.py --ignore=test/test_helper_script.py --ignore=test/test_config.py
+          pytest --cov --cov-append -n 4 -v
+          --ignore=test/test_cli.py
+          --ignore=test/test_cvedb.py
+          --ignore=test/test_requirements.py
+          --ignore=test/test_helper_script.py
+          --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v --cov --cov-append --cov-report=xml
-          test/test_cvedb.py
           test/test_cli.py
+          test/test_cvedb.py
       - name: upload code coverage to codecov
         uses: codecov/codecov-action@v1
         with:
@@ -250,7 +260,12 @@ jobs:
           python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.py --ignore=test/test_helper_script.py --ignore=test/test_config.py
+          pytest -n 4 -v
+          --ignore=test/test_cli.py
+          --ignore=test/test_cvedb.py
+          --ignore=test/test_requirements.py
+          --ignore=test/test_helper_script.py
+          --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -137,7 +137,6 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
-          --ignore=test/test_helper_script.py
           --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
@@ -203,7 +202,6 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
-          --ignore=test/test_helper_script.py
           --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
@@ -264,7 +262,6 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
-          --ignore=test/test_helper_script.py
           --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -133,7 +133,7 @@ jobs:
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.txt --ignore=test/test_helper_script.py --ignore=test/test_config.py
+          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.py --ignore=test/test_helper_script.py --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v
@@ -194,7 +194,7 @@ jobs:
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest --cov --cov-append -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.txt --ignore=test/test_helper_script.py --ignore=test/test_config.py
+          pytest --cov --cov-append -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.py --ignore=test/test_helper_script.py --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v --cov --cov-append --cov-report=xml
@@ -250,7 +250,7 @@ jobs:
           python -m cve_bin_tool.cli test/assets
       - name: Run async tests
         run: >
-          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.txt --ignore=test/test_helper_script.py --ignore=test/test_config.py
+          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py --ignore=test/test_requirements.py --ignore=test/test_helper_script.py --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >
           pytest -v

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -131,9 +131,14 @@ jobs:
         run: |
           python -m pip install -e .
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
-      - name: Run pytest
+      - name: Run async tests
         run: >
-          pytest -v -n 4
+          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py
+      - name: Run synchronous tests
+        run: >
+          pytest -v
+          test/test_cli.py
+          test/test_cvedb.py
 
   long_tests:
     name: Long tests on python3.8
@@ -187,9 +192,14 @@ jobs:
         run: |
           python -m pip install -e .
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
-      - name: Run pytest
+      - name: Run async tests
         run: >
-          pytest --cov --cov-append -n 4 -v --cov-report=xml
+          pytest ---cov --cov-append -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py
+      - name: Run synchronous tests
+        run: >
+          pytest -v --cov --cov-append --cov-report=xml
+          test/test_cvedb.py
+          test/test_cli.py
       - name: upload code coverage to codecov
         uses: codecov/codecov-action@v1
         with:
@@ -238,9 +248,14 @@ jobs:
         run: |
           python -m pip install -e .
           python -m cve_bin_tool.cli test/assets
-      - name: Run pytest
+      - name: Run async tests
         run: >
-          pytest -n 4 -v
+          pytest -n 4 -v --ignore=test/test_cli.py --ignore=test/test_cvedb.py
+      - name: Run synchronous tests
+        run: >
+          pytest -v
+          test/test_cli.py
+          test/test_cvedb.py
 
   cve_scan:
     name: CVE Scan on dependencies

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -262,6 +262,7 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
+          --ignore=test/test_helper_script.py
           --ignore=test/test_config.py
       - name: Run synchronous tests
         run: >


### PR DESCRIPTION
fixes: #1159

This switches the way we're running tests so that it does a full pytest gather for the async tests (minus a few files known to cause rate limiting issues). This will run a few tests that were not previously being run, and will help us so that new test files no longer need to be added manually to CI before they will run.