### PR TITLE
docs: add link to offline guide, rearrange order

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,19 @@ For more details, see our [documentation](https://cve-bin-tool.readthedocs.io/en
 - [CVE Binary Tool quick start / README](#cve-binary-tool-quick-start--readme)
   - [Installing CVE Binary Tool](#installing-cve-binary-tool)
   - [Most popular usage options](#most-popular-usage-options)
-    - [Using the tool offline](#using-the-tool-offline)
     - [Finding known vulnerabilities using the binary scanner](#finding-known-vulnerabilities-using-the-binary-scanner)
     - [Finding known vulnerabilities in a list of components](#finding-known-vulnerabilities-in-a-list-of-components)
     - [Scanning an SBOM file for known vulnerabilities](#scanning-an-sbom-file-for-known-vulnerabilities)
+    - [Using the tool offline](#using-the-tool-offline)
   - [Output Options](#output-options)
   - [Full option list](#full-option-list)
   - [Configuration](#configuration)
   - [Using CVE Binary Tool in GitHub Actions](#using-cve-binary-tool-in-github-actions)
   - [Binary checker list](#binary-checker-list)
   - [Language Specific checkers](#language-specific-checkers)
+    - [Java](#java)
+    - [Javascript](#javascript)
+    - [Python](#python)
   - [Limitations](#limitations)
   - [Requirements](#requirements)
   - [Feedback & Contributions](#feedback--contributions)
@@ -51,10 +54,6 @@ You can also do `pip install --user -e .` to install a local copy which is usefu
 [the cve-bin-tool github](https://github.com/intel/cve-bin-tool) or doing development.  The [Contributor Documentation](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md) covers how to set up for local development in more detail.
 
 ## Most popular usage options
-
-## Using the tool offline
-
-Specifying the `--offline` option when running a scan ensures that cve-bin-tool doesn't attempt to download the latest database files or to check for a newer version of the tool.
 
 ### Finding known vulnerabilities using the binary scanner
 
@@ -88,6 +87,12 @@ cve-bin-tool  --sbom <sbom_filetype> --sbom-file <sbom_filename>
 
 Valid SBOM types are [SPDX](https://spdx.dev/specifications/),
 [CycloneDX](https://cyclonedx.org/specification/overview/), and [SWID](https://csrc.nist.gov/projects/software-identification-swid/guidelines).
+
+### Using the tool offline
+
+Specifying the `--offline` option when running a scan ensures that cve-bin-tool doesn't attempt to download the latest database files or to check for a newer version of the tool.
+
+Note that you will need to obtain a copy of the vulnerability data before the tool can run in offline mode. [The offline how-to guide contains more information on how to set up your database.](https://github.com/intel/cve-bin-tool/blob/main/doc/how_to_guides/offline.md)
 
 ## Output Options
 


### PR DESCRIPTION
We have the caveat about offline mode in the limitations section, but I wanted to make it more clear.  Also I didn't want it top of the list of most used options because that didn't make sense to me.