### PR TITLE
fix: add urllib3 explicitly to avoid CVEs

### DIFF
--- a/requirements.csv
+++ b/requirements.csv
@@ -20,3 +20,4 @@ tiran_not_in_db,defusedxml
 sissaschool_not_in_db,xmlschema
 python_not_in_db,importlib_metadata
 python,requests
+python,urllib3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ defusedxml
 xmlschema
 importlib_metadata; python_version < "3.8"
 requests
+urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs


### PR DESCRIPTION
urllib3 is used by requests.  It had some CVEs last year (and before).  Pip tends to be very conservative about upgrading packages and requests doesn't require a non-vulnerable version of the library, so I'm adding it to our requirements.txt file in order to force an upgrade for users of cve-bin-tool. 

Probably not necessary, as these fixes have been out quite some time, but I happened upon a machine I was using for testing that had the older version, and figured I might as well set this up as a courtesy in case anyone else encounters a similar issue.   This way, when you run `pip install --upgrade -r requirements.txt` urllib3 will be explicitly named and upgraded.  (Without this line, upgrading the other packages would not upgrade urllib3.)