### PR TITLE
fix(available-fix): Use `affected_release` for fixed status

### DIFF
--- a/cve_bin_tool/available_fix/redhat_cve_tracker.py
+++ b/cve_bin_tool/available_fix/redhat_cve_tracker.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from json import loads
+from re import search, split
 from typing import Dict
 from urllib import error, request
 
@@ -30,23 +31,41 @@ class RedhatCVETracker:
                 try:
                     if not json_data:
                         raise KeyError
+
                     package_state = json_data["package_state"]
-                    output = f'{cve["product"]}: No known fix for {cve["cve_number"]}.'
+                    affected_releases = json_data["affected_release"]
+
+                    no_fix = True
+
+                    for package in affected_releases:
+                        if (
+                            package["product_name"]
+                            == f"Red Hat Enterprise Linux {self.distro_codename}"
+                        ):
+                            package_data = self.get_package_name(package["package"])
+                            LOGGER.info(
+                                f'{cve["product"]}: {cve["cve_number"]} - Status: Fixed - Fixed package: {package_data}'
+                            )
+                            no_fix = False
+
                     for package in package_state:
                         if (
                             package["product_name"]
                             == f"Red Hat Enterprise Linux {self.distro_codename}"
                         ):
-                            output = f'{cve["product"]}: {cve["cve_number"]} - Status: {package["fix_state"]}'
-                            if (
-                                package["fix_state"] == "Affected"
-                                and "upstream_fix" in json_data
-                            ):
-                                output += (
-                                    f' - Fixed releases: {json_data["upstream_fix"]}'
-                                )
-                            break
-                    LOGGER.info(output)
+                            package_data = self.get_package_name(
+                                package["package_name"]
+                            )
+                            LOGGER.info(
+                                f'{cve["product"]}: {cve["cve_number"]} - Status: {package["fix_state"]} - Related package: {package_data}'
+                            )
+                            no_fix = False
+
+                    if no_fix:
+                        LOGGER.info(
+                            f'{cve["product"]}: No known fix for {cve["cve_number"]}.'
+                        )
+
                 except (KeyError, TypeError):
                     if cve["cve_number"] != "UNKNOWN":
                         LOGGER.info(
@@ -60,3 +79,33 @@ class RedhatCVETracker:
             return loads(response)
         except error.HTTPError:
             LOGGER.info(f"{product}: No known fix for {cve_number}.")
+
+    def get_package_name(self, package_data: str) -> str:
+        """
+        Parses package name and version data from the package data provided by Red Hat.
+
+        Sample input:
+        nodejs:12-8040020210817133458.522a0ee4
+        edk2-0:20210527gite1999b264f1f-3.el8
+        dnsmasq-0:2.79-13.el8_3.1
+
+        Sample output:
+        nodejs v12
+        edk v2
+        dnsmasq v2.79
+
+        """
+        parsed_package_data = ""
+        package_name = split(r"-\d", package_data, 1)[0]
+        if ":" in package_name:
+            package_name, package_version = split(":", package_name)
+            package_version = search(r"\d+", package_version).group(0)
+            parsed_package_data = f"{package_name} v{package_version}"
+        else:
+            parsed_package_data = package_name
+            match = search(r"\d+\.\d+", package_data)
+            if match:
+                package_version = match.group(0)
+                parsed_package_data += f" v{package_version}"
+
+        return parsed_package_data

--- a/cve_bin_tool/available_fix/redhat_cve_tracker.py
+++ b/cve_bin_tool/available_fix/redhat_cve_tracker.py
@@ -77,8 +77,8 @@ class RedhatCVETracker:
             full_query = f"{RH_CVE_API}/{cve_number}.json"
             response = request.urlopen(full_query).read().decode("utf-8")
             return loads(response)
-        except error.HTTPError:
-            LOGGER.info(f"{product}: No known fix for {cve_number}.")
+        except error.HTTPError as e:
+            LOGGER.debug(e)
 
     def get_package_name(self, package_data: str) -> str:
         """

--- a/cve_bin_tool/available_fix/redhat_cve_tracker.py
+++ b/cve_bin_tool/available_fix/redhat_cve_tracker.py
@@ -42,7 +42,7 @@ class RedhatCVETracker:
                             package["product_name"]
                             == f"Red Hat Enterprise Linux {self.distro_codename}"
                         ):
-                            package_data = self.get_package_name(package["package"])
+                            package_data = self.parse_package_data(package["package"])
                             LOGGER.info(
                                 f'{cve["product"]}: {cve["cve_number"]} - Status: Fixed - Fixed package: {package_data}'
                             )
@@ -53,7 +53,7 @@ class RedhatCVETracker:
                             package["product_name"]
                             == f"Red Hat Enterprise Linux {self.distro_codename}"
                         ):
-                            package_data = self.get_package_name(
+                            package_data = self.parse_package_data(
                                 package["package_name"]
                             )
                             LOGGER.info(
@@ -80,7 +80,7 @@ class RedhatCVETracker:
         except error.HTTPError as e:
             LOGGER.debug(e)
 
-    def get_package_name(self, package_data: str) -> str:
+    def parse_package_data(self, package_data: str) -> str:
         """
         Parses package name and version data from the package data provided by Red Hat.
 

--- a/test/test_available_fix.py
+++ b/test/test_available_fix.py
@@ -119,10 +119,19 @@ class TestAvailableFixReport:
         fixes = AvailableFixReport(self.MOCK_NODEJS_CVE_DATA, "rhel-8", False)
         fixes.check_available_fix()
         expected_output = [
-            "node.js: CVE-2021-22918 - Status: Affected - Fixed releases: node 16.4.1, node 14.17.2, node 12.22.2, libuv 1.41.1",
-            "node.js: CVE-2021-22931 - Status: Not affected",
-            "node.js: CVE-2021-22939 - Status: Affected - Fixed releases: nodejs 12.22.5, nodejs 14.17.5, nodejs 16.6.2",
-            "node.js: CVE-2021-22940 - Status: Affected - Fixed releases: nodejs 12.22.5, nodejs 14.17.5, nodejs 16.6.2",
+            "node.js: CVE-2021-22918 - Status: Fixed - Fixed package: nodejs v12",
+            "node.js: CVE-2021-22918 - Status: Fixed - Fixed package: nodejs v14",
+            "node.js: CVE-2021-22918 - Status: Fixed - Fixed package: libuv v1.41",
+            "node.js: CVE-2021-22918 - Status: Not affected - Related package: nodejs v16",
+            "node.js: CVE-2021-22931 - Status: Fixed - Fixed package: nodejs v12",
+            "node.js: CVE-2021-22931 - Status: Fixed - Fixed package: nodejs v14",
+            "node.js: CVE-2021-22931 - Status: Not affected - Related package: nodejs v16",
+            "node.js: CVE-2021-22939 - Status: Fixed - Fixed package: nodejs v12",
+            "node.js: CVE-2021-22939 - Status: Fixed - Fixed package: nodejs v14",
+            "node.js: CVE-2021-22939 - Status: Not affected - Related package: nodejs v16",
+            "node.js: CVE-2021-22940 - Status: Fixed - Fixed package: nodejs v12",
+            "node.js: CVE-2021-22940 - Status: Fixed - Fixed package: nodejs v14",
+            "node.js: CVE-2021-22940 - Status: Not affected - Related package: nodejs v16",
         ]
 
         assert expected_output == [rec.message for rec in caplog.records]


### PR DESCRIPTION
fix #1444 

Instead of the previous approach of looking for affected versions  and logging the upstream fixes all together now we will use the `affected_release` to find if the package has fixes.

refer https://github.com/intel/cve-bin-tool/issues/1444#issuecomment-974786177 and https://github.com/intel/cve-bin-tool/issues/1444#issuecomment-974790541