### PR TITLE
fix: Default to UNKNOWN in java version checker

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -237,7 +237,7 @@ class VersionScanner:
             if version is None and parent is not None:
                 version = parent.find(schema + "version").text
 
-            # If no version has been found, set versin to UNKNOWN
+            # If no version has been found, set version to UNKNOWN
             if version is None:
                 version = "UNKNOWN"
 

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -236,6 +236,11 @@ class VersionScanner:
                 version = root.find(schema + "version").text
             if version is None and parent is not None:
                 version = parent.find(schema + "version").text
+
+            # If all else fails, set version to UNKNOWN
+            if version is None:
+                version = "UNKNOWN"
+
             # Check valid version identifier (i.e. starts with a digit)
             if not version[0].isdigit():
                 self.logger.debug(f"Invalid {version} detected in {filename}")

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -237,7 +237,7 @@ class VersionScanner:
             if version is None and parent is not None:
                 version = parent.find(schema + "version").text
 
-            # If all else fails, set version to UNKNOWN
+            # If no version has been found, set versin to UNKNOWN
             if version is None:
                 version = "UNKNOWN"
 


### PR DESCRIPTION
Static analysis says we can still sometimes wind up with version set to None in the java version parser.  Set it explicitly to "UNKNOWN" to match the other checkers.

cc @anthonyharrison who might want to review this 