### PR TITLE
Gave output types its own subheading

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ For more details, see our [documentation](https://cve-bin-tool.readthedocs.io/en
     - [Finding known vulnerabilities using the binary scanner](#finding-known-vulnerabilities-using-the-binary-scanner)
     - [Finding known vulnerabilities in a list of components](#finding-known-vulnerabilities-in-a-list-of-components)
     - [Scanning an SBOM file for known vulnerabilities](#scanning-an-sbom-file-for-known-vulnerabilities)
+    - [Output Options](#output-options)
   - [Full option list](#full-option-list)
   - [Configuration](#configuration)
   - [Using CVE Binary Tool in Github Actions](#using-cve-binary-tool-in-github-actions)
@@ -77,6 +78,8 @@ cve-bin-tool  --sbom <sbom_filetype> --sbom-file <sbom_filename>
 
 Valid SBOM types are [SPDX](https://spdx.dev/specifications/),
 [CycloneDX](https://cyclonedx.org/specification/overview/), and [SWID](https://csrc.nist.gov/projects/software-identification-swid/guidelines).
+
+## Output Options
 
 The CVE Binary Tool provides console-based output by default.  If you wish to provide another format, you can specify this and a filename on the command line using `--format`.  The valid formats are CSV, JSON, console, HTML and PDF.  The output filename can be specified using the `--output-file` flag.
 


### PR DESCRIPTION
Gave output types its own subheading in README.md
Fixes #1506 