### PR TITLE
Updated requirements.csv with valid vendors  #1403

### DIFF
--- a/requirements.csv
+++ b/requirements.csv
@@ -4,7 +4,7 @@ pocoo,jinja2
 aiohttp_project,aiohttp
 pyyaml,pyyaml
 reportlab,reportlab
-pytest,pytest_not_in_db
+pytest_not_in_db,pytest
 pytest_not_in_db,pytest-xdist
 pytest_not_in_db,pytest-cov
 pytest_not_in_db,pytest-asyncio


### PR DESCRIPTION
Fix #1403
UPDATET The vendor name of pytest to py from pytest_not_in_db