### PR TITLE
feat(cli): allow to overwrite nvd cache dir

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -99,6 +99,12 @@ def main(argv=None):
         choices=["now", "daily", "never", "latest"],
         help="update schedule for NVD database (default: daily)",
     )
+    nvd_database_group.add_argument(
+        "--cache-dir",
+        action="store",
+        default="",
+        help="Overwrite database cache directory, defaults to ~/.cache/cve-bin-tool",
+    )
 
     input_group = parser.add_argument_group("Input")
     input_group.add_argument(
@@ -370,6 +376,7 @@ def main(argv=None):
     # Database update related settings
     # Connect to the database
     cvedb_orig = CVEDB(
+        cachedir=args["cache_dir"],
         version_check=not args["disable_version_check"],
         error_mode=error_mode,
         nvd_type=args["nvd"],


### PR DESCRIPTION
I would like to be able to overwrite the cache-dir location, but the `DISK_LOCATION_DEFAULT`is used in multiple places so that **this PR does not yet work.**

related to https://github.com/intel/cve-bin-tool/issues/636