### PR TITLE
fix: add update_egg function to test_checker

### DIFF
--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -8,6 +8,8 @@ import pkg_resources
 import pytest
 
 from cve_bin_tool.checkers import Checker, VendorProductPair
+from cve_bin_tool.egg_updater import IS_DEVELOP, update_egg
+from cve_bin_tool.log import LOGGER
 
 Pattern = type(re.compile("", 0))
 
@@ -40,6 +42,14 @@ class TestCheckerClass:
 class TestCheckerVersionParser:
     """Run a series of tests directly against individual checkers.
     This is a companion to the tests in TestScanner."""
+
+    @classmethod
+    def setup_class(cls):
+        """Initialize egg so all checkers can be found"""
+        # Update egg if installed in development mode
+        if IS_DEVELOP():
+            LOGGER.info("Updating egg_info")
+            update_egg()
 
     @pytest.mark.parametrize(
         "checker_name, file_name, expected_results",


### PR DESCRIPTION
* fixes #708

This should prevent instances where checker tests fail after a new checker is added.

Signed-off-by: Terri Oda <terri.oda@intel.com>