### PR TITLE
CI: Add bandit to pre-commit (fixes #1110)

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: ['isort', 'black', 'pyupgrade', 'flake8', 'format_checkers']
+        tool: ['isort', 'black', 'pyupgrade', 'flake8', 'format_checkers', 'bandit']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,17 @@ repos:
     hooks:
     - id: pyupgrade
       args: ["--py37-plus"]
-      
+
 -   repo: https://github.com/pycqa/flake8
     rev: 4.0.1
     hooks:
     - id: flake8
+
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.7.1
+    hooks:
+    - id: bandit
+      args: ["-c", "bandit.conf"]
 
 -   repo: local
     hooks:

--- a/bandit.conf
+++ b/bandit.conf
@@ -85,7 +85,10 @@
 tests:
 
 # (optional) list skipped test IDs here, eg '[B101, B406]':
-skips: ['B603', 'B607', 'B404']
+skips: ['B603', 'B607', 'B404', "B608"]
+# B603, B607 and B404 are all subprocess-related.
+# B608 should be re-enabled when multi-line issues can be marked with nosec
+
 # Explantion: cve-bin-tool is at heart a shell script that calls other processes.
 # Switching to pure python has significant performance impacts.
 

--- a/cve_bin_tool/available_fix/redhat_cve_tracker.py
+++ b/cve_bin_tool/available_fix/redhat_cve_tracker.py
@@ -74,8 +74,8 @@ class RedhatCVETracker:
 
     def get_data(self, cve_number: str, product: str):
         try:
-            full_query = f"{RH_CVE_API}/{cve_number}.json"
-            response = request.urlopen(full_query).read().decode("utf-8")
+            full_query = f"{RH_CVE_API}/{cve_number}.json"  # static https url above
+            response = request.urlopen(full_query).read().decode("utf-8")  # nosec
             return loads(response)
         except error.HTTPError as e:
             LOGGER.debug(e)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,4 @@ black==21.12b0
 isort==5.10.1
 pre-commit==2.16.0
 flake8==4.0.1
+bandit=1.7.1


### PR DESCRIPTION
* fixes #1110

Note that because there's a bug about marking things `#nosec` when they span multiple lines, I've disabled the SQL checker which was catching those.  (We had some cases where we needed to use a table name from a variable and the like; they're fine and can be verified manually pre-release just in case.)