### PR TITLE
doc: keep pdftotext windows install instructions (partial revert #1515)

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -145,3 +145,5 @@ pytest -v test/test_checkers.py -k python
 ```
 
 ## Known issues
+
+If you're using Windows and plan to run PDF tests, we **strongly** recommend also `pdftotext`. We experienced problems running tests without this. The best approach to do this is through [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/windows.html) (click [here](https://anaconda.org/conda-forge/pdftotext) to find out how to install this package with conda).


### PR DESCRIPTION
I merged #1515 before we fully fixed the issue with the pdttotext instructions (oops) so this is a partial revert so that the instructions are still there, but updated to indicate that pdftotext is only needed if you intend to run the pdf tests.