### PR TITLE
refactor: bad archive file tests

### DIFF
--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -31,7 +31,8 @@ BAD_FILE = dict()
 FILE_EXT = ["tar", "zip", "cab", "exe", "rpm", "deb"]
 for ext in FILE_EXT:
     BAD_FILE[ext] = os.path.join(
-        os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
+        os.path.abspath(os.path.dirname(__file__)),
+        "assets",
         "empty-file." + ext,
     )
 

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -26,30 +26,14 @@ CAB_TEST_FILE_PATH = os.path.join(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
     "cab-test-python3.8.cab",
 )
-BAD_EXE_FILE = os.path.join(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
-    "empty-file.exe",
-)
-BAD_ZIP_FILE = os.path.join(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
-    "empty-file.zip",
-)
-BAD_TAR_FILE = os.path.join(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
-    "empty-file.tar",
-)
-BAD_RPM_FILE = os.path.join(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
-    "empty-file.rpm",
-)
-BAD_DEB_FILE = os.path.join(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
-    "empty-file.deb",
-)
-BAD_CAB_FILE = os.path.join(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
-    "empty-file.cab",
-)
+
+BAD_FILE = dict()
+FILE_EXT = ["tar", "zip", "cab", "exe", "rpm", "deb"]
+for ext in FILE_EXT:
+    BAD_FILE[ext] = os.path.join(
+        os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets"),
+        "empty-file." + ext,
+    )
 
 
 class TestExtractorBase:
@@ -135,7 +119,7 @@ class TestExtractFileTar(TestExtractorBase):
     async def test_bad_tar(self):
         """Test handling of invalid tar files.  No errors should be raised."""
 
-        self.extract_files(BAD_TAR_FILE)
+        self.extract_files(BAD_FILE["tar"])
 
 
 class TestExtractFileRpm(TestExtractorBase):
@@ -173,7 +157,7 @@ class TestExtractFileRpm(TestExtractorBase):
     async def test_bad_rpm(self):
         """Test handling of invalid rpm files.  No errors should be raised."""
 
-        self.extract_files(BAD_RPM_FILE)
+        self.extract_files(BAD_FILE["rpm"])
 
 
 class TestExtractFileDeb(TestExtractorBase):
@@ -202,7 +186,7 @@ class TestExtractFileDeb(TestExtractorBase):
     async def test_bad_deb(self):
         """Test handling of invalid deb files.  No errors should be raised."""
 
-        self.extract_files(BAD_DEB_FILE)
+        self.extract_files(BAD_FILE["deb"])
 
 
 class TestExtractFileCab(TestExtractorBase):
@@ -232,7 +216,7 @@ class TestExtractFileCab(TestExtractorBase):
     async def test_bad_cab(self):
         """Test handling of invalid cab files.  No errors should be raised."""
 
-        self.extract_files(BAD_CAB_FILE)
+        self.extract_files(BAD_FILE["cab"])
 
 
 class TestExtractFileZip(TestExtractorBase):
@@ -271,5 +255,5 @@ class TestExtractFileZip(TestExtractorBase):
         Log messages differ for .exe and .zip and are tested in test_cli.py
         """
 
-        self.extract_files(BAD_EXE_FILE)
-        self.extract_files(BAD_ZIP_FILE)
+        self.extract_files(BAD_FILE["exe"])
+        self.extract_files(BAD_FILE["zip"])


### PR DESCRIPTION
fix #1325

Used global `BAD_FILE` dictionary to reduce the number of variables (`BAD_*_FILE`) 