### PR TITLE
OpenSSF Badge (in progress)

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -23,6 +23,7 @@ backported
 bcca
 bdbd
 bdist
+bestpractices
 bigbird
 binutils
 bksahu
@@ -52,6 +53,7 @@ codecov
 conda
 config
 copyleft
+coreinfrastructure
 cpio
 cpp
 CQA

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![On PyPI](https://img.shields.io/pypi/v/cve-bin-tool)](https://pypi.org/project/cve-bin-tool/)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/python/black)
 [![Imports: isort](https://img.shields.io/badge/%20imports-isort-%231674b1?style=flat&labelColor=ef8336)](https://pycqa.github.io/isort/)
-
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/5380/badge)](https://bestpractices.coreinfrastructure.org/projects/5380)
 
 The CVE Binary Tool scans for a number of common, vulnerable open source
 components such as openssl, libpng, libxml2, and expat to let you know


### PR DESCRIPTION
I've started filling out the OpenSSF Badge (formerly known as the CII best practices badge).  It's intended to show that we're following security best practices.  It's not done yet, but I think it might be nice to show that it's in progress.