### PR TITLE
fix: fix egg_updater for installed packages

### DIFF
--- a/cve_bin_tool/egg_updater.py
+++ b/cve_bin_tool/egg_updater.py
@@ -9,11 +9,14 @@ from io import StringIO
 from setuptools import find_packages
 from setuptools.dist import Distribution
 
-with open(os.path.join("cve_bin_tool", "version.py")) as f:
-    for line in f:
-        if line.startswith("VERSION"):
-            VERSION = ast.literal_eval(line.strip().split("=")[-1].strip())
-            break
+try:
+    from cve_bin_tools.version import VERSION
+except ModuleNotFoundError:
+    with open(os.path.join("cve_bin_tool", "version.py")) as f:
+        for line in f:
+            if line.startswith("VERSION"):
+                VERSION = ast.literal_eval(line.strip().split("=")[-1].strip())
+                break
 
 
 def IS_DEVELOP() -> bool:


### PR DESCRIPTION
Found a flaw in the installed 3.1rc2 package: egg_updater was failing because it was trying to get the version incorrectly.  This might not be the best possible fix (we could maybe make sure this code doesn't get loaded for installed packages) but this does the trick for now.