### PR TITLE
fix: logger.warn() warning & test_output_vex test (#1691)

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -315,7 +315,7 @@ except ModuleNotFoundError:
         merge_report,
         exploits: bool = False,
     ):
-        LOGGER.warn("PDF output requires install of reportlab")
+        LOGGER.warning("PDF output requires install of reportlab")
 
 
 class OutputEngine:

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -682,7 +682,7 @@ class TestOutputEngine(unittest.TestCase):
     def test_output_vex(self):
         """Test creating VEX formatted file"""
         self.output_engine.generate_vex(self.MOCK_OUTPUT, "test.vex")
-        with open("test.vex", "r") as f:
+        with open("test.vex") as f:
             self.assertEqual(json.load(f), self.VEX_FORMATTED_OUTPUT[0])
         os.remove("test.vex")
 

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -682,7 +682,8 @@ class TestOutputEngine(unittest.TestCase):
     def test_output_vex(self):
         """Test creating VEX formatted file"""
         self.output_engine.generate_vex(self.MOCK_OUTPUT, "test.vex")
-        self.assertEqual(json.load(open("test.vex")), self.VEX_FORMATTED_OUTPUT[0])
+        with open("test.vex", "r") as f:
+            self.assertEqual(json.load(f), self.VEX_FORMATTED_OUTPUT[0])
         os.remove("test.vex")
 
     @unittest.skipUnless(


### PR DESCRIPTION
- Fixed #1691 by replace the depreciated `warn` method with `warning`.
- Fixed the ResourceWarning in `test_output_vex` test. The following warning was printed because the test file was only being opened in default 'r' mode but was never closed. 

The test was run using `python3 setup.py test`

```
test_output_vex (test.test_output_engine.TestOutputEngine)
Test creating VEX formatted file ... /workspaces/cve-bin-tool/test/test_output_engine.py:685: ResourceWarning:

unclosed file <_io.TextIOWrapper name='test.vex' mode='r' encoding='UTF-8'>
```