### PR TITLE
test: add test for null byte in filename

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,6 +6,7 @@ CVE-bin-tool CLI tests
 """
 import logging
 import os
+import sys
 import tempfile
 import unittest
 from test.utils import (
@@ -103,14 +104,28 @@ class TestCLI(TempDirTest):
         # Put a null byte into the filename of a real file used in other tests
         CSV_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
         null_byte_file = os.path.join(CSV_PATH, "test_triage\0.csv")
-        with pytest.raises(SystemExit) as e:
-            main(["cve-bin-tool", null_byte_file])
-        assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
 
-        null_byte_file = os.path.join(CSV_PATH, "test_triage.csv\0something")
-        with pytest.raises(SystemExit) as e:
-            main(["cve-bin-tool", null_byte_file])
-        assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
+        # for Python 3.8+ this should raise FileNotFound
+        if sys.version_info.major == 3 and sys.version_info.minor > 7:
+            with pytest.raises(SystemExit) as e:
+                main(["cve-bin-tool", null_byte_file])
+            assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
+
+            null_byte_file = os.path.join(CSV_PATH, "test_triage.csv\0something")
+            with pytest.raises(SystemExit) as e:
+                main(["cve-bin-tool", null_byte_file])
+            assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
+
+        # for Python 3.7 it will raise a ValueError (embedded null byte)
+        if sys.version_info.major == 3 and sys.version_info.minor == 7:
+            with pytest.raises(ValueError) as e:
+                main(["cve-bin-tool", null_byte_file])
+            assert e.value.args[0] == ERROR_CODES[ValueError]
+
+            null_byte_file = os.path.join(CSV_PATH, "test_triage.csv\0something")
+            with pytest.raises(ValueError) as e:
+                main(["cve-bin-tool", null_byte_file])
+            assert e.value.args[0] == ERROR_CODES[ValueError]
 
     def test_invalid_parameter(self):
         """Test that invalid parmeters exit with expected error code.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -120,12 +120,10 @@ class TestCLI(TempDirTest):
         if sys.version_info.major == 3 and sys.version_info.minor == 7:
             with pytest.raises(ValueError) as e:
                 main(["cve-bin-tool", null_byte_file])
-            assert e.value.args[0] == ERROR_CODES[ValueError]
 
             null_byte_file = os.path.join(CSV_PATH, "test_triage.csv\0something")
             with pytest.raises(ValueError) as e:
                 main(["cve-bin-tool", null_byte_file])
-            assert e.value.args[0] == ERROR_CODES[ValueError]
 
     def test_invalid_parameter(self):
         """Test that invalid parmeters exit with expected error code.

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -97,6 +97,16 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", "non-existant"])
         assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
 
+    def test_null_byte_in_filename(self):
+        """Test behaviour with an invalid file/directory that contains a \0"""
+
+        # Put a null byte into the filename of a real file used in other tests
+        CSV_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
+        null_byte_file = os.path.join(CSV_PATH, "test_triage\0.csv")
+        with pytest.raises(SystemExit) as e:
+            main(["cve-bin-tool", null_byte_file])
+        assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
+
     def test_invalid_parameter(self):
         """Test that invalid parmeters exit with expected error code.
         ArgParse calls sys.exit(2) for all errors"""

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -107,6 +107,11 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", null_byte_file])
         assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
 
+        null_byte_file = os.path.join(CSV_PATH, "test_triage.csv\0something")
+        with pytest.raises(SystemExit) as e:
+            main(["cve-bin-tool", null_byte_file])
+        assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
+
     def test_invalid_parameter(self):
         """Test that invalid parmeters exit with expected error code.
         ArgParse calls sys.exit(2) for all errors"""


### PR DESCRIPTION
Simple test to make sure that null bytes are handled correctly in filenames specified on the command line.

This is a kind of useless attack in practice for cve-bin-tool: you can only scan files you already have access to on the system so there's not much point in trying to disguise a file with a null byte.  But since it's a relatively small test to prove that this isn't an issue for security compliance reasons, I'm just going to go ahead and add it.