### PR TITLE
ci: add flake8 to CI

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -46,22 +46,24 @@ jobs:
       - uses: actions/checkout@v2
       - uses: jpetrucciani/black-check@master
 
-  pyupgrade:
-    name: pyupgrade check
+  linting:
+    name: Linting
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        tool: ["pyupgrade", "flake8"]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-        with:
-          python-version: '3.x'
       - name: Install pre-commit
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade pre-commit
           pre-commit install
-      - name: Run pyupgrade
+      - name: Run ${{ matrix.tool }}
         run: |
-          pre-commit run pyupgrade --all-files
+          pre-commit run ${{ matrix.tool }} --all-files
 
   docs:
     name: Documentation

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,48 +11,13 @@ on:
         default: 'false'
 
 jobs:
-  isort:
-    name: Run isort
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.8
-      - name: Get cached Python packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade wheel setuptools
-          python -m pip install -r requirements.txt -r doc/requirements.txt
-          python -m pip install -r dev-requirements.txt
-      - uses: isort/isort-action@master
-        with:
-            configuration: --profile black --check-only
-            requirementsFiles: "requirements.txt doc/requirements.txt"
-
-  check:
-    name: Black check
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v2
-      - uses: jpetrucciani/black-check@master
-
   linting:
     name: Linting
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        tool: ["pyupgrade", "flake8"]
+        tool: ['isort', 'black', 'pyupgrade', 'flake8']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,0 @@
-[settings]
-profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,6 @@ repos:
     rev: 5.6.4
     hooks:
     - id: isort
-      args: ["--profile", "black"]
 
 -   repo: https://github.com/python/black
     rev: 20.8b1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,3 +15,8 @@ repos:
     hooks:
     - id: pyupgrade
       args: ["--py36-plus"]
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+    - id: flake8

--- a/cve_bin_tool/checkers/systemd.py
+++ b/cve_bin_tool/checkers/systemd.py
@@ -8,11 +8,9 @@ CVE checker for systemd
 https://www.cvedetails.com/product/38088/Freedesktop-Systemd.html?vendor_id=7971
 """
 
-from re import DOTALL, MULTILINE, compile, search
+from re import DOTALL, MULTILINE, compile
 
 from cve_bin_tool.checkers import Checker
-
-from ..util import regex_find
 
 
 class SystemdChecker(Checker):

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,4 @@
 black==20.8b1
 isort
 pre-commit
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,7 @@
+[isort]
+profile = black
+
+[flake8]
+exclude = build
+max-line-length = 88
+extend-ignore = E203, E501


### PR DESCRIPTION
Fixes #1276

1. GitHub workflow was changed a bit, instead of another job running flake8 through pre-commit I have created a matrix linting job that will run all tools. It looks pretty!
![image](https://user-images.githubusercontent.com/12860284/127785829-a3339529-9564-4dfa-82c9-8570d2bb72cf.png)
[Link to run](https://github.com/Molkree/cve-bin-tool/actions/runs/1088163557)
2. I've added flake8 to dev-requirements.txt unpinned. The only pinned tool there is Black, if needed I can pin to the same version as in the pre-commit config.
3. I've put both isort and flake8 configs in setup.cfg even though isort "prefers" .isort.cfg->pyproject.toml->setup.cfg. Unfortunately, flake8 doesn't support pyproject.toml and I didn't want to split configs into two files so we are stuck with "old" setup.cfg. I can change it if desired.

P.S. Note about isort: in #1146 I have added dependencies installation per GitHub Action [docs](https://github.com/isort/isort-action#requirementsfiles), however now I think that it is not needed. pre-commit hook doesn't pass any dependency files to the isort, it just uses existing config (it only specifies Black profile) and there were no changes. I think it is just the remnant of pre-v5 isort ([details here](https://pycqa.github.io/isort/docs/major_releases/introducing_isort_5.html#:~:text=Consistent%20behavior%20across%20all%20environments))

~~P.P.S. flake8 check will fail until #1294 is merged, I'll keep it as a draft for now and rebase later.~~