### PR TITLE
ci: switch format_checker to run in ci

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -28,6 +28,6 @@ jobs:
         with:
           commit-message: "chore: update checkers table"
           title: "chore: update checkers table"
-          branch: chore-precommit-config
+          branch: chore-update-table
           delete-branch: true
           author: GitHub <noreply@github.com>

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,23 @@
+name: Formatting
+
+on:
+  push:
+    paths:
+      - 'cve_bin_tool/checkers/__init__.py'
+
+jobs:
+  formatting:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          cache: 'pip'
+      - name: Install cve-bin-tool
+        run: |
+          python -m pip install --upgrade wheel
+          python -m pip install .
+      - name: Run format_checkers.py
+        run: |
+          python cve_bin_tool/format_checkers.py

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -2,6 +2,8 @@ name: Formatting
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'cve_bin_tool/checkers/__init__.py'
 
@@ -21,3 +23,11 @@ jobs:
       - name: Run format_checkers.py
         run: |
           python cve_bin_tool/format_checkers.py
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: "chore: update checkers table"
+          title: "chore: update checkers table"
+          branch: chore-precommit-config
+          delete-branch: true
+          author: GitHub <noreply@github.com>

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: ['isort', 'black', 'pyupgrade', 'flake8', 'format_checkers', 'bandit', 'gitlint']
+        tool: ['isort', 'black', 'pyupgrade', 'flake8', 'bandit', 'gitlint']
     steps:
       - uses: actions/checkout@v2
         with:
@@ -26,11 +26,6 @@ jobs:
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade pre-commit
           pre-commit install
-      - name: Install cve-bin-tool if needed
-        if: ${{ matrix.tool == 'format_checkers' }}
-        run: |
-          python -m pip install --upgrade wheel
-          python -m pip install .
       - name: Run ${{ matrix.tool }} using pre-commit
         if: ${{ matrix.tool != 'gitlint' }}
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,14 +26,6 @@ repos:
     - id: bandit
       args: ["-c", "bandit.conf"]
 
--   repo: local
-    hooks:
-    - id: format_checkers
-      language: system
-      name: format_checkers
-      entry: python cve_bin_tool/format_checkers.py
-      files: "^cve_bin_tool/checkers/__init__.py"
-
 -   repo: https://github.com/jorisroovers/gitlint
     rev:  v0.17.0
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ We use [pyupgrade](https://github.com/asottile/pyupgrade) to make sure our synta
 
 We also have a spell checker set up to help us avoid typos in documentation.  The [spelling actions readme file](https://github.com/intel/cve-bin-tool/tree/main/.github/actions/spelling) gives more information including how to add new words to the dictionary if needed.
 
-We also have a tool to help make sure that new checkers are added to the tables in our documentation.  [The format_checkers code is here](https://github.com/intel/cve-bin-tool/blob/main/cve_bin_tool/format_checkers.py), if you're curious.
+We also have a tool to help make sure that new checkers are added to the tables in our documentation, this is automatically done with github actions.  [The format_checkers code is here](https://github.com/intel/cve-bin-tool/blob/main/cve_bin_tool/format_checkers.py), if you're curious.
 
 You can view all the config files for GitHub Actions (what we use for Continuous Integration (CI)) in [the .github/workflows directory](https://github.com/intel/cve-bin-tool/tree/main/.github/workflows).
 

--- a/cve_bin_tool/checkers/README.md
+++ b/cve_bin_tool/checkers/README.md
@@ -428,3 +428,7 @@ return following dictionary.
 In most of the cases, Just providing above five class attributes will be enough.
 But sometimes, you need to override this method to correctly detect version of 
 the product. We have done this in the checkers of `python`, `sqlite` and `kerberos`.
+
+## Updating checker table
+You do not need to run format_checkers.py to update the checker table in documentation.
+A pull request with updated checker table is created automatically when a new checker is merged. 


### PR DESCRIPTION
closes #1582 
format_checker no longer runs as a linting check and in pre-commit.
A pull request is created with updated checkers table when a new checker is merged.