### PR TITLE
refactor(extractor): Prioritize 7z while extracting pkg files in windows

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -128,6 +128,24 @@ class BaseExtractor:
     async def extract_file_pkg(self, filename: str, extraction_path: str) -> int:
         """Extract pkg files"""
 
+        async def _extract_through_7z() -> int:
+            """Extract file using `7z`"""
+
+            temp = os.path.join(self.tempdir, f"{os.path.basename(filename)}")
+            stdout, stderr, _ = await aio_run_command(
+                ["7z", "x", filename, f"-o{self.tempdir}"]
+            )
+            stdout, stderr, _ = await aio_run_command(
+                ["7z", "x", temp[:-4], f"-o{extraction_path}"]
+            )
+            if not stdout:
+                return 1
+            return 0
+
+        if sys.platform.startswith("win"):
+            if await aio_inpath("7z"):
+                return await _extract_through_7z()
+
         # Tarfile wasn't used here because it can't open [.pkg] files directy
         # and failed to manage distinct compression types in differnet versions of FreeBSD packages.
         # Reference: https://github.com/intel/cve-bin-tool/pull/1580#discussion_r829346602
@@ -139,12 +157,7 @@ class BaseExtractor:
                 return 1
             return 0
         if await aio_inpath("7z"):
-            stdout, stderr, _ = await aio_run_command(
-                ["7z", "x", filename, "-o", extraction_path]
-            )
-            if stderr or not stdout:
-                return 1
-            return 0
+            return await _extract_through_7z()
         return 1
 
     async def extract_file_deb(self, filename, extraction_path):


### PR DESCRIPTION
fixes #1688 