### PR TITLE
CI: disable jsonschema tests due to NVD data errors

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -160,7 +160,6 @@ jobs:
             cvedb.py
             test_scanner.py
             test_cli.py
-            test_json.py
           SET_ENV_NAME_COUNT: LONG_TESTS
       - name: Install dependencies
         run: |


### PR DESCRIPTION
* related: #1438

The json schema tests are flaky because NVD sometimes provides
non-compliant data.  Currently the 2021 yearly file does not pass.

Users wishing to run these checks can still do so locally, but the value
of running failing tests in CI seems minimal so they're being disabled.