### PR TITLE
ci: add filetype to allowed word list

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -103,6 +103,7 @@ fedoraproject
 ffmpeg
 figcaption
 filepaths
+filetype
 filterdiv
 firefox
 freeradius


### PR DESCRIPTION
I somehow missed this in the last commit.