### PR TITLE
feat: add NVD API key

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -62,6 +62,8 @@ jobs:
 
   tests:
     name: Linux Tests
+      with:
+        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -122,6 +124,8 @@ jobs:
 
   long_tests:
     name: Long tests on Python 3.8
+      with:
+        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -196,6 +200,8 @@ jobs:
 
   windows_tests:
     name: Windows Tests
+      with:
+        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -260,6 +266,8 @@ jobs:
 
   cve_scan:
     name: CVE Scan on dependencies
+      with:
+        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ For more details, see our [documentation](https://cve-bin-tool.readthedocs.io/en
 - [CVE Binary Tool quick start / README](#cve-binary-tool-quick-start--readme)
   - [Installing CVE Binary Tool](#installing-cve-binary-tool)
   - [Most popular usage options](#most-popular-usage-options)
-    - [Using the tool offline](#using-the-tool-offline)
+  - [Using the tool offline](#using-the-tool-offline)
     - [Finding known vulnerabilities using the binary scanner](#finding-known-vulnerabilities-using-the-binary-scanner)
     - [Finding known vulnerabilities in a list of components](#finding-known-vulnerabilities-in-a-list-of-components)
     - [Scanning an SBOM file for known vulnerabilities](#scanning-an-sbom-file-for-known-vulnerabilities)
-    - [Output Options](#output-options)
+  - [Output Options](#output-options)
   - [Full option list](#full-option-list)
   - [Configuration](#configuration)
   - [Using CVE Binary Tool in Github Actions](#using-cve-binary-tool-in-github-actions)
@@ -106,6 +106,8 @@ Usage:
                             choose method for getting CVE lists from NVD
       -u {now,daily,never,latest}, --update {now,daily,never,latest}
                             update schedule for NVD database (default: daily)
+      --nvd-api-key NVD_API_KEY
+                        specify NVD API key (used to improve NVD rate limit)
 
     Input:
       directory             directory to scan

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -66,10 +66,6 @@ def main(argv=None):
 
     # Reset logger level to info
     LOGGER.setLevel(logging.INFO)
-    LOGGER.info(f"CVE Binary Tool v{VERSION}")
-    LOGGER.info(
-        "This product uses the NVD API but is not endorsed or certified by the NVD."
-    )
 
     parser = argparse.ArgumentParser(
         prog="cve-bin-tool",
@@ -340,6 +336,12 @@ def main(argv=None):
         error_mode = ErrorMode.NoTrace
     else:
         error_mode = ErrorMode.TruncTrace
+
+    # once logging is set, we can output the version and NVD notice
+    LOGGER.info(f"CVE Binary Tool v{VERSION}")
+    LOGGER.info(
+        "This product uses the NVD API but is not endorsed or certified by the NVD."
+    )
 
     if platform.system() != "Linux":
         warning_nolinux = """

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -101,6 +101,12 @@ def main(argv=None):
         choices=["now", "daily", "never", "latest"],
         help="update schedule for NVD database (default: daily)",
     )
+    nvd_database_group.add_argument(
+        "--nvd-api-key",
+        action="store",
+        default="",
+        help="specify NVD API key (used to improve NVD rate limit)",
+    )
 
     input_group = parser.add_argument_group("Input")
     input_group.add_argument(
@@ -305,6 +311,7 @@ def main(argv=None):
         "backport_fix": "",
         "available_fix": "",
         "nvd": "api",
+        "nvd_api_key": "",
         "filter": [],
         "affected_versions": 0,
         "sbom": "spdx",
@@ -406,6 +413,7 @@ def main(argv=None):
         error_mode=error_mode,
         nvd_type=args["nvd"],
         incremental_update=True if db_update == "latest" and args["nvd"] else False,
+        nvd_api_key=args["nvd_api_key"],
     )
 
     # if OLD_CACHE_DIR (from cvedb.py) exists, print warning

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -66,6 +66,10 @@ def main(argv=None):
 
     # Reset logger level to info
     LOGGER.setLevel(logging.INFO)
+    LOGGER.info(f"CVE Binary Tool v{VERSION}")
+    LOGGER.info(
+        "This product uses the NVD API but is not endorsed or certified by the NVD."
+    )
 
     parser = argparse.ArgumentParser(
         prog="cve-bin-tool",

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -349,9 +349,14 @@ def main(argv=None):
     LOGGER.info(
         "This product uses the NVD API but is not endorsed or certified by the NVD."
     )
+
+    # If NVD API key is not set, check for environment variable (e.g. GitHub Secrets)
+    if not args["nvd_api_key"] and os.getenv("nvd_api_key"):
+        args["nvd_api_key"] = os.getenv("nvd_api_key")
+
     # If you're not using an NVD key, let you know how to get one
     if not args["nvd_api_key"] and not args["offline"]:
-        LOGGER.info("Not using an NVD API Key. Your access may be rate limited by NVD.")
+        LOGGER.info("Not using an NVD API key. Your access may be rate limited by NVD.")
         LOGGER.info(
             "Get an NVD API key here: https://nvd.nist.gov/developers/request-an-api-key"
         )

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -349,6 +349,12 @@ def main(argv=None):
     LOGGER.info(
         "This product uses the NVD API but is not endorsed or certified by the NVD."
     )
+    # If you're not using an NVD key, let you know how to get one
+    if not args["nvd_api_key"] and not args["offline"]:
+        LOGGER.info("Not using an NVD API Key. Your access may be rate limited by NVD.")
+        LOGGER.info(
+            "Get an NVD API key here: https://nvd.nist.gov/developers/request-an-api-key"
+        )
 
     if platform.system() != "Linux":
         warning_nolinux = """

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -71,6 +71,7 @@ class CVEDB:
         error_mode=ErrorMode.TruncTrace,
         nvd_type="json",
         incremental_update=False,
+        nvd_api_key: str = "",
     ):
         self.feed = feed if feed is not None else self.FEED
         self.cachedir = cachedir if cachedir is not None else self.CACHEDIR
@@ -93,6 +94,9 @@ class CVEDB:
         self.incremental_update = incremental_update
         self.all_cve_entries = None
 
+        # store the nvd api key for use later
+        self.nvd_api_key = nvd_api_key
+
         if not os.path.exists(self.dbpath):
             self.rollback_cache_backup()
 
@@ -108,6 +112,7 @@ class CVEDB:
             logger=self.LOGGER,
             error_mode=self.error_mode,
             incremental_update=self.incremental_update,
+            api_key=self.nvd_api_key,
         )
         if self.incremental_update:
             await nvd_api.get_nvd_params(

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -32,7 +32,7 @@ from cve_bin_tool.error_handler import (
 )
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.nvd_api import NVD_API
-from cve_bin_tool.version import VERSION, check_latest_version
+from cve_bin_tool.version import check_latest_version
 
 logging.basicConfig(level=logging.DEBUG)
 
@@ -256,7 +256,7 @@ class CVEDB:
         # refresh the database
         if not os.path.isdir(self.cachedir):
             os.makedirs(self.cachedir)
-        self.LOGGER.info(f"CVE Binary Tool v{VERSION}")
+
         # check for the latest version
         if self.version_check:
             check_latest_version()

--- a/cve_bin_tool/nvd_api.py
+++ b/cve_bin_tool/nvd_api.py
@@ -3,6 +3,8 @@
 
 """
 Retrieval access and of NVD entries using NVD Automatic CVE Retrieval
+
+Parameter values and more information: https://nvd.nist.gov/developers/products
 """
 
 import asyncio
@@ -40,6 +42,7 @@ class NVD_API:
         interval: int = INTERVAL_PERIOD,
         error_mode: ErrorMode = ErrorMode.TruncTrace,
         incremental_update=False,
+        api_key: str = "",
     ):
         self.logger = logger or LOGGER.getChild(self.__class__.__name__)
         self.feed = feed
@@ -53,6 +56,8 @@ class NVD_API:
         self.total_results = -1
         self.failed_count = 0
         self.all_cve_entries: List = []
+        if api_key:
+            self.params["apiKey"] = api_key
 
     @staticmethod
     def convert_date_to_nvd_date(date: datetime) -> str:

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -13,6 +13,7 @@
   - [CVE Data Download Arguments](#cve-data-download-arguments)
     - [-u {now,daily,never,latest}, --update {now,daily,never,latest}](#-u-nowdailyneverlatest---update-nowdailyneverlatest)
     - [-n {json,api}, --nvd {json,api}](#-n-jsonapi---nvd-jsonapi)
+    - [--nvd-api-key NVD_API_KEY](#--nvd-api-key-nvd_api_key)
   - [Checkers Arguments](#checkers-arguments)
     - [-s SKIPS, --skips SKIPS](#-s-skips---skips-skips)
     - [-r CHECKERS, --runs CHECKERS](#-r-checkers---runs-checkers)
@@ -68,6 +69,8 @@ which is useful if you're trying the latest code from
                             choose method for getting CVE lists from NVD
       -u {now,daily,never,latest}, --update {now,daily,never,latest}
                             update schedule for NVD database (default: daily)
+      --nvd-api-key NVD_API_KEY
+                        specify NVD API key (used to improve NVD rate limit)
 
     Input:
       directory             directory to scan
@@ -258,6 +261,16 @@ This option selects how CVE data is downloaded from the National Vulnerability D
 A major benefit of using this NVD API is incremental updates which basically means you won't have to download the complete feed again in case you want the latest CVE entries from NVD. See the detailed guide on [incremental updates](how_to_guides/use_incremental_updates.html) for more details.
 
 You may also choose to update the data using `json` option which uses the JSON feeds available on [this page](https://nvd.nist.gov/vuln/data-feeds). These per-year feeds are updated once per day.  This mode was the default for CVE Binary Tool prior to the 3.0 release.
+
+### --nvd-api-key NVD_API_KEY
+
+An NVD API key allows registered users to make a greater number of requests to the API.  At this time, the [NVD API documentation](https://nvd.nist.gov/developers)) says, "The public rate limit (without an API key) is 10 requests in a rolling 60 second window; the rate limit with an API key is 100 requests in a rolling 60 second window."
+
+CVE Binary tool by default queries the NVD database once per day and caches the results to help alleviate load on the NVD servers.  Users who update more regularly or who are running the tool in shared environments (such as cloud providers or GitHub Actions) may find themselves hitting the rate limits despite those precautions and should obtain and use an NVD API key with CVE Binary Tool.
+
+To get an API key, users should visit the [NVD API key request page](https://nvd.nist.gov/developers/request-an-api-key).
+
+Related: [NVD API Key Announcement](https://nvd.nist.gov/general/news/API-Key-Announcement)
 
 ## Checkers Arguments
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -270,7 +270,7 @@ CVE Binary tool by default queries the NVD database once per day and caches the 
 
 To get an API key, users should visit the [NVD API key request page](https://nvd.nist.gov/developers/request-an-api-key).
 
-Related: [NVD API Key Announcement](https://nvd.nist.gov/general/news/API-Key-Announcement)
+Related: [NVD API key announcement](https://nvd.nist.gov/general/news/API-Key-Announcement)
 
 ## Checkers Arguments
 


### PR DESCRIPTION
This PR will add support for NVD API keys
* fixes #1428

This includes the following:
- adding the NVD notice as required by the NVD API docs
- adding `--nvd-api-key` to the command line
- modifying CVEDB to accept the api key and pass it through to NVD_API
- modifying NVD_API to accept and use the api key by adding it to the parameters sent with the request.
- documentation on how to get and use an api key
- accepting an $nvd_api_key environment variable as alternative to using the command-line flag.  This allows users of GitHub Actions (including us!) to use their built-in secrets options to keep the key private in the CI logs.
- enabled the nvd_api_key in our GitHub Actions setup -- this allows the long tests to pass without being rate limited