### PR TITLE
test(package-list-parser): use ubuntu packages' versions dynamically

### DIFF
--- a/test/test_package_list_parser.py
+++ b/test/test_package_list_parser.py
@@ -38,19 +38,23 @@ class TestPackageListParser:
 
     # Find the versions of the ubuntu packages
     UBUNTU_PACKAGE_VERSIONS = (
-        subprocess.run(
-            [
-                "dpkg-query",
-                "--show",
-                "--showformat=${Version}\n",
-                "bash",
-                "binutils",
-                "wget",
-            ],
-            stdout=subprocess.PIPE,
+        (
+            subprocess.run(
+                [
+                    "dpkg-query",
+                    "--show",
+                    "--showformat=${Version}\n",
+                    "bash",
+                    "binutils",
+                    "wget",
+                ],
+                stdout=subprocess.PIPE,
+            )
+            .stdout.decode("utf-8")
+            .splitlines()
         )
-        .stdout.decode("utf-8")
-        .splitlines()
+        if "ubuntu" in distro.id()
+        else ["dummy", "array", "for windows"]
     )
 
     UBUNTU_PARSED_TRIAGE_DATA = {

--- a/test/test_package_list_parser.py
+++ b/test/test_package_list_parser.py
@@ -2,9 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import subprocess
-from os import environ
 from os.path import dirname, join
-from sys import platform
 
 import distro
 import pytest
@@ -38,16 +36,39 @@ class TestPackageListParser:
         },
     }
 
+    # Find the versions of the ubuntu packages
+    UBUNTU_PACKAGE_VERSIONS = (
+        subprocess.run(
+            [
+                "dpkg-query",
+                "--show",
+                "--showformat=${Version}\n",
+                "bash",
+                "binutils",
+                "wget",
+            ],
+            stdout=subprocess.PIPE,
+        )
+        .stdout.decode("utf-8")
+        .splitlines()
+    )
+
     UBUNTU_PARSED_TRIAGE_DATA = {
-        ProductInfo(vendor="gnu*", product="bash", version="5.0-6ubuntu1.1"): {
+        ProductInfo(
+            vendor="gnu*", product="bash", version=UBUNTU_PACKAGE_VERSIONS[0]
+        ): {
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
             "paths": {""},
         },
-        ProductInfo(vendor="gnu*", product="binutils", version="2.34-6ubuntu1.3"): {
+        ProductInfo(
+            vendor="gnu*", product="binutils", version=UBUNTU_PACKAGE_VERSIONS[1]
+        ): {
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
             "paths": {""},
         },
-        ProductInfo(vendor="gnu*", product="wget", version="1.20.3-1ubuntu1"): {
+        ProductInfo(
+            vendor="gnu*", product="wget", version=UBUNTU_PACKAGE_VERSIONS[2]
+        ): {
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
             "paths": {""},
         },
@@ -103,25 +124,13 @@ class TestPackageListParser:
         assert expected_output == [rec.message for rec in caplog.records]
 
     @pytest.mark.skipif(
-        "ACTIONS" not in environ
-        or not platform == "linux"
-        or ("ubuntu" not in distro.id() and "20.04" not in distro.version()),
-        reason="Running locally requires root permission",
+        "ubuntu" not in distro.id(),
+        reason="Test for Ubuntu systems",
     )
     @pytest.mark.parametrize(
         "filepath, parsed_data",
         [(join(TXT_PATH, "test_ubuntu_list.txt"), UBUNTU_PARSED_TRIAGE_DATA)],
     )
     def test_valid_ubuntu_list(self, filepath, parsed_data):
-        subprocess.run(
-            [
-                "sudo",
-                "apt-get",
-                "install",
-                "bash=5.0-6ubuntu1.1",
-                "binutils=2.34-6ubuntu1.3",
-                "wget=1.20.3-1ubuntu1",
-            ]
-        )
         package_list = PackageListParser(filepath, error_mode=ErrorMode.FullTrace)
         assert package_list.parse_list() == parsed_data


### PR DESCRIPTION
- fix #1457

now the test picks the packages' details installed in the OS and doesn't need to install a specific version (which ended up being a pain for us in #1457  and #1433).