### PR TITLE
feat(checkers): Add polarssl fedora contains patterns

### DIFF
--- a/cve_bin_tool/checkers/expat.py
+++ b/cve_bin_tool/checkers/expat.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-r"""
+"""
 CVE checker for libexpat
 
 References:

--- a/cve_bin_tool/checkers/expat.py
+++ b/cve_bin_tool/checkers/expat.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-"""
+r"""
 CVE checker for libexpat
 
 References:
@@ -14,7 +14,7 @@ http://www.cvedetails.com/vulnerability-feed.php?vendor_id=12682&product_id=0&ve
 http://www.cvedetails.com/vulnerability-feed.php?vendor_id=16735&product_id=0&version_id=0&orderby=3&cvssscoremin=0
 
 Easiest way to check CVEs is currently the Changes.txt file.  You can pinpoint the CVEs using grep as follows:
-grep 'Release\\|CVE' Changes.txt
+grep 'Release\|CVE' Changes.txt
 
 Which will give you output like...
 

--- a/cve_bin_tool/checkers/expat.py
+++ b/cve_bin_tool/checkers/expat.py
@@ -14,7 +14,7 @@ http://www.cvedetails.com/vulnerability-feed.php?vendor_id=12682&product_id=0&ve
 http://www.cvedetails.com/vulnerability-feed.php?vendor_id=16735&product_id=0&version_id=0&orderby=3&cvssscoremin=0
 
 Easiest way to check CVEs is currently the Changes.txt file.  You can pinpoint the CVEs using grep as follows:
-grep 'Release\|CVE' Changes.txt
+grep 'Release\\|CVE' Changes.txt
 
 Which will give you output like...
 
@@ -26,7 +26,6 @@ Release 2.2.2 Wed July 12 2017
 Release 2.2.1 Sat June 17 2017
                   CVE-2017-9233 -- External entity infinite loop DoS
 (etc.)
-
 """
 from cve_bin_tool.checkers import Checker
 

--- a/cve_bin_tool/checkers/polarssl_fedora.py
+++ b/cve_bin_tool/checkers/polarssl_fedora.py
@@ -23,7 +23,6 @@ class PolarsslFedoraChecker(Checker):
         # see https://github.com/intel/cve-bin-tool/tree/main/cve_bin_tool/checkers#helper-script for more details
         # r"mbedtls_ssl_conf_ciphersuites_for_version",
         # r"mbedtls_x509_crt_check_extended_key_usage",
-
     ]
     FILENAME_PATTERNS = [r"libpolarssl.so."]
     VERSION_PATTERNS = [

--- a/cve_bin_tool/checkers/polarssl_fedora.py
+++ b/cve_bin_tool/checkers/polarssl_fedora.py
@@ -30,6 +30,7 @@ class PolarsslFedoraChecker(Checker):
     ]  # patterns like this aren't ideal
     VENDOR_PRODUCT = [("polarssl", "polarssl")]
 
+
 # Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
 # The reason behind this is that these might depend on who packages the file (like it
 # might work on fedora but not on ubuntu)

--- a/cve_bin_tool/checkers/polarssl_fedora.py
+++ b/cve_bin_tool/checkers/polarssl_fedora.py
@@ -15,7 +15,16 @@ from cve_bin_tool.checkers import Checker
 
 
 class PolarsslFedoraChecker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS = [
+        r"Bad usage of mbedtls_ssl_set_bio() or mbedtls_ssl_set_bio()",
+        r"You must use mbedtls_ssl_set_timer_cb() for DTLS",
+        r"configured max major version is invalid, consider using mbedtls_ssl_config_defaults()",
+        # Alternate optional contains patterns,
+        # see https://github.com/intel/cve-bin-tool/tree/main/cve_bin_tool/checkers#helper-script for more details
+        # r"mbedtls_ssl_conf_ciphersuites_for_version",
+        # r"mbedtls_x509_crt_check_extended_key_usage",
+
+    ]
     FILENAME_PATTERNS = [r"libpolarssl.so."]
     VERSION_PATTERNS = [
         r"libpolarssl.so.([0-9]+\.[0-9]+\.[0-9]+)"

--- a/cve_bin_tool/checkers/polarssl_fedora.py
+++ b/cve_bin_tool/checkers/polarssl_fedora.py
@@ -31,9 +31,6 @@ class PolarsslFedoraChecker(Checker):
     ]  # patterns like this aren't ideal
     VENDOR_PRODUCT = [("polarssl", "polarssl")]
 
-
-"""
-Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it
-might work on fedora but not on ubuntu)
-"""
+# Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
+# The reason behind this is that these might depend on who packages the file (like it
+# might work on fedora but not on ubuntu)


### PR DESCRIPTION
As discussed in [this PR](https://github.com/intel/cve-bin-tool/issues/1349) contains patterns for polarssl fedora added.
There is also a small modification on docstring.