### PR TITLE
chore: change comment about not detecting backported fixes

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -7,6 +7,9 @@ This tool scans for a number of common, vulnerable open source components
 (openssl, libpng, libxml2, expat and a few others) to let you know if your
 system includes common libraries with known vulnerabilities.  It emits a list
 of CVE numbers that may be relevant to your binary based on the versions.
+There is a flag to enable information about backported fixes for specific
+Linux distributions, but cve-bin-tool cannot detect backported fixes outside
+of those published lists.
 """
 
 import argparse

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -6,8 +6,7 @@
 This tool scans for a number of common, vulnerable open source components
 (openssl, libpng, libxml2, expat and a few others) to let you know if your
 system includes common libraries with known vulnerabilities.  It emits a list
-of CVE numbers that may be relevant to your binary based on the versions.  It
-cannot detect backported fixes.
+of CVE numbers that may be relevant to your binary based on the versions.
 """
 
 import argparse


### PR DESCRIPTION
We can detect backported fixes on Debian based distros now.