### PR TITLE
ci(experiment): add py3.9, move nvd to synchronous

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -61,7 +61,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.6, 3.7]
+        python: [3.6, 3.7, 3.9]
     timeout-minutes: 20
     env:
       ACTIONS: 1
@@ -105,11 +105,13 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
+          --ignore=test/test_nvd.py
       - name: Run synchronous tests
         run: >
           pytest -v
           test/test_cli.py
           test/test_cvedb.py
+          test/test_nvd.py
 
   long_tests:
     name: Long tests on python3.8
@@ -169,11 +171,13 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
+          --ignore=test/test_nvd.py
       - name: Run synchronous tests
         run: >
           pytest -v --cov --cov-append --cov-report=xml
           test/test_cli.py
           test/test_cvedb.py
+          test/test_nvd.py
       - name: upload code coverage to codecov
         uses: codecov/codecov-action@v1
         with:
@@ -229,11 +233,13 @@ jobs:
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
           --ignore=test/test_helper_script.py
+          --ignore=test/test_nvd.py
       - name: Run synchronous tests
         run: >
           pytest -v
           test/test_cli.py
           test/test_cvedb.py
+          test/test_nvd.py
 
   cve_scan:
     name: CVE Scan on dependencies


### PR DESCRIPTION
Quick experiment PR to see if we should add python 3.9 to our CI matrix, and if moving nvd to be done with the synchronous tests improves stability short-term while Sahil works on a more robust fix.