### PR TITLE
test: Move backported fix tests to LONG_TESTS (#1502)

### DIFF
--- a/test/test_available_fix.py
+++ b/test/test_available_fix.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from test.utils import LONG_TESTS
+
 import pytest
 
 from cve_bin_tool.available_fix import AvailableFixReport
@@ -87,6 +89,9 @@ class TestAvailableFixReport:
         )
     }
 
+    @pytest.mark.skipif(
+        LONG_TESTS() != 1, reason="Skipping tests to reduce network calls"
+    )
     def test_debian_backport_fix_output(self, caplog: pytest.LogCaptureFixture):
         """Test Backported fix for Debian distros output on console"""
 
@@ -99,6 +104,9 @@ class TestAvailableFixReport:
 
         assert expected_output == [rec.message for rec in caplog.records]
 
+    @pytest.mark.skipif(
+        LONG_TESTS() != 1, reason="Skipping tests to reduce network calls"
+    )
     def test_debian_available_fix_output(self, caplog: pytest.LogCaptureFixture):
         """Test Available fix for Debian distros output on console"""
 
@@ -113,6 +121,9 @@ class TestAvailableFixReport:
 
         assert expected_output == [rec.message for rec in caplog.records]
 
+    @pytest.mark.skipif(
+        LONG_TESTS() != 1, reason="Skipping tests to reduce network calls"
+    )
     def test_redhat_available_fix_output(self, caplog: pytest.LogCaptureFixture):
         """Test Available fix for Redhat distros output on console"""
 


### PR DESCRIPTION
Closes #1502 