### PR TITLE
feat: add radare2 contains patterns

### DIFF
--- a/cve_bin_tool/checkers/radare2.py
+++ b/cve_bin_tool/checkers/radare2.py
@@ -12,7 +12,12 @@ from cve_bin_tool.checkers import Checker
 
 
 class Radare2Checker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS = [
+        r"--           run radare2 without opening any file",
+        r"-v, -V       show radare2 version (-V show lib versions)",
+        r"list all links in radare2 command format.",
+        r"radare2 does not support projects on debugged bins.",
+    ]
     FILENAME_PATTERNS = [r"rafind2"]
     VERSION_PATTERNS = [r"rafind2 v([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("radare", "radare2")]


### PR DESCRIPTION
Added contains patterns which included in current RPM, DEB, and git repository binaries from stable versions (checked from 5.4.0 to 5.6.8)

related to [this issue](https://github.com/intel/cve-bin-tool/issues/1349)