### PR TITLE
ci: Add csv file for scanning js libraries we include

### DIFF
--- a/htmlrequirements.csv
+++ b/htmlrequirements.csv
@@ -1,0 +1,5 @@
+vendor,product,version
+getbootstrap,bootstrap,4.5.0
+jquery,jquery,3.6.0
+plotly,plotly.js,1.54.1
+plot,plotly,1.54.1


### PR DESCRIPTION
I just made this file to do a quick check on the .js libraries we include in cve binary tool.  This could probably be integrated into our automated scans in a future PR.  Unlike the other requirements.csv file, we do know the versions in advance, so it doesn't need the same framework for scanning.