### PR TITLE
doc: add info on syncing to origin/main and rebasing

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -14,6 +14,7 @@ apk
 Args
 asn
 asottile
+atlassian
 autoescape
 autoextract
 autoextracts

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -287,6 +287,7 @@ Rahul
 readme
 readthedocs
 realpython
+rebasing
 refactoring
 regex
 Romi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -230,6 +230,13 @@ git pull
 git checkout -b my_new_branch
 ```
 
+>Note: If you accidentally check something in to main and want to reset it to match our main branch, you can save your work using `checkout -b` and then do a `git reset` to fix it:
+>```
+>git checkout -b saved_branch
+>git reset --hard origin/main
+>```
+>You do not need to do the `checkout` step if you don't want to save the changes you made.
+
 When you're ready to share that branch to make a pull request, make sure you've checked in all the files you're working on.  You can get a list of the files you modified using `git status` and see what modifications you made using `git diff`
 
 Use `git add FILENAME` to add the files you want to put in your pull request, and use `git commit` to check them in.  Try to use [a clear commit message](https://chris.beams.io/posts/git-commit/) and use the [Conventional Commits](https://www.conventionalcommits.org/) format.  
@@ -278,6 +285,8 @@ Once you have created a pull request (PR), GitHub Actions will try to run all th
 Someone will review your code and try to provide feedback in the comments on GitHub.  Usually it takes a few days, sometimes up to a week.  The core contributors for this project work on it as part of their day jobs and are usually on US Pacific time, so you might get an answer a bit faster during their work week.
 
 If something needs fixing or we have questions, we'll work back and forth with you to get that sorted.  We usually do most of the chatting directly in the pull request comments on GitHub, but if you're stuck you can also stop by our [Gitter chat room](https://gitter.im/cve-bin-tool/community) to talk with folk outside of the bug.
+
+>Another useful tool is `git rebase`, which allows you to change the "base" that your code uses.  We most often use it as `git rebase origin/main` which can be useful if a change in the main tree is affecting your code's ability to merge.  Rebasing is a bit much for an intro document, but [there's a git rebase tutorial here](https://www.atlassian.com/git/tutorials/rewriting-history/git-rebase) that you may find useful if it comes up.
 
 Once any issues are resolved, we'll merge your code.  Yay!
 


### PR DESCRIPTION
Adding some information for common problems first time contributors have:
- keeping their `main` branch in sync with `origin/main` . Previously we said it was a good idea but didn't include info on what to do if you accidentally commit to that branch)
- rebasing to `origin/main`.  Just saying that it comes up sometimes in code review and giving a link to a more extensive document on what git rebase means.