### PR TITLE
lint: remove unused BeautifulSoup import, fix black

### DIFF
--- a/test/test_nvd_api.py
+++ b/test/test_nvd_api.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 
 import aiohttp
 import pytest
-from bs4 import BeautifulSoup
 
 from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.nvd_api import NVD_API
@@ -63,7 +62,7 @@ class TestNVD_API:
 
     @pytest.mark.asyncio
     async def test_api_cve_count(self):
-        """Test to match the totalResults and the total CVE count on NVD """
+        """Test to match the totalResults and the total CVE count on NVD"""
 
         connector = aiohttp.TCPConnector()
         async with aiohttp.ClientSession(


### PR DESCRIPTION
This fixes the current linting errors from flake8 and black.  (Caused because of PRs merged before the updated CI rules went through.)