### PR TITLE
test: skip NVD API tests

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -114,6 +114,7 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
+          --ignore=test/test_nvd_api.py
       - name: Run synchronous tests
         run: >
           pytest -v
@@ -182,6 +183,7 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
+          --ignore=test/test_nvd_api.py
       - name: Run synchronous tests
         run: >
           pytest -v --cov --cov-append --cov-report=xml
@@ -253,6 +255,7 @@ jobs:
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
           --ignore=test/test_helper_script.py
+          --ignore=test/test_nvd_api.py
       - name: Run synchronous tests
         run: >
           pytest -v


### PR DESCRIPTION
Another attempt to unstuck tests, seems like (almost) all NVD API tests are awaiting indefinitely. We will also need to do some digging to find out why it suddenly stopped working without any code changes.