### PR TITLE
chore: modify detected languages in github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.html linguist-detectable=false


### PR DESCRIPTION
Our HTML templates and test files are currently dominating our language results
because they're so big, but most of our development is actually done in Python.
We are suppressing html detection to get a better picture for contributors.