### PR TITLE
CI: Raise timeout limits

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -67,7 +67,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python: ['3.6', '3.7', '3.9', '3.10']
-    timeout-minutes: 20
+    timeout-minutes: 40
     env:
       ACTIONS: 1
       LONG_TESTS: 0
@@ -123,7 +123,7 @@ jobs:
   long_tests:
     name: Long tests on Python 3.8
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 90
     env:
       ACTIONS: 1
       LONG_TESTS: 1
@@ -202,7 +202,7 @@ jobs:
       matrix:
         os: [windows-latest]
         python: ['3.9', '3.10']
-    timeout-minutes: 20
+    timeout-minutes: 40
     env:
       ACTIONS: 1
       LONG_TESTS: 0
@@ -262,7 +262,7 @@ jobs:
   cve_scan:
     name: CVE Scan on dependencies
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       - name: Get Date
         id: get-date


### PR DESCRIPTION
Attempting to unstick our CI because it's hitting timeouts on the short tests.  We will also need to do some digging to find out if there's a slowdown caused by us and whether some tests need to be moved to long tests, but I'd like to up the limits for now to unstick existing PRs.

Signed-off-by: Terri Oda <terri.oda@intel.com>