### PR TITLE
fix(pdf): resolve reportlab table style index bug

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -240,7 +240,7 @@ def output_pdf(
                                 "TEXTCOLOR",
                                 (3, row),
                                 (4, row),
-                                severity_colour[cve.severity],
+                                severity_colour[cve.severity.upper()],
                             ),
                             ("FONT", (3, row), (4, row), "Helvetica-Bold"),
                         ],

--- a/cve_bin_tool/output_engine/pdfbuilder.py
+++ b/cve_bin_tool/output_engine/pdfbuilder.py
@@ -122,7 +122,7 @@ class PDFBuilder:
             ("INNERGRID", (0, 0), (-1, -1), 0.25, colors.black),
             ("BOX", (0, 0), (-1, -1), 0.25, colors.black),
             ("FONT", (0, 0), (-1, -1), "Helvetica", 12),
-            ("FONT", (0, 0), (5, 0), "Helvetica-Bold"),
+            ("FONT", (0, 0), (-1, 0), "Helvetica-Bold"),
         ]
     )
 


### PR DESCRIPTION
In #1326 PDF Builder is generating a list index out of range exception.
This might be due to the fact we are using a `(0,0) to (5, 0)` range. I have changed  5 to -1.
But I am still not sure whether this will work.
@anthonyharrison You might be interested in this.