### PR TITLE
refactor: flake8 code cleanup

### DIFF
--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -144,7 +144,7 @@ class CheckerMetaClass(type):
         # Validate that vendor product pair is in lowercase
         for items in cls.VENDOR_PRODUCT:
             for vp in items:
-                if vp.islower() != True:
+                if not vp.islower():
                     raise InvalidCheckerError(
                         f"Checker {name} has a VENDOR_PRODUCT string that is not lowercase"
                     )

--- a/cve_bin_tool/checkers/glibc.py
+++ b/cve_bin_tool/checkers/glibc.py
@@ -71,6 +71,6 @@ class GlibcChecker(Checker):
 
 """
 Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it 
+The reason behind this is that these might depend on who packages the file (like it
 might work on fedora but not on ubuntu)
 """

--- a/cve_bin_tool/checkers/nessus.py
+++ b/cve_bin_tool/checkers/nessus.py
@@ -28,6 +28,6 @@ class NessusChecker(Checker):
 
 """
 Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it 
+The reason behind this is that these might depend on who packages the file (like it
 might work on fedora but not on ubuntu)
 """

--- a/cve_bin_tool/checkers/polarssl_fedora.py
+++ b/cve_bin_tool/checkers/polarssl_fedora.py
@@ -25,6 +25,6 @@ class PolarsslFedoraChecker(Checker):
 
 """
 Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it 
+The reason behind this is that these might depend on who packages the file (like it
 might work on fedora but not on ubuntu)
 """

--- a/cve_bin_tool/checkers/samba.py
+++ b/cve_bin_tool/checkers/samba.py
@@ -9,9 +9,8 @@ https://www.cvedetails.com/product/171/Samba-Samba.html?vendor_id=102
 
 https://www.samba.org/~ab/output/htmldocs/Samba3-HOWTO/compiling.html also
 lists "winbindd" and "nmbd" as necessary to configure in startup along with smbd.
-But these files do not have the strings which match the signatures in regex. 
-That is why they have not been added in FILENAME_PATTERNS. 
-
+But these files do not have the strings which match the signatures in regex.
+That is why they have not been added in FILENAME_PATTERNS.
 """
 from cve_bin_tool.checkers import Checker
 

--- a/cve_bin_tool/checkers/sqlite.py
+++ b/cve_bin_tool/checkers/sqlite.py
@@ -103,6 +103,6 @@ class SqliteChecker(Checker):
 
 """
 Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it 
+The reason behind this is that these might depend on who packages the file (like it
 might work on fedora but not on ubuntu)
 """

--- a/cve_bin_tool/checkers/systemd.py
+++ b/cve_bin_tool/checkers/systemd.py
@@ -35,7 +35,7 @@ class SystemdChecker(Checker):
 
     """
     Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-    The reason behind this is that these might depend on who packages the file (like it 
+    The reason behind this is that these might depend on who packages the file (like it
     might work on fedora but not on ubuntu)
     """
 

--- a/cve_bin_tool/checkers/zlib.py
+++ b/cve_bin_tool/checkers/zlib.py
@@ -35,6 +35,6 @@ class ZlibChecker(Checker):
 
 """
 Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it 
+The reason behind this is that these might depend on who packages the file (like it
 might work on fedora but not on ubuntu)
 """

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -350,7 +350,7 @@ def main(argv=None):
     # Output validation
     if not args["append"] and args["tag"]:
         LOGGER.warning(
-            f"Please specify -a --append to generate intermediate reports while using -t --tag"
+            "Please specify -a --append to generate intermediate reports while using -t --tag"
         )
 
     if args["directory"] and not os.path.exists(args["directory"]):

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#!/usr/bin/python3
 # pylint: disable=invalid-name
 
 """

--- a/cve_bin_tool/csv2cve.py
+++ b/cve_bin_tool/csv2cve.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#!/usr/bin/python3
 import os
 import sys
 

--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -175,10 +175,10 @@ class CVEScanner:
 
                 query = f"""
                 SELECT CVE_number, severity, description, score, cvss_version, cvss_vector
-		FROM cve_severity
-		WHERE CVE_number IN ({",".join(["?"] * number_of_cves)}) AND score >= ?
-		ORDER BY CVE_number
-		"""
+                FROM cve_severity
+                WHERE CVE_number IN ({",".join(["?"] * number_of_cves)}) AND score >= ?
+                ORDER BY CVE_number
+                """
                 # Add score parameter to tuple listing CVEs to pass to query
                 result = self.cursor.execute(query, cve_list[start:end] + [self.score])
                 start = end

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -431,7 +431,7 @@ class CVEDB:
             description,
             score,
             cvss_version,
-            cvss_vector			
+            cvss_vector
         )
         VALUES (?, ?, ?, ?, ?, ?)
         """
@@ -727,7 +727,7 @@ class CVEDB:
     def rollback_cache_backup(self):
         """Rollback the cachedir backup in case anything fails"""
         if os.path.exists(os.path.join(self.backup_cachedir, DBNAME)):
-            self.LOGGER.info(f"Rolling back the cache to its previous state")
+            self.LOGGER.info("Rolling back the cache to its previous state")
             if os.path.exists(self.cachedir):
                 shutil.rmtree(self.cachedir)
             shutil.move(self.backup_cachedir, self.cachedir)

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -175,7 +175,7 @@ class HelperScript:
         cursor = self.connection.cursor()
 
         # finding out all distinct (vendor, product) pairs with the help of product_name
-        query = f"""
+        query = """
             SELECT distinct vendor, product FROM cve_range
             WHERE product=(:product);
         """
@@ -189,7 +189,7 @@ class HelperScript:
             if len(data) != 1:
                 self.logger.warning(
                     textwrap.dedent(
-                        f"""
+                        """
                             ============================================
                             Multiple ("vendor", "product") pairs found.
                             Please manually select the appropriate pair.
@@ -213,7 +213,7 @@ class HelperScript:
                         textwrap.dedent(
                             f"""
                                 =================================================================
-                                No match was found for "{self.product}" in database. 
+                                No match was found for "{self.product}" in database.
                                 Please check your file or try specifying the "product_name" also.
                                 =================================================================
                             """
@@ -246,7 +246,7 @@ class HelperScript:
 
         """
         Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-        The reason behind this is that these might depend on who packages the file (like it 
+        The reason behind this is that these might depend on who packages the file (like it
         might work on fedora but not on ubuntu)
         """
 

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -162,7 +162,7 @@ class HelperScript:
             )
             return product_name, version_number
         else:
-            ### raise error for unknown archive types
+            # raise error for unknown archive types
             with ErrorHandler(mode=ErrorMode.NoTrace, logger=self.logger):
                 raise UnknownArchiveType(filename)
 
@@ -208,7 +208,7 @@ class HelperScript:
                     )
                     return self.find_vendor_product()
                 else:
-                    ### raise error and ask for product_name
+                    # raise error and ask for product_name
                     self.logger.warning(
                         textwrap.dedent(
                             f"""
@@ -306,7 +306,7 @@ if __name__ == "__main__":
     # accepting arguments
     args = sys.argv
 
-    ### raise error if no file given
+    # raise error if no file given
     if len(args) == 1:
         with ErrorHandler(mode=ErrorMode.NoTrace, logger=LOGGER):
             raise InsufficientArgs("Atleast 1 input file is required")

--- a/cve_bin_tool/output_engine/pdfbuilder.py
+++ b/cve_bin_tool/output_engine/pdfbuilder.py
@@ -243,7 +243,7 @@ class PDFBuilder:
         # Add row to table
         if self.table_ident == ident:
             self.table_data.append(self.validatedata(data))
-            if style != None:
+            if style is not None:
                 for s in style:
                     # Only take first 4 parameters in each style setting
                     self.table_style.add(s[0], s[1], s[2], s[3])

--- a/cve_bin_tool/package_list_parser/__init__.py
+++ b/cve_bin_tool/package_list_parser/__init__.py
@@ -186,7 +186,7 @@ class PackageListParser:
             if distro.id() in DEB_DISTROS:
                 # Simulate installation on Debian based system using apt-get to check if the file is valid
                 output = run(
-                    [f"xargs", "-a", input_file, "apt-get", "install", "-s"],
+                    ["xargs", "-a", input_file, "apt-get", "install", "-s"],
                     stderr=PIPE,
                     stdout=PIPE,
                 )
@@ -198,7 +198,7 @@ class PackageListParser:
                         )
             elif distro.id() in RPM_DISTROS:
                 output = run(
-                    [f"xargs", "-a", input_file, "rpm", "-qi"],
+                    ["xargs", "-a", input_file, "rpm", "-qi"],
                     stderr=PIPE,
                     stdout=PIPE,
                 )
@@ -213,7 +213,7 @@ class PackageListParser:
                         )
             elif distro.id() in PACMAN_DISTROS:
                 output = run(
-                    [f"xargs", "-a", input_file, "pacman", "-Qk"],
+                    ["xargs", "-a", input_file, "pacman", "-Qk"],
                     stderr=PIPE,
                     stdout=PIPE,
                 )

--- a/cve_bin_tool/package_list_parser/vendor_fetch.py
+++ b/cve_bin_tool/package_list_parser/vendor_fetch.py
@@ -21,7 +21,7 @@ class VendorFetch:
         vendor_package_pairs = []
         query = """
         SELECT DISTINCT vendor FROM cve_range
-        WHERE product=? 
+        WHERE product=?
         """
         # For python package checkers we don't need the progress bar running
         if type(package_names) != list:

--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -1,8 +1,6 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#!/usr/bin/python3
-
 """
 These are the customized strings and file classes, by doing this
 the tool is able to support other operating systems like Windows

--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -50,7 +50,7 @@ def check_latest_version():
         -------------------------- Can't check for the latest version ---------------------------
         warning: unable to access 'https://pypi.org/pypi/{name}'
         Exception details: {error}
-        Please make sure you have a working internet connection or try again later. 
+        Please make sure you have a working internet connection or try again later.
         """
             )
         )

--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -73,7 +73,7 @@ class VersionSignatureDb:
 
         datestamp = self.cursor.execute(
             f"SELECT * FROM {self.update_table_name}"
-        ).fetchone()  #  update_table_name validated in __init__
+        ).fetchone()  # update_table_name validated in __init__
 
         if datestamp and type(datestamp) is int:
             # Updates if the difference between current time and the time of last update is greater than duration

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -15,7 +15,6 @@
 #
 import ast
 import os
-import sys
 
 # -- Project information -----------------------------------------------------
 with open(os.path.join(os.path.abspath(".."), "cve_bin_tool", "version.py")) as f:

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#!python
 import re
 
 import pkg_resources

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,7 +4,6 @@
 """
 CVE-bin-tool CLI tests
 """
-import json
 import logging
 import os
 import tempfile

--- a/test/test_cvedb.py
+++ b/test/test_cvedb.py
@@ -1,12 +1,9 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import asyncio
 import datetime
 import shutil
-import sys
 import tempfile
-from test.utils import event_loop
 
 import aiohttp
 import pytest

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -10,7 +10,7 @@ import tempfile
 import unittest
 import unittest.mock
 from io import BytesIO
-from test.utils import CURL_7_20_0_URL, TMUX_DEB, download_file, event_loop
+from test.utils import CURL_7_20_0_URL, TMUX_DEB, download_file
 from zipfile import ZipFile, ZipInfo
 
 import pytest

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -5,7 +5,6 @@
 CVE-bin-tool file tests
 """
 import os
-from test.utils import event_loop
 
 import pytest
 

--- a/test/test_helper_script.py
+++ b/test/test_helper_script.py
@@ -3,7 +3,6 @@
 
 import pytest
 
-from cve_bin_tool.error_handler import UnknownArchiveType
 from cve_bin_tool.helper_script import HelperScript
 
 

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-#!/usr/bin/python
 """ Validates the NIST data feed
 1. Against their schema.
 This uses the schemas mentioned here: https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -56,7 +56,7 @@ class TestMergeReports:
             merge_files=filepaths, error_mode=ErrorMode.FullTrace
         )
         with pytest.raises(exception):
-            path = merged_cves.merge_intermediate()
+            merged_cves.merge_intermediate()
 
     @pytest.mark.parametrize(
         "filepaths,missing_fields",
@@ -76,7 +76,7 @@ class TestMergeReports:
             merge_files=filepaths, error_mode=ErrorMode.FullTrace
         )
         with pytest.raises(MissingFieldsError) as exc:
-            merged = merged_cves.merge_intermediate()
+            merged_cves.merge_intermediate()
         match = self.MISSING_FIELD_REGEX.search(exc.value.args[0])
         raised_fields = match.group(1)
 

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -115,4 +115,4 @@ class TestMergeReports:
         )
         merge_cve_scanner = merged_cves.merge_intermediate()
 
-        assert isinstance(merge_cve_scanner, CVEScanner) == True
+        assert isinstance(merge_cve_scanner, CVEScanner)

--- a/test/test_nvd_api.py
+++ b/test/test_nvd_api.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import asyncio
 import shutil
 import tempfile
 from datetime import datetime, timedelta

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -197,7 +197,7 @@ class TestOutputEngine(unittest.TestCase):
             expected_output = report.read()
             report.close()
 
-        ## Changing some dynamic data in html reports
+        # Changing some dynamic data in html reports
         # 1. date
         # 2. div IDs (dynamic ones)
 
@@ -206,13 +206,13 @@ class TestOutputEngine(unittest.TestCase):
 
         result_lines = result.splitlines()
 
-        ## date
+        # date
         # date is replaced by {{date}} in the result
         # The respective change is also made in the sample report
 
         result = result.replace(datetime.now().strftime("%d %b %Y"), r"{{date}}")
 
-        ## div IDs
+        # div IDs
         # div IDs, in the dashboard, which were created dynamically is being replaced by their respective line numbers
         # The respective changes are also made in the sample report
 

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -5,7 +5,6 @@
 CVE-bin-tool OutputEngine tests
 """
 import csv
-import datetime
 import json
 import logging
 import os

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -5,7 +5,6 @@
 CVE-bin-tool Strings tests
 """
 import os
-from test.utils import event_loop
 
 import pytest
 

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,12 +4,9 @@
 """
 Resource definitions and helper utilities for tests.
 """
-import asyncio
 import os
 import shutil
-import sys
 import tempfile
-import unittest
 from urllib.request import urlopen
 
 import pytest


### PR DESCRIPTION
In preparation for #1276.
One commit per one warning.
I can split it into multiple PRs if desired.

Some questions:
- this function is not used anywhere in the code, it was just imported in a bunch of files, 2e14650
https://github.com/intel/cve-bin-tool/blob/281cd76bb67540c4beadf7d46fd1db0b4638c517/test/utils.py#L56-L58
Delete it?
- in abbd852 I just discarded some local variables, but maybe you intended to test something, @imsahil007?
- some files had `#!/usr/bin/python3` at the top but BELOW the license so I removed those lines (can put them above license if needed?), ba4d9cc