### PR TITLE
fix(cve_scanner): fix `canonical_convert`

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -8,9 +8,10 @@ import sys
 from collections import defaultdict
 from logging import Logger
 from string import ascii_lowercase
-from typing import DefaultDict, Dict, List
+from typing import DefaultDict, Dict, List, Tuple, Union
 
-from pkg_resources import parse_version
+from packaging.version import LegacyVersion, Version
+from packaging.version import parse as parse_version
 from rich.console import Console
 
 from cve_bin_tool.cvedb import DBNAME, DISK_LOCATION_DEFAULT
@@ -251,10 +252,14 @@ class CVEScanner:
             version = f"{version[:-1]}.{self.ALPHA_TO_NUM[last_char]}"
         return version
 
-    def canonical_convert(self, product_info: ProductInfo) -> str:
-        version_between = ""
+    VersionType = Union[Version, LegacyVersion]
+
+    def canonical_convert(
+        self, product_info: ProductInfo
+    ) -> Tuple[VersionType, VersionType]:
+        version_between = parse_version("")
         if product_info.version == "":
-            return product_info.version, version_between
+            return parse_version(product_info.version), version_between
         if product_info.product == "openssl":
             pv = re.search(r"\d[.\d]*[a-z]?", product_info.version)
             version_between = parse_version(self.openssl_convert(pv.group(0)))


### PR DESCRIPTION
- fixes #1518

Regression was introduced in 6cd49cf, first `if` clause returns a tuple of two strings instead of special `Version` objects. This only happens when `product_info.version` is an empty string.

Note that this also affects #1517 ([user report](https://github.com/intel/cve-bin-tool/issues/1300#issuecomment-1008291338)). With the proposed fix scanning completes successfully and just detects empty version for xml2:
```console
           INFO     cve_bin_tool - Known CVEs in ('busybox', '1.30.1'), ('curl', '7.66.0'), ('hostapd', '2.9'), ('libcurl', '7.66.0'), ('libxml2', ''), ('lighttpd', '1.4.48'), ('lua', '5.1.5'),      cli.py:565
                    ('openssl', '1.1.1d'), ('openvpn', '2.5.0'), ('sqlite', '3.31.1'), ('wpa_supplicant', '2.9'):
```

P.S. I can't seem to pass all tests in CI in my fork due to NVD returning 403.