### PR TITLE
fix!: Make error codes fit standard range

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -554,10 +554,19 @@ def main(argv=None):
                     )
                     fixes.check_available_fix()
 
-        # Use the number of products with known cves as error code
-        # as requested by folk planning to automate use of this script.
-        # If no cves found, then the program exits cleanly.
-        return cve_scanner.products_with_cve
+        # If no cves found, then the program exits cleanly (0 exit)
+        if cve_scanner.products_with_cve == 0:
+            return 0
+
+        # if some cves are found, return with exit code 1
+        # Previously this returned a number of CVEs found, but that can
+        # exceed expected return value range.
+        if cve_scanner.products_with_cve > 0:
+            return 1
+
+        # If somehow we got negative numbers of cves something has gone
+        # horribly wrong.  Since return code 2 is used by argparse, use 3
+        return 3
 
 
 if __name__ == "__main__":

--- a/cve_bin_tool/error_handler.py
+++ b/cve_bin_tool/error_handler.py
@@ -166,27 +166,31 @@ class ErrorHandler:
             return False
 
 
-# Exit codes for Exception. exit code -1 is reserved for unknown exceptions.
+# Exit codes for Exception.
+# Error code 1 is reserved to mean that cves were found
+# Error code 2 is reserved for argparse errors (default argparse behaviour)
+# Error code 3 is reserved for "we found negative cves" (should be impossible)
+# Error code 4-20 are reserved just in case
 ERROR_CODES = {
-    SystemExit: -2,
-    FileNotFoundError: -3,
-    InvalidCsvError: -4,
-    InvalidJsonError: -4,
-    EmptyTxtError: -4,
-    InvalidListError: -4,
-    MissingFieldsError: -5,
-    InsufficientArgs: -6,
-    EmptyCache: -7,
-    CVEDataForYearNotInCache: -8,
-    CVEDataForCurlVersionNotInCache: -9,
-    AttemptedToWriteOutsideCachedir: -10,
-    SHAMismatch: -11,
-    ExtractionFailed: -12,
-    UnknownArchiveType: -13,
-    UnknownConfigType: -14,
-    CVEDataMissing: -15,
-    InvalidCheckerError: -16,
-    NVDRateLimit: -17,
-    InvalidIntermediateJsonError: -18,
-    NVDServiceError: -19,
+    SystemExit: 2,
+    FileNotFoundError: 21,
+    InvalidCsvError: 22,
+    InvalidJsonError: 22,
+    EmptyTxtError: 22,
+    InvalidListError: 22,
+    MissingFieldsError: 23,
+    InsufficientArgs: 24,
+    EmptyCache: 25,
+    CVEDataForYearNotInCache: 26,
+    CVEDataForCurlVersionNotInCache: 27,
+    AttemptedToWriteOutsideCachedir: 28,
+    SHAMismatch: 29,
+    ExtractionFailed: 30,
+    UnknownArchiveType: 31,
+    UnknownConfigType: 32,
+    CVEDataMissing: 33,
+    InvalidCheckerError: 34,
+    NVDRateLimit: 35,
+    InvalidIntermediateJsonError: 36,
+    NVDServiceError: 37,
 }

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -88,37 +88,37 @@ class TestCLI(TempDirTest):
         """Test that the usage returns 0"""
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool"])
-        assert e.value.args[0] == -6
+        assert e.value.args[0] == 24
 
     def test_invalid_file_or_directory(self):
         """Test behaviour with an invalid file/directory"""
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "non-existant"])
-        assert e.value.args[0] == -3
+        assert e.value.args[0] == 21
 
     def test_invalid_parameter(self):
         """Test that invalid parmeters exit with expected error code.
-        ArgParse calls sys.exit(2) for all errors, we've overwritten to -2"""
+        ArgParse calls sys.exit(2) for all errors """
 
         # no directory specified
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param"])
-        assert e.value.args[0] == -2
+        assert e.value.args[0] == 2
 
         # bad parameter (but good directory)
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param", self.tempdir])
-        assert e.value.args[0] == -2
+        assert e.value.args[0] == 2
 
         # worse parameter
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param && cat hi", self.tempdir])
-        assert e.value.args[0] == -2
+        assert e.value.args[0] == 2
 
         # bad parameter after directory
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", self.tempdir, "--bad-param;cat hi"])
-        assert e.value.args[0] == -2
+        assert e.value.args[0] == 2
 
     @unittest.skipUnless(LONG_TESTS() > 0, "Skipping long tests")
     def test_update_flags(self):
@@ -136,7 +136,7 @@ class TestCLI(TempDirTest):
         )
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-u", "whatever", "-n", "json", self.tempdir])
-        assert e.value.args[0] == -2
+        assert e.value.args[0] == 2
 
     @staticmethod
     def check_exclude_log(caplog, exclude_path, checkers):
@@ -349,11 +349,11 @@ class TestCLI(TempDirTest):
         # Check command line parameters - wrong case
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-S", "HIGH", self.tempdir])
-        assert e.value.args[0] == -2
+        assert e.value.args[0] == 2
         # Check command line parameters - wrong option
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-S", "ALL", self.tempdir])
-        assert e.value.args[0] == -2
+        assert e.value.args[0] == 2
 
         my_test_filename = "sevtest.csv"
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -22,6 +22,7 @@ import pytest
 
 from cve_bin_tool.cli import main
 from cve_bin_tool.cvedb import DISK_LOCATION_DEFAULT
+from cve_bin_tool.error_handler import ERROR_CODES, InsufficientArgs
 from cve_bin_tool.extractor import Extractor
 from cve_bin_tool.version_scanner import VersionScanner
 
@@ -88,37 +89,37 @@ class TestCLI(TempDirTest):
         """Test that the usage returns 0"""
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool"])
-        assert e.value.args[0] == 24
+        assert e.value.args[0] == ERROR_CODES[InsufficientArgs]
 
     def test_invalid_file_or_directory(self):
         """Test behaviour with an invalid file/directory"""
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "non-existant"])
-        assert e.value.args[0] == 21
+        assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
 
     def test_invalid_parameter(self):
         """Test that invalid parmeters exit with expected error code.
-        ArgParse calls sys.exit(2) for all errors """
+        ArgParse calls sys.exit(2) for all errors"""
 
         # no directory specified
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param"])
-        assert e.value.args[0] == 2
+        assert e.value.args[0] == ERROR_CODES[SystemExit]
 
         # bad parameter (but good directory)
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param", self.tempdir])
-        assert e.value.args[0] == 2
+        assert e.value.args[0] == ERROR_CODES[SystemExit]
 
         # worse parameter
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param && cat hi", self.tempdir])
-        assert e.value.args[0] == 2
+        assert e.value.args[0] == ERROR_CODES[SystemExit]
 
         # bad parameter after directory
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", self.tempdir, "--bad-param;cat hi"])
-        assert e.value.args[0] == 2
+        assert e.value.args[0] == ERROR_CODES[SystemExit]
 
     @unittest.skipUnless(LONG_TESTS() > 0, "Skipping long tests")
     def test_update_flags(self):
@@ -136,7 +137,7 @@ class TestCLI(TempDirTest):
         )
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-u", "whatever", "-n", "json", self.tempdir])
-        assert e.value.args[0] == 2
+        assert e.value.args[0] == ERROR_CODES[SystemExit]
 
     @staticmethod
     def check_exclude_log(caplog, exclude_path, checkers):
@@ -349,11 +350,11 @@ class TestCLI(TempDirTest):
         # Check command line parameters - wrong case
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-S", "HIGH", self.tempdir])
-        assert e.value.args[0] == 2
+        assert e.value.args[0] == ERROR_CODES[SystemExit]
         # Check command line parameters - wrong option
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-S", "ALL", self.tempdir])
-        assert e.value.args[0] == 2
+        assert e.value.args[0] == ERROR_CODES[SystemExit]
 
         my_test_filename = "sevtest.csv"
 


### PR DESCRIPTION
* fixes #1135

Previously, cve-bin-tool returned the number of CVEs found, or negative
numbers for error codes.  Because error codes are expected to be in the
range 0-127 that could cause unexpected behaviours (particularly on
Windows) so this PR changes our error codes to be positive values.

error code 1 is reserved to indicate the cves were found
error codes 2+ indicate operational errors.

Signed-off-by: Terri Oda <terri@toybox.ca>
BREAKING CHANGE: Error codes