### PR TITLE
fix: add excel macro filter for csv output

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -57,7 +57,14 @@ def save_intermediate(
 
 def output_csv(all_cve_data: Dict[ProductInfo, CVEData], outfile):
     """Output a CSV of CVEs"""
+
     formatted_output = format_output(all_cve_data)
+
+    # Trim any leading -, =, + or @ to avoid excel macros
+    for cve_entry in formatted_output:
+        for key, value in cve_entry.items():
+            cve_entry[key] = value.strip("-=+@")
+
     writer = csv.DictWriter(
         outfile,
         fieldnames=[

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -844,3 +844,43 @@ class TestOutputEngine(unittest.TestCase):
 
         # assert
         self.assertEqual(contains_sb, True)
+
+    def test_csv_macros(self):
+        """tests that output engine will not output leading -, =, + or @
+        characters, used in spreadsheet macros"""
+
+        bad_input = {
+            ProductInfo("=vendor0", "+product0", "@1.0"): CVEData(
+                cves=[
+                    CVE(
+                        "-CVE-1234-1234",
+                        "@-=+MEDIUM",
+                        score=4.2,
+                        cvss_version=2,
+                        cvss_vector="C:H",
+                    ),
+                ],
+                paths={"@@@@bad"},
+            ),
+        }
+        expected_output = [
+            {
+                "vendor": "vendor0",
+                "product": "product0",
+                "version": "1.0",
+                "cve_number": "CVE-1234-1234",
+                "severity": "MEDIUM",
+                "score": "4.2",
+                "cvss_version": "2",
+                "cvss_vector": "C:H",
+                "paths": "bad",
+                "remarks": "NewFound",
+                "comments": "",
+            },
+        ]
+
+        output_csv(bad_input, self.mock_file)
+        self.mock_file.seek(0)  # reset file position
+        reader = csv.DictReader(self.mock_file)
+        actual_output = [dict(x) for x in reader]
+        self.assertEqual(actual_output, expected_output)


### PR DESCRIPTION
I've added some basic excel macro prevention to the csv output. That means trimming leading special characters (+, -, =, @) used by excel for formulae.

Honestly, it's a bit unlikely that anyone would manage to put an excel macro into the NVD data, but it *is* possible that folk might share triage with intentional or unintentional comments that parse as macros.  Either way, there's no reason for us to allow these characters in output so we might as well add the filter for additional safety.