### PR TITLE
test: Move NVD queries to LONG_TESTS due to rate limits (fixes #1509)

### DIFF
--- a/test/test_cvedb.py
+++ b/test/test_cvedb.py
@@ -4,6 +4,7 @@
 import datetime
 import shutil
 import tempfile
+from test.utils import LONG_TESTS
 
 import aiohttp
 import pytest
@@ -21,6 +22,9 @@ class TestCVEDB:
         shutil.rmtree(cls.cvedb.cachedir)
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        LONG_TESTS() != 1, reason="Skipping NVD calls due to rate limits"
+    )
     async def test_00_getmeta(self):
         connector = aiohttp.TCPConnector(limit_per_host=19)
         async with aiohttp.ClientSession(
@@ -33,6 +37,9 @@ class TestCVEDB:
         assert "sha256" in meta
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        LONG_TESTS() != 1, reason="Skipping NVD calls due to rate limits"
+    )
     async def test_01_nist_scrape(self):
         async with aiohttp.ClientSession(trust_env=True) as session:
             jsonshas = await self.cvedb.nist_scrape(session)
@@ -42,6 +49,9 @@ class TestCVEDB:
             )
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        LONG_TESTS() != 1, reason="Skipping NVD calls due to rate limits"
+    )
     async def test_02_cache_update(self):
         async with aiohttp.ClientSession(trust_env=True) as session:
             jsonurl, meta = await self.cvedb.getmeta(
@@ -51,6 +61,9 @@ class TestCVEDB:
             await self.cvedb.cache_update(session, jsonurl, meta["sha256"])
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        LONG_TESTS() != 1, reason="Skipping NVD calls due to rate limits"
+    )
     async def test_03_refresh(self):
         await self.cvedb.refresh()
         years = self.cvedb.nvd_years()


### PR DESCRIPTION
* fixes #1509 