### PR TITLE
test: mark jsonschema tests as xfail

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -288,7 +288,7 @@ jobs:
           key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel	  
+          python -m pip install --upgrade pip setuptools wheel
           pip install -r requirements.txt -r doc/requirements.txt
       - name: Test to check for CVEs for python requirements and HTML report dependencies
         run: |

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -35,6 +35,7 @@ class TestJSON:
         "year", list(range(2002, datetime.datetime.now().year + 1))
     )
     # NVD database started in 2002, so range then to now.
+    @pytest.mark.xfail(reason="NVD data is sometimes imperfect", run=True)
     def test_json_validation(self, year):
         """Validate latest nvd json file against their published schema"""
         # Open the latest nvd file on disk


### PR DESCRIPTION
* Related to #1438

Due to occasional mistakes in the NVD data, the jsonschema tests are
flaky and have been making our CI results less useful.

Also fixed a whitespace issue in pythonapp.yml