### PR TITLE
test: Add Atheris fuzzing setup for cve-bin-tool

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -14,6 +14,7 @@ apk
 Args
 asn
 asottile
+atheris
 atlassian
 autoescape
 autoextract
@@ -113,6 +114,7 @@ frontend
 fsck
 fsf
 ftp
+fuzzer
 gcc
 getenv
 gettext
@@ -123,6 +125,7 @@ glibc
 gnomeshell
 gnupg
 gnutls
+google
 Google
 gpgme
 grep

--- a/fuzz/Readme.md
+++ b/fuzz/Readme.md
@@ -1,0 +1,18 @@
+# Fuzz testing for cve-bin-tool
+
+We're in the early stages of doing fuzz testing on cve-bin-tool, with the goal
+of improving our input validation and finding potential crashes before users
+do.
+
+If you want to try it out, I have made a very simple setup for the [Atheris
+fuzzer](https://github.com/google/atheris) in `fuzz/fuzz_main.py`
+
+You can run this yourself from the main cve-bin-tool directory using
+
+```console
+python -m fuzz.fuzz_main
+```
+
+We recommend that you use a separate VM or machine for fuzz testing, as fuzzing involves sending a lot of bad data into a program and can produce unpredictable results.  This could include damage to data on your system.
+
+

--- a/fuzz/Readme.md
+++ b/fuzz/Readme.md
@@ -7,7 +7,10 @@ do.
 If you want to try it out, I have made a very simple setup for the [Atheris
 fuzzer](https://github.com/google/atheris) in `fuzz/fuzz_main.py`
 
-You can run this yourself from the main cve-bin-tool directory using
+To install Atheris, use `pip install atheris` or you can use the fuzz-requirements.txt file I've provided (`pip install -U -r fuzz-requirements.txt`).
+
+Once you have atheris installed, you can run the main fuzzing script yourself
+from the main cve-bin-tool directory using
 
 ```console
 python -m fuzz.fuzz_main

--- a/fuzz/Readme.md
+++ b/fuzz/Readme.md
@@ -61,7 +61,7 @@ pip install -e .
 pip install -U -r fuzz/fuzz-requirements.txt
 
 # run cve-bin-tool once to get the cve data and make sure it's working
-# (We may wan to fuzz the cve data gaterhing part later, but not now)
+# (We may wan to fuzz the cve data gathering part later, but not now)
 python -m cve_bin_tool.cli test/assets/test-curl-7.34.0.out
 
 # actually fuzz something

--- a/fuzz/Readme.md
+++ b/fuzz/Readme.md
@@ -16,6 +16,55 @@ from the main cve-bin-tool directory using
 python -m fuzz.fuzz_main
 ```
 
+Right now, this won't do much, because it's just throwing garbage at the command line arguments and mostly that will return an error.  The fuzzer will need to be made smarter before we'll get really interesting crashes.
+
 We recommend that you use a separate VM or machine for fuzz testing, as fuzzing involves sending a lot of bad data into a program and can produce unpredictable results.  This could include damage to data on your system.
 
+Note that `virtualenv` does not provide the kind of protections you need.  Python's `virtualenv` handles default python versions and `$PYTHON_PATH` setup and whatnot for you, but does not restrict access to data on your machine.`
 
+
+## Setting up for fuzzing
+
+Setting up a VM or container is beyond the scope of this document, but if you
+search for "[set up a linux
+vm](https://www.google.com/search?q=set+up+a+linux+vm)" or "[set up a linux
+docker
+container](https://www.google.com/search?q=set+up+a+linux+docker+container)" or
+similar you should be able to find what you need.
+
+Once you have an operating system installed, you can then grab the code for cve-bin-tool and try fuzzing:
+
+An example setup script used on Ubuntu 20.04 LTS:
+
+```bash
+#!/bin/bash
+
+# copy ssh keys over for easier copying of data
+
+# Get system python.  Defaulting to 3.9 for now.
+# Note that this is the Ubuntu 20.04 requirements; other systems may differ
+sudo apt install python3.9 python3-virtualenv cabextract
+
+# set up cve-bin-tool code
+mkdir Code
+cd Code
+git clone https://github.com/intel/cve-bin-tool
+
+# set up virtualenv
+virtualenv -p python3.9 ~/venv-fuzz/
+source ~/venv-fuzz/bin/activate
+
+# Install cve-bin-tool & required packages
+# Note that you need the cve-bin-tool install to get the checkers set up
+cd cve-bin-tool
+pip install -e .
+pip install -U -r fuzz/fuzz-requirements.txt
+
+# run cve-bin-tool once to get the cve data and make sure it's working
+# (We may wan to fuzz the cve data gaterhing part later, but not now)
+python -m cve_bin_tool.cli test/assets/test-curl-7.34.0.out
+
+# actually fuzz something
+python -m fuzz.fuzz_main
+
+```

--- a/fuzz/fuzz-requirements.txt
+++ b/fuzz/fuzz-requirements.txt
@@ -1,0 +1,1 @@
+atheris

--- a/fuzz/fuzz_main.py
+++ b/fuzz/fuzz_main.py
@@ -7,7 +7,12 @@ with atheris.instrument_imports():
 
 
 def TestOneInput(data):
-    cli.main(data)
+    try:
+        cli.main(data)
+
+    except SystemExit:
+        # force return on SystemExit since those are mostly InsufficientArgs
+        return
 
 
 atheris.Setup(sys.argv, TestOneInput)

--- a/fuzz/fuzz_main.py
+++ b/fuzz/fuzz_main.py
@@ -8,6 +8,8 @@ with atheris.instrument_imports():
 
 def TestOneInput(data):
     try:
+        # uncomment the one below to run tests where there is a valid filename:
+        # cli.main(["test/assets/test-curl-7.34.0.out", data])
         cli.main(data)
 
     except SystemExit:

--- a/fuzz/fuzz_main.py
+++ b/fuzz/fuzz_main.py
@@ -1,0 +1,14 @@
+import atheris
+
+with atheris.instrument_imports():
+    import sys
+
+    from cve_bin_tool import cli
+
+
+def TestOneInput(data):
+    cli.main(data)
+
+
+atheris.Setup(sys.argv, TestOneInput)
+atheris.Fuzz()


### PR DESCRIPTION
I'm working on some initial exploration into fuzzing cve-bin-tool using the Atheris fuzzer from Google.  This looks like it handles instrumentation of python code and then hooks up libfuzzer.

Fuzzing (for those not familiar) involves sending potentially large amounts of "bad" data into a program and seeing how it responds.  It's regularly used for security and validation to find crashes and potential security holes.  Since we've never done it on cve-bin-tool before I expect we'll find a lot of crashes.  Doing fuzzing can potentially damage data on your system, so I recommend you do this within a vm, docker container, or have some other way of sandboxing the tool.  (Note that virtualenv won't work for this; it does not provide the protections needed.)