### PR TITLE
fix: bump binutils to v2.34-6ubuntu1.3 in package list parser test

### DIFF
--- a/test/test_package_list_parser.py
+++ b/test/test_package_list_parser.py
@@ -43,7 +43,7 @@ class TestPackageListParser:
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
             "paths": {""},
         },
-        ProductInfo(vendor="gnu*", product="binutils", version="2.34-6ubuntu1.1"): {
+        ProductInfo(vendor="gnu*", product="binutils", version="2.34-6ubuntu1.3"): {
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
             "paths": {""},
         },
@@ -119,7 +119,7 @@ class TestPackageListParser:
                 "apt-get",
                 "install",
                 "bash=5.0-6ubuntu1.1",
-                "binutils=2.34-6ubuntu1.1",
+                "binutils=2.34-6ubuntu1.3",
                 "wget=1.20.3-1ubuntu1",
             ]
         )


### PR DESCRIPTION
fix #1433 