### PR TITLE
fix: check return on re.search

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -272,7 +272,13 @@ class CVEScanner:
             else:
                 # Handle a.b.c<string> e.g. 1.20.9rel1
                 pv = re.search(r"\d[.\d]*", product_info.version)
-        parsed_version = parse_version(pv.group(0))
+        if pv is None:
+            parsed_version = "UNKNOWN"
+            self.logger.warn(
+                f"error parsing {product_info.vendor}.{product_info.product} v{product_info.version} - manual inspection required"
+            )
+        else:
+            parsed_version = parse_version(pv.group(0))
         return parsed_version, version_between
 
     def affected(self):


### PR DESCRIPTION
addresses #1639

re.search returns `None` on failure, updating to indicate the version is
`UNKNOWN` when this occurs and generating a log message

I noted as well that there are other places in the code where this is unchecked, but it doesn't look like they could normally fail, but this should specifically fix #1639. 

Checklist
----

- [x] Have I run the tests locally on at least one version of Python? - the number of tests that pass before and after this change are the same. No additional warnings are generated.
- [x] Have I run the code linters and fixed any issues they found?
- [ ] Have I added any tests I need to prove that my code works? - **N/A** I am unable to provide the binary that causes this defect at this time.
- [x] Have I used [Conventional Commits](https://www.conventionalcommits.org/) to format the title of my pull request?
- [x] If I closed a bug, have I linked it using one of [GitHub's keywords]
Have I checked on the results from GitHub Actions?


Please feel free to make any recommendations / suggestions for improvement as this is my first PR to your project.