### PR TITLE
ci: use Dependabot to bump GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This will keep the various GH Actions used in workflows up to date.
I set the interval to daily and not weekly/monthly but I believe it shouldn't create too much noise because:
- major versions of Actions are not updated too often (every few months) and we only pin to major version
- this doesn't produce any new runs in the Actions tab
We will just get pull requests sooner.

I recommend merging #1711 before this PR.