### PR TITLE
ci: bump `setup-python` version

### DIFF
--- a/.github/workflows/cve_scan.yml
+++ b/.github/workflows/cve_scan.yml
@@ -12,8 +12,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
+          python-version: '3.x'
           cache: 'pip'
           cache-dependency-path: '**/requirements.txt'
       - name: Get date

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -13,8 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
+          python-version: '3.x'
           cache: 'pip'
       - name: Install cve-bin-tool
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,8 +15,9 @@ jobs:
         tool: ['isort', 'black', 'pyupgrade', 'flake8', 'bandit', 'gitlint']
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
+          python-version: '3.x'
           cache: 'pip'
       - name: Install pre-commit
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -21,8 +21,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
+          python-version: '3.x'
           cache: 'pip'
           cache-dependency-path: 'doc/requirements.txt'
       - name: Install doc dependencies
@@ -45,7 +46,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
@@ -92,7 +93,7 @@ jobs:
       LONG_TESTS: 1
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: '3.8'
           cache: 'pip'
@@ -162,7 +163,7 @@ jobs:
       PYTHONIOENCODING: 'utf8'
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'

--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -17,7 +17,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
 
       - name: Install pre-commit
         run: |

--- a/doc/how_to_guides/cve_scanner_gh_action.md
+++ b/doc/how_to_guides/cve_scanner_gh_action.md
@@ -30,9 +30,9 @@ jobs:
     #  Let's first download dependencies for this action.
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.x'
     #  This second step is unnecessary but highly recommended because
     #  It will cache database and saves time re-downloading it if database isn't stale.
       - name: get cached python packages

--- a/doc/how_to_guides/cve_scanner_gh_action.yml
+++ b/doc/how_to_guides/cve_scanner_gh_action.yml
@@ -16,9 +16,9 @@ jobs:
     #  Let's first download dependencies for this action.
       - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.x'
     #  This second step is unnecessary but highly recommended because
     #  It will cache database and saves time redownloading it if database isn't stale.
       - name: get cached python packages


### PR DESCRIPTION
`setup-python` Action had a breaking change with [v4 release](https://github.com/actions/setup-python/releases/tag/v4.0.0), it's now required to specify `python-version` or it defaults to the `python-version-file` and errors out if it can't find such file.