### PR TITLE
ci: fix passing of NVD_API_KEY

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -62,8 +62,6 @@ jobs:
 
   tests:
     name: Linux Tests
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -73,6 +71,7 @@ jobs:
     env:
       ACTIONS: 1
       LONG_TESTS: 0
+      nvd_api_key: $${{ secrets.NVD_API_KEY }}
     steps:
       - name: Get Date
         id: get-date
@@ -124,13 +123,12 @@ jobs:
 
   long_tests:
     name: Long tests on Python 3.8
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
       ACTIONS: 1
       LONG_TESTS: 1
+      nvd_api_key: $${{ secrets.NVD_API_KEY }}
     steps:
       - name: Get Date
         id: get-date
@@ -200,8 +198,6 @@ jobs:
 
   windows_tests:
     name: Windows Tests
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -213,6 +209,7 @@ jobs:
       LONG_TESTS: 0
       NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'
+      nvd_api_key: $${{ secrets.NVD_API_KEY }}
     steps:
       - name: Get Date
         id: get-date
@@ -266,10 +263,10 @@ jobs:
 
   cve_scan:
     name: CVE Scan on dependencies
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      nvd_api_key: $${{ secrets.NVD_API_KEY }}
     steps:
       - name: Get Date
         id: get-date


### PR DESCRIPTION
* related: #1529 

Previous fix introduced an error in the CI workflow -- NVD keys should be passed as environment variables rather than using "with"