### PR TITLE
chore: Add # nosec comment for bandit

### DIFF
--- a/cve_bin_tool/available_fix/debian_cve_tracker.py
+++ b/cve_bin_tool/available_fix/debian_cve_tracker.py
@@ -91,7 +91,7 @@ def update_json():
     """Update the Debian CVE JSON file"""
 
     LOGGER.info("Updating Debian CVE JSON file for checking available fixes.")
-    response = request.urlopen(JSON_URL).read().decode("utf-8") #nosec - static url
+    response = request.urlopen(JSON_URL).read().decode("utf-8")  # nosec - static url
     response = loads(response)
     with open(DEB_CVE_JSON_PATH, "w") as debian_json:
         dump(response, debian_json, indent=4)


### PR DESCRIPTION
Bandit issues a warning regarding urlopen saying we should audit the url being opened.  This is a static url and it's been double-checked, so we can safely disable bandit's warning for this line of code.