### PR TITLE
fix(scanner): crash when scanning a METADATA file w/o appropriate data

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -184,7 +184,7 @@ class VersionScanner:
 
                 yield ProductInfo(vendor, product, version), file_path
 
-        # There are packages with a file METADATA in them but contains data different from what the tool expects
+        # There are packages with a METADATA file in them containing different data from what the tool expects
         except AttributeError:
             self.logger.debug(f"{filename} is an invalid METADATA/PKG-INFO")
 

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -169,19 +169,24 @@ class VersionScanner:
         There are no actual checkers.
         The ProductInfo is computed without the help of any checkers from PKG-INFO or METADATA.
         """
-        product = search(compile(r"^Name: (.+)$", MULTILINE), lines).group(1)
-        version = search(compile(r"^Version: (.+)$", MULTILINE), lines).group(1)
+        try:
+            product = search(compile(r"^Name: (.+)$", MULTILINE), lines).group(1)
+            version = search(compile(r"^Version: (.+)$", MULTILINE), lines).group(1)
 
-        with VendorFetch() as vendor_fetch:
-            vendor_package_pair = vendor_fetch.get_vendor_product_pairs(product)
+            with VendorFetch() as vendor_fetch:
+                vendor_package_pair = vendor_fetch.get_vendor_product_pairs(product)
 
-        if vendor_package_pair != []:
-            vendor = vendor_package_pair[0]["vendor"]
-            file_path = "".join(self.file_stack)
+            if vendor_package_pair != []:
+                vendor = vendor_package_pair[0]["vendor"]
+                file_path = "".join(self.file_stack)
 
-            self.logger.info(f"{file_path} is {product} {version}")
+                self.logger.info(f"{file_path} is {product} {version}")
 
-            yield ProductInfo(vendor, product, version), file_path
+                yield ProductInfo(vendor, product, version), file_path
+
+        # There are packages with a file METADATA in them but contains data different from what the tool expects
+        except AttributeError:
+            self.logger.debug(f"{filename} is an invalid METADATA/PKG-INFO")
 
         self.logger.debug(f"Done scanning file: {filename}")
 


### PR DESCRIPTION
Fix #1300 