### PR TITLE
docs: add Python 3.9 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup_kwargs = dict(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],


### PR DESCRIPTION
I think Python 3.9 is officially supported now since it's being explicitly tested in CI.