### PR TITLE
fix: typo fix + version bump

### DIFF
--- a/cve_bin_tool/egg_updater.py
+++ b/cve_bin_tool/egg_updater.py
@@ -10,7 +10,7 @@ from setuptools import find_packages
 from setuptools.dist import Distribution
 
 try:
-    from cve_bin_tools.version import VERSION
+    from cve_bin_tool.version import VERSION
 except ModuleNotFoundError:
     with open(os.path.join("cve_bin_tool", "version.py")) as f:
         for line in f:

--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -8,7 +8,7 @@ from packaging import version
 
 from cve_bin_tool.log import LOGGER
 
-VERSION: str = "3.1"
+VERSION: str = "3.1.1"
 
 
 def check_latest_version():


### PR DESCRIPTION
Error report on the new 3.1 package -- apparently we missed a typo in the egg_updater code.  