### PR TITLE
WIP: Re-enable test_helper_script.py on windows (expect failures)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -251,7 +251,6 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
-          --ignore=test/test_helper_script.py
       - name: Run synchronous tests
         run: >
           pytest -v


### PR DESCRIPTION
* Related: #1264

This PR just re-enables test_helper_script.py on windows to see exactly what error messages we're getting in CI.  I expect tests to fail, but I want to see if they fail in the same way on my local system or not for further validation.