### PR TITLE
ci: autoupdate pre-commit config

### DIFF
--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -1,0 +1,38 @@
+# This is a scheduled workflow to keep pre-commit config up to date
+
+name: Update pre-commit config
+
+on:
+  schedule:
+    # Runs at 00:00 UTC on the 1st of every month
+    - cron: '0 0 1 * *'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade pre-commit
+          pre-commit install
+
+      - name: Update pre-commit config
+        run: |
+          pre-commit autoupdate
+          pre-commit uninstall
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "chore: update pre-commit config"
+          title: "chore: update pre-commit config"
+          branch: chore-precommit-config
+          delete-branch: true
+          author: GitHub <noreply@github.com>


### PR DESCRIPTION
Per @terriko https://github.com/intel/cve-bin-tool/pull/1260#issuecomment-884447289:

> I can't authorize pre-commit.ci for this repo because it's managed by Intel, so let's focus on getting things working in github actions as is for now.

If pre-commit.ci is not an option (yet?), this workflow can be used to autoupdate pre-commit config.

Here is an [example](https://github.com/Molkree/cve-bin-tool/pull/9) of generated PR.

The body of the PR can be tweaked as well, just don't know if you want something more meaningful.

P.S. If pre-commit hooks will be kept up to date with this workflow it would probably make more sense to unpin Black in `dev-requirements.txt`
https://github.com/intel/cve-bin-tool/blob/281cd76bb67540c4beadf7d46fd1db0b4638c517/dev-requirements.txt#L1