### PR TITLE
ci: Add python 3.9 for short tests

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -66,7 +66,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: [3.6, 3.7]
+        python: [3.6, 3.7, 3.9]
     timeout-minutes: 20
     env:
       ACTIONS: 1


### PR DESCRIPTION
* fixes #1316

I'm making the executive decision to leave 3.8 as the python of choice for long tests because it looks like 3.8 is still default for Ubuntu 20.04 (the current LTS version).  No deeper thinking than that for the moment.