### PR TITLE
fix(nvd_api): nvd_api fetch results over 2000 limit

### DIFF
--- a/test/test_nvd_api.py
+++ b/test/test_nvd_api.py
@@ -27,6 +27,7 @@ class TestNVD_API:
         await nvd_api.get_nvd_params(
             time_of_last_update=(datetime.now() + timedelta(days=2))
         )
+        await nvd_api.get()
         assert nvd_api.total_results == 0 and nvd_api.all_cve_entries == []
 
     @pytest.mark.asyncio
@@ -36,6 +37,7 @@ class TestNVD_API:
         await nvd_api.get_nvd_params(
             time_of_last_update=datetime.now() - timedelta(days=2)
         )
+        await nvd_api.get()
         assert len(nvd_api.all_cve_entries) >= nvd_api.total_results
 
     @pytest.mark.asyncio


### PR DESCRIPTION
This will fix failing NVD REST API tests.