### PR TITLE
ci: remove NVD_API_KEY from CI because it isn't working

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -62,8 +62,6 @@ jobs:
 
   tests:
     name: Linux Tests
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -124,8 +122,6 @@ jobs:
 
   long_tests:
     name: Long tests on Python 3.8
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -200,8 +196,6 @@ jobs:
 
   windows_tests:
     name: Windows Tests
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -266,8 +260,6 @@ jobs:
 
   cve_scan:
     name: CVE Scan on dependencies
-      with:
-        nvd_api_key: $${{ secrets.NVD_API_KEY }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:


### PR DESCRIPTION
The NVD_API_KEY changes I pushed in #1529 didn't work correctly in github actions.  This PR reverts just the CI part of the patch.

A better fix is coming in #1543 but right now it looks like NVD isn't recognizing the key passed through github secrets.  This PR should just be a stand-in until I figure out how to plumb the secret variable through correctly.