### PR TITLE
chore: Update dev version to 3.0.dev0

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -9,7 +9,7 @@ from packaging import version
 
 from cve_bin_tool.log import LOGGER
 
-VERSION: str = "2.2"
+VERSION: str = "3.0.dev0"
 
 
 def check_latest_version():


### PR DESCRIPTION
The 3.0 release is planned for after Google Summer of Code winds down in September, this bump reflects that the current main branch will eventually become the 3.0 release.