### PR TITLE
refactor: use pathlib.Path instead of os.path

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -90,7 +90,7 @@ class BaseExtractor:
                 stdout, stderr, _ = await aio_run_command(["rpm2cpio", filename])
                 if stderr or not stdout:
                     return 1
-                cpio_path = (extraction_path_pathlib / "data.cpio").__str__()
+                cpio_path = str(extraction_path_pathlib / "data.cpio")
                 async with FileIO(cpio_path, "wb") as f:
                     await f.write(stdout)
                 stdout, stderr, _ = await aio_run_command(
@@ -106,20 +106,16 @@ class BaseExtractor:
                 stdout, stderr, _ = await aio_run_command(["7z", "x", filename])
                 if stderr or not stdout:
                     return 1
-                filenames = await aio_glob(
-                    (extraction_path_pathlib / "*.cpio").__str__()
-                )
+                filenames = await aio_glob(str(extraction_path_pathlib / "*.cpio"))
                 if not filenames:
                     filenames = await aio_glob(
-                        (extraction_path_pathlib / "*.cpio.zstd").__str__()
+                        str(extraction_path_pathlib / "*.cpio.zstd")
                     )
                     filename = filenames[0]
                     exit_code = await self.extract_file_zst(filename, extraction_path)
                     if exit_code:
                         return 1
-                    filenames = await aio_glob(
-                        (extraction_path_pathlib / "*.cpio").__str__()
-                    )
+                    filenames = await aio_glob(str(extraction_path_pathlib / "*.cpio"))
                 filename = filenames[0]
                 stdout, stderr, _ = await aio_run_command(["7z", "x", filename])
                 if stderr or not stdout:
@@ -150,7 +146,7 @@ class BaseExtractor:
         async def _extract_through_7z() -> int:
             """Extract file using `7z`"""
 
-            temp = (Path(self.tempdir) / Path(filename).stem).__str__()
+            temp = str(Path(self.tempdir) / Path(filename).stem)
             stdout, stderr, _ = await aio_run_command(
                 ["7z", "x", filename, f"-o{self.tempdir}"]
             )
@@ -188,7 +184,7 @@ class BaseExtractor:
             stdout, stderr, _ = await aio_run_command(["ar", "x", filename])
             if stderr:
                 return 1
-            datafile = await aio_glob((Path(extraction_path) / "data.tar.*").__str__())
+            datafile = await aio_glob(str(Path(extraction_path) / "data.tar.*"))
             with ErrorHandler(mode=ErrorMode.Ignore) as e:
                 await aio_unpack_archive(datafile[0], extraction_path)
             return e.exit_code
@@ -290,13 +286,13 @@ class TempDirExtractorContext(BaseExtractor):
         """Run the extractor"""
         filename_pathlib = Path(filename)
         # Resolve path in case of cwd change
-        filename = filename_pathlib.resolve().__str__()
+        filename = str(filename_pathlib.resolve())
         for extractor in self.file_extractors:
             for extension in self.file_extractors[extractor]:
                 if filename.endswith(extension):
-                    extracted_path = (
+                    extracted_path = str(
                         Path(self.tempdir) / f"{filename_pathlib.name}.extracted"
-                    ).__str__()
+                    )
                     if Path(extracted_path).exists():
                         await aio_rmdir(extracted_path)
                     await aio_makedirs(extracted_path, 0o700)

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -5,12 +5,12 @@
 Extraction of archives
 """
 import itertools
-import os
 import re
 import shutil
 import sys
 import tarfile
 import tempfile
+from pathlib import Path
 
 import zstandard
 from rpmfile.cli import main as rpmextract
@@ -66,7 +66,7 @@ class BaseExtractor:
     def can_extract(self, filename):
         """Check if the filename is something we know how to extract"""
         # Do not try to extract symlinks
-        if os.path.islink(filename):
+        if Path(filename).is_symlink():
             return False
         for extension in itertools.chain(*self.file_extractors.values()):
             if filename.endswith(extension):
@@ -82,6 +82,7 @@ class BaseExtractor:
 
     async def extract_file_rpm(self, filename, extraction_path):
         """Extract rpm packages"""
+        extraction_path_pathlib = Path(extraction_path)
         if sys.platform.startswith("linux"):
             if not await aio_inpath("rpm2cpio") or not await aio_inpath("cpio"):
                 await rpmextract("-xC", extraction_path, filename)
@@ -89,7 +90,7 @@ class BaseExtractor:
                 stdout, stderr, _ = await aio_run_command(["rpm2cpio", filename])
                 if stderr or not stdout:
                     return 1
-                cpio_path = os.path.join(extraction_path, "data.cpio")
+                cpio_path = (extraction_path_pathlib / "data.cpio").__str__()
                 async with FileIO(cpio_path, "wb") as f:
                     await f.write(stdout)
                 stdout, stderr, _ = await aio_run_command(
@@ -105,16 +106,20 @@ class BaseExtractor:
                 stdout, stderr, _ = await aio_run_command(["7z", "x", filename])
                 if stderr or not stdout:
                     return 1
-                filenames = await aio_glob(os.path.join(extraction_path, "*.cpio"))
+                filenames = await aio_glob(
+                    (extraction_path_pathlib / "*.cpio").__str__()
+                )
                 if not filenames:
                     filenames = await aio_glob(
-                        os.path.join(extraction_path, "*.cpio.zstd")
+                        (extraction_path_pathlib / "*.cpio.zstd").__str__()
                     )
                     filename = filenames[0]
                     exit_code = await self.extract_file_zst(filename, extraction_path)
                     if exit_code:
                         return 1
-                    filenames = await aio_glob(os.path.join(extraction_path, "*.cpio"))
+                    filenames = await aio_glob(
+                        (extraction_path_pathlib / "*.cpio").__str__()
+                    )
                 filename = filenames[0]
                 stdout, stderr, _ = await aio_run_command(["7z", "x", filename])
                 if stderr or not stdout:
@@ -128,9 +133,7 @@ class BaseExtractor:
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
             if filename.endswith(".cpio.zstd"):
                 with open(filename, "rb") as compressed:
-                    base = os.path.basename(filename)
-                    file = os.path.splitext(base)[0]
-                    output_path = os.path.join(extraction_path, file)
+                    output_path = Path(extraction_path) / Path(filename).stem
                     with open(output_path, "wb") as destination:
                         dctx.copy_stream(compressed, destination)
             else:
@@ -147,12 +150,12 @@ class BaseExtractor:
         async def _extract_through_7z() -> int:
             """Extract file using `7z`"""
 
-            temp = os.path.join(self.tempdir, f"{os.path.basename(filename)}")
+            temp = (Path(self.tempdir) / Path(filename).stem).__str__()
             stdout, stderr, _ = await aio_run_command(
                 ["7z", "x", filename, f"-o{self.tempdir}"]
             )
             stdout, stderr, _ = await aio_run_command(
-                ["7z", "x", temp[:-4], f"-o{extraction_path}"]
+                ["7z", "x", temp, f"-o{extraction_path}"]
             )
             if not stdout:
                 return 1
@@ -185,7 +188,7 @@ class BaseExtractor:
             stdout, stderr, _ = await aio_run_command(["ar", "x", filename])
             if stderr:
                 return 1
-            datafile = await aio_glob(os.path.join(extraction_path, "data.tar.*"))
+            datafile = await aio_glob((Path(extraction_path) / "data.tar.*").__str__())
             with ErrorHandler(mode=ErrorMode.Ignore) as e:
                 await aio_unpack_archive(datafile[0], extraction_path)
             return e.exit_code
@@ -285,15 +288,16 @@ class TempDirExtractorContext(BaseExtractor):
 
     async def aio_extract(self, filename):
         """Run the extractor"""
+        filename_pathlib = Path(filename)
         # Resolve path in case of cwd change
-        filename = os.path.abspath(filename)
+        filename = filename_pathlib.resolve().__str__()
         for extractor in self.file_extractors:
             for extension in self.file_extractors[extractor]:
                 if filename.endswith(extension):
-                    extracted_path = os.path.join(
-                        self.tempdir, f"{os.path.basename(filename)}.extracted"
-                    )
-                    if os.path.exists(extracted_path):
+                    extracted_path = (
+                        Path(self.tempdir) / f"{filename_pathlib.name}.extracted"
+                    ).__str__()
+                    if Path(extracted_path).exists():
                         await aio_rmdir(extracted_path)
                     await aio_makedirs(extracted_path, 0o700)
                     async with ChangeDirContext(extracted_path):

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,10 +5,10 @@
 CVE-bin-tool CLI tests
 """
 import logging
-import os
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from test.utils import (
     CURL_7_20_0_RPM,
     CURL_7_20_0_URL,
@@ -31,11 +31,11 @@ from cve_bin_tool.version_scanner import VersionScanner
 class TestCLI(TempDirTest):
     """Tests the CVE Bin Tool CLI"""
 
-    TEST_PATH = os.path.abspath(os.path.dirname(__file__))
+    TEST_PATH = Path(__file__).parent.resolve()
 
     def setup_method(self):
-        download_file(CURL_7_20_0_URL, os.path.join(self.tempdir, CURL_7_20_0_RPM))
-        download_file(TMUX_DEB, os.path.join(self.tempdir, TMUX_DEB_NAME))
+        download_file(CURL_7_20_0_URL, Path(self.tempdir) / CURL_7_20_0_RPM)
+        download_file(TMUX_DEB, Path(self.tempdir) / TMUX_DEB_NAME)
 
     def test_extract_curl_7_20_0(self):
         """Scanning curl-7.20.0"""
@@ -44,14 +44,14 @@ class TestCLI(TempDirTest):
     def test_binary_curl_7_20_0(self):
         """Extracting from rpm and scanning curl-7.20.0"""
         with Extractor() as ectx:
-            extracted_path = ectx.extract(os.path.join(self.tempdir, CURL_7_20_0_RPM))
+            extracted_path = ectx.extract(str(Path(self.tempdir) / CURL_7_20_0_RPM))
             assert (
                 main(
                     [
                         "cve-bin-tool",
                         "-l",
                         "debug",
-                        os.path.join(extracted_path, "usr", "bin", "curl"),
+                        str(Path(extracted_path) / "usr" / "bin" / "curl"),
                     ]
                 )
                 != 0
@@ -59,19 +59,19 @@ class TestCLI(TempDirTest):
 
     def test_no_extraction(self):
         """Test scanner against curl-7.20.0 rpm with extraction turned off"""
-        assert main(["cve-bin-tool", os.path.join(self.tempdir, CURL_7_20_0_RPM)]) != 0
+        assert main(["cve-bin-tool", str(Path(self.tempdir) / CURL_7_20_0_RPM)]) != 0
 
     def test_extract_bad_zip_messages(self, caplog):
         """Test that bad zip files are logged as extraction failed, but
         bad exe files produce no such message"""
-        bad_exe_file = os.path.join(self.tempdir, "empty-file.exe")
+        bad_exe_file = str(Path(self.tempdir) / "empty-file.exe")
         # creates an empty, invalid .exe test file
         open(bad_exe_file, "w").close()
         with caplog.at_level(logging.WARNING):
             main(["cve-bin-tool", bad_exe_file])
         assert "Failure extracting" not in caplog.text
 
-        bad_zip_file = os.path.join(self.tempdir, "empty-file.zip")
+        bad_zip_file = str(Path(self.tempdir) / "empty-file.zip")
         open(bad_zip_file, "w").close()
         with caplog.at_level(logging.WARNING):
             main(["cve-bin-tool", bad_zip_file])
@@ -79,11 +79,11 @@ class TestCLI(TempDirTest):
 
     def test_exclude(self, caplog):
         """Test that the exclude paths are not scanned"""
-        test_path = os.path.abspath(os.path.dirname(__file__))
-        exclude_path = os.path.join(test_path, "assets/")
+        test_path = Path(__file__).parent.resolve()
+        exclude_path = str(test_path / "assets/")
         checkers = list(VersionScanner().checkers.keys())
         with caplog.at_level(logging.INFO):
-            main(["cve-bin-tool", test_path, "-e", ",".join(exclude_path)])
+            main(["cve-bin-tool", str(test_path), "-e", ",".join(exclude_path)])
         self.check_exclude_log(caplog, exclude_path, checkers)
 
     def test_usage(self):
@@ -102,8 +102,8 @@ class TestCLI(TempDirTest):
         """Test behaviour with an invalid file/directory that contains a \0"""
 
         # Put a null byte into the filename of a real file used in other tests
-        CSV_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
-        null_byte_file = os.path.join(CSV_PATH, "test_triage\0.csv")
+        CSV_PATH = Path(__file__).parent.resolve() / "csv"
+        null_byte_file = str(CSV_PATH / "test_triage\0.csv")
 
         # for Python 3.8+ this should raise FileNotFound
         if sys.version_info.major == 3 and sys.version_info.minor > 7:
@@ -111,7 +111,7 @@ class TestCLI(TempDirTest):
                 main(["cve-bin-tool", null_byte_file])
             assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
 
-            null_byte_file = os.path.join(CSV_PATH, "test_triage.csv\0something")
+            null_byte_file = str(CSV_PATH / "test_triage.csv\0something")
             with pytest.raises(SystemExit) as e:
                 main(["cve-bin-tool", null_byte_file])
             assert e.value.args[0] == ERROR_CODES[FileNotFoundError]
@@ -121,7 +121,7 @@ class TestCLI(TempDirTest):
             with pytest.raises(ValueError) as e:
                 main(["cve-bin-tool", null_byte_file])
 
-            null_byte_file = os.path.join(CSV_PATH, "test_triage.csv\0something")
+            null_byte_file = str(CSV_PATH / "test_triage.csv\0something")
             with pytest.raises(ValueError) as e:
                 main(["cve-bin-tool", null_byte_file])
 
@@ -199,7 +199,7 @@ class TestCLI(TempDirTest):
     def test_skips(self, caplog):
         """Tests the skips option"""
 
-        test_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
+        test_path = str(Path(__file__).parent.resolve() / "csv")
 
         skip_checkers = ["systemd", "xerces", "xml2", "kerberos"]
         include_checkers = ["expat", "libgcrypt", "openssl", "sqlite"]
@@ -214,7 +214,7 @@ class TestCLI(TempDirTest):
         self.check_checkers_log(caplog, skip_checkers, include_checkers)
 
     def test_runs(self, caplog):
-        test_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
+        test_path = str(Path(__file__).parent.resolve() / "csv")
 
         runs = ["expat", "libgcrypt", "openssl", "sqlite"]
         skip_checkers = ["systemd", "xerces", "xml2", "kerberos"]
@@ -229,7 +229,7 @@ class TestCLI(TempDirTest):
 
     @unittest.skipUnless(LONG_TESTS() > 0, "Skipping long tests")
     def test_update(self, caplog):
-        test_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
+        test_path = str(Path(__file__).parent.resolve() / "csv")
 
         with caplog.at_level(logging.INFO):
             main(["cve-bin-tool", "-u", "never", "-n", "json", test_path])
@@ -299,7 +299,7 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", filename, "-l", "debug"])
 
         # clean up temporary file.
-        os.remove(filename)
+        Path(filename).unlink()
 
         warnings = [
             record.message
@@ -321,7 +321,7 @@ class TestCLI(TempDirTest):
 
         main(["cve-bin-tool", "-q", filename, "-u", "now"])
         # clean up temporary file.
-        os.remove(filename)
+        Path(filename).unlink()
 
         # Make sure log is empty
         assert not caplog.records
@@ -333,8 +333,8 @@ class TestCLI(TempDirTest):
     @pytest.mark.parametrize(
         "filename",
         (
-            os.path.join(TEST_PATH, "config", "cve_bin_tool_config.toml"),
-            os.path.join(TEST_PATH, "config", "cve_bin_tool_config.yaml"),
+            str(TEST_PATH / "config" / "cve_bin_tool_config.toml"),
+            str(TEST_PATH / "config" / "cve_bin_tool_config.yaml"),
         ),
     )
     def test_config_file(self, caplog, filename):
@@ -385,9 +385,10 @@ class TestCLI(TempDirTest):
         assert e.value.args[0] == ERROR_CODES[SystemExit]
 
         my_test_filename = "sevtest.csv"
+        my_test_filename_pathlib = Path(my_test_filename)
 
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
         with caplog.at_level(logging.DEBUG):
             main(
                 [
@@ -399,7 +400,7 @@ class TestCLI(TempDirTest):
                     my_test_filename,
                     "-S",
                     "high",
-                    os.path.join(self.tempdir, CURL_7_20_0_RPM),
+                    str(Path(self.tempdir) / CURL_7_20_0_RPM),
                 ]
             )
         # Verify that no CVEs with a severity of Medium are reported
@@ -407,17 +408,18 @@ class TestCLI(TempDirTest):
         # Verify that CVEs with a higher severity are reported
         assert self.check_string_in_file(my_test_filename, "HIGH")
         caplog.clear()
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
 
     def test_CVSS_score(self, capsys, caplog):
         # scan with severity score to ensure only CVEs above score threshold are reported
 
         my_test_filename = "sevtest.csv"
+        my_test_filename_pathlib = Path(my_test_filename)
 
         # Check command line parameters. Less than 0 result in default behaviour.
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
         with caplog.at_level(logging.DEBUG):
             main(
                 [
@@ -429,7 +431,7 @@ class TestCLI(TempDirTest):
                     "csv",
                     "-o",
                     my_test_filename,
-                    os.path.join(self.tempdir, CURL_7_20_0_RPM),
+                    str(Path(self.tempdir) / CURL_7_20_0_RPM),
                 ]
             )
         # Verify that some CVEs with a severity of Medium are reported
@@ -437,8 +439,8 @@ class TestCLI(TempDirTest):
         caplog.clear()
 
         # Check command line parameters. >10 results in no CVEs being reported (Maximum CVSS score is 10)
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
         with caplog.at_level(logging.DEBUG):
             main(
                 [
@@ -450,11 +452,11 @@ class TestCLI(TempDirTest):
                     "csv",
                     "-o",
                     my_test_filename,
-                    os.path.join(self.tempdir, CURL_7_20_0_RPM),
+                    str(Path(self.tempdir) / CURL_7_20_0_RPM),
                 ]
             )
         # Verify that no CVEs are reported (no file is created)
-        assert not os.path.exists(my_test_filename)
+        assert not my_test_filename_pathlib.exists()
         caplog.clear()
 
         with caplog.at_level(logging.DEBUG):
@@ -466,14 +468,14 @@ class TestCLI(TempDirTest):
                     "csv",
                     "-o",
                     my_test_filename,
-                    os.path.join(self.tempdir, CURL_7_20_0_RPM),
+                    str(Path(self.tempdir) / CURL_7_20_0_RPM),
                 ]
             )
         # Verify that CVEs with a severity of Medium are reported
         assert self.check_string_in_file(my_test_filename, "MEDIUM")
         caplog.clear()
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
 
         # Now check subset
         with caplog.at_level(logging.DEBUG):
@@ -487,18 +489,18 @@ class TestCLI(TempDirTest):
                     "csv",
                     "-o",
                     my_test_filename,
-                    os.path.join(self.tempdir, CURL_7_20_0_RPM),
+                    str(Path(self.tempdir) / CURL_7_20_0_RPM),
                 ]
             )
         # Verify that no CVEs with a severity of Medium are reported
         assert not self.check_string_in_file(my_test_filename, "MEDIUM")
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
         caplog.clear()
 
     def test_SBOM(self, caplog):
         # check sbom file option
-        SBOM_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "sbom")
+        SBOM_PATH = Path(__file__).parent.resolve() / "sbom"
 
         with caplog.at_level(logging.INFO):
             main(
@@ -507,7 +509,7 @@ class TestCLI(TempDirTest):
                     "--sbom",
                     "spdx",
                     "--sbom-file",
-                    os.path.join(SBOM_PATH, "spdx_test.spdx"),
+                    str(SBOM_PATH / "spdx_test.spdx"),
                 ]
             )
         # Verify that one product detected
@@ -521,10 +523,11 @@ class TestCLI(TempDirTest):
         from importlib.machinery import ModuleSpec
         from importlib.util import module_from_spec
 
-        my_test_filename = os.path.join(self.tempdir, "reportlab_test_report.pdf")
+        my_test_filename_pathlib = Path(self.tempdir) / "reportlab_test_report.pdf"
+        my_test_filename = str(my_test_filename_pathlib)
 
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
 
         pkg_to_spoof = "reportlab"
         not_installed_msg = "PDF output not available. Default to console."
@@ -534,7 +537,7 @@ class TestCLI(TempDirTest):
             "pdf",
             "-o",
             my_test_filename,
-            os.path.join(self.tempdir, CURL_7_20_0_RPM),
+            str(Path(self.tempdir) / CURL_7_20_0_RPM),
         ]
 
         with caplog.at_level(logging.INFO):
@@ -548,8 +551,8 @@ class TestCLI(TempDirTest):
 
         caplog.clear()
 
-        if os.path.exists(my_test_filename):
-            os.remove(my_test_filename)
+        if my_test_filename_pathlib.exists():
+            my_test_filename_pathlib.unlink()
 
         ms = ModuleSpec(pkg_to_spoof, "surelyanotexistentmodule")
         m = module_from_spec(ms)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
+from pathlib import Path
 
 import pytest
 
@@ -10,7 +10,7 @@ from cve_bin_tool.error_handler import ErrorMode, UnknownConfigType
 
 
 class TestConfig:
-    TEST_PATH = os.path.abspath(os.path.dirname(__file__))
+    TEST_PATH = Path(__file__).parent.resolve()
     EXPECTED_CONFIG = {
         "cvss": 0,
         "directory": "test/assets",
@@ -34,7 +34,7 @@ class TestConfig:
 
     def test_unsupported_config(self):
         config_parser = ConfigParser(
-            os.path.join(self.TEST_PATH, "json", "bad.json"),
+            str(self.TEST_PATH / "json" / "bad.json"),
             error_mode=ErrorMode.FullTrace,
         )
         with pytest.raises(UnknownConfigType):
@@ -44,11 +44,11 @@ class TestConfig:
         "filepath, expected_config",
         (
             (
-                os.path.join(TEST_PATH, "config", "cve_bin_tool_config.toml"),
+                str(TEST_PATH / "config" / "cve_bin_tool_config.toml"),
                 EXPECTED_CONFIG,
             ),
             (
-                os.path.join(TEST_PATH, "config", "cve_bin_tool_config.yaml"),
+                str(TEST_PATH / "config" / "cve_bin_tool_config.yaml"),
                 EXPECTED_CONFIG,
             ),
         ),

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -57,7 +57,7 @@ class TestExtractorBase:
         # Make sure extraction reports success
         for filename in filenames:
             async with self.extractor as ectx:
-                yield await ectx.aio_extract((self.tempdir / filename).__str__())
+                yield await ectx.aio_extract(str(self.tempdir / filename))
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -110,9 +110,7 @@ class TestExtractFileTar(TestExtractorBase):
     async def test_extract_cleanup(self):
         """Make sure tar extractor cleans up after itself"""
         async with self.extractor as ectx:
-            extracted_path = await ectx.aio_extract(
-                (self.tempdir / "test.tar").__str__()
-            )
+            extracted_path = await ectx.aio_extract(str(self.tempdir / "test.tar"))
             extracted_path = Path(extracted_path)
             assert extracted_path.is_dir()
         assert not extracted_path.exists()

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -8,7 +8,7 @@ import tempfile
 import unittest
 import unittest.mock
 from io import BytesIO
-from os import path
+from pathlib import Path
 from test.utils import (
     CURL_7_20_0_URL,
     GLIB_PKG_URL,
@@ -28,14 +28,11 @@ from cve_bin_tool.util import inpath
 # import logging
 # logging.basicConfig(level=logging.DEBUG)
 
-DOVECOT_FILE_PATH = path.join(
-    path.abspath(path.dirname(__file__)),
-    "condensed-downloads",
-    "dovecot-2.3.14-1.fc34.i686.rpm",
+TEST_DIR_PATH = Path(__file__).parent.resolve()
+DOVECOT_FILE_PATH = (
+    TEST_DIR_PATH / "condensed-downloads" / "dovecot-2.3.14-1.fc34.i686.rpm"
 )
-CAB_TEST_FILE_PATH = path.join(
-    path.abspath(path.dirname(__file__)), "assets", "cab-test-python3.8.cab"
-)
+CAB_TEST_FILE_PATH = TEST_DIR_PATH / "assets" / "cab-test-python3.8.cab"
 
 
 class TestExtractorBase:
@@ -44,7 +41,7 @@ class TestExtractorBase:
     @classmethod
     def setup_class(cls):
         cls.extractor = Extractor()
-        cls.tempdir = tempfile.mkdtemp(prefix="cve-bin-tool-")
+        cls.tempdir = Path(tempfile.mkdtemp(prefix="cve-bin-tool-"))
 
     @classmethod
     def teardown_class(cls):
@@ -54,13 +51,13 @@ class TestExtractorBase:
     async def extract_files(self, filenames):
         """Make sure all test files are present"""
         for filename in filenames:
-            assert path.exists(
-                path.join(self.tempdir, filename)
-            ), f"test file {filename} was not found"
+            assert (
+                self.tempdir / filename
+            ).exists(), f"test file {filename} was not found"
         # Make sure extraction reports success
         for filename in filenames:
             async with self.extractor as ectx:
-                yield await ectx.aio_extract(path.join(self.tempdir, filename))
+                yield await ectx.aio_extract((self.tempdir / filename).__str__())
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -70,7 +67,7 @@ class TestExtractorBase:
     async def test_bad_files(self, extension_list: List[str]):
         """Test handling of invalid files. No exceptions should be raised."""
         for extension in extension_list:
-            filename = path.join(self.tempdir, f"empty-file{extension}")
+            filename = self.tempdir / f"empty-file{extension}"
             # creates an empty file with the expected extension
             open(filename, "w").close()
             async for _ in self.extract_files([filename]):
@@ -88,7 +85,7 @@ class TestExtractFileTar(TestExtractorBase):
             ("test.tar", "w"),
             ("test.tar.xz", "w:xz"),
         ]:
-            tarpath = path.join(self.tempdir, filename)
+            tarpath = self.tempdir / filename
             tar = tarfile.open(tarpath, mode=tarmode)
             data = b"feedface"
             addfile = BytesIO(data)
@@ -107,15 +104,18 @@ class TestExtractFileTar(TestExtractorBase):
         async for dir_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isdir(dir_path)
+            assert Path(dir_path).is_dir()
 
     @pytest.mark.asyncio
     async def test_extract_cleanup(self):
         """Make sure tar extractor cleans up after itself"""
         async with self.extractor as ectx:
-            extracted_path = await ectx.aio_extract(path.join(self.tempdir, "test.tar"))
-            assert path.isdir(extracted_path)
-        assert not path.exists(extracted_path)
+            extracted_path = await ectx.aio_extract(
+                (self.tempdir / "test.tar").__str__()
+            )
+            extracted_path = Path(extracted_path)
+            assert extracted_path.is_dir()
+        assert not extracted_path.exists()
 
 
 class TestExtractFileRpm(TestExtractorBase):
@@ -124,7 +124,7 @@ class TestExtractFileRpm(TestExtractorBase):
     @classmethod
     def setup_class(cls):
         super().setup_class()
-        download_file(CURL_7_20_0_URL, path.join(cls.tempdir, "test.rpm"))
+        download_file(CURL_7_20_0_URL, cls.tempdir / "test.rpm")
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -136,7 +136,7 @@ class TestExtractFileRpm(TestExtractorBase):
         async for extracted_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isfile(path.join(extracted_path, "usr", "bin", "curl"))
+            assert (Path(extracted_path) / "usr" / "bin" / "curl").is_file()
 
     @pytest.mark.asyncio
     async def test_extract_file_rpm_no_rpm2cipo(self, extension_list: List[str]):
@@ -155,7 +155,7 @@ class TestExtractFileZst(TestExtractorBase):
     """Tests for the zst file extractor"""
 
     def setup_method(self):
-        download_file(TAR_ZST_URL, path.join(self.tempdir, "test.zst"))
+        download_file(TAR_ZST_URL, self.tempdir / "test.zst")
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -167,7 +167,7 @@ class TestExtractFileZst(TestExtractorBase):
         async for extracted_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isfile(path.join(extracted_path, "usr", "bin", "tar"))
+            assert (Path(extracted_path) / "usr" / "bin" / "tar").is_file()
 
 
 class TestExtractFilePkg(TestExtractorBase):
@@ -175,7 +175,7 @@ class TestExtractFilePkg(TestExtractorBase):
 
     def setup_method(self):
         assert inpath("tar") or inpath("7z"), "Required tools 'tar' or '7z' not found"
-        download_file(GLIB_PKG_URL, path.join(self.tempdir, "test.pkg"))
+        download_file(GLIB_PKG_URL, self.tempdir / "test.pkg")
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -187,7 +187,7 @@ class TestExtractFilePkg(TestExtractorBase):
         async for extracted_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isfile(path.join(extracted_path, "usr", "local", "bin", "gio"))
+            assert (Path(extracted_path) / "usr" / "local" / "bin" / "gio").is_file()
 
 
 class TestExtractFileRpmWithZstd(TestExtractorBase):
@@ -196,7 +196,7 @@ class TestExtractFileRpmWithZstd(TestExtractorBase):
     @classmethod
     def setup_class(cls):
         super().setup_class()
-        shutil.copyfile(DOVECOT_FILE_PATH, path.join(cls.tempdir, "test.rpm"))
+        shutil.copyfile(DOVECOT_FILE_PATH, cls.tempdir / "test.rpm")
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -208,7 +208,7 @@ class TestExtractFileRpmWithZstd(TestExtractorBase):
         async for extracted_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isfile(path.join(extracted_path, "usr", "sbin", "dovecot"))
+            assert (Path(extracted_path) / "usr" / "sbin" / "dovecot").is_file()
 
 
 class TestExtractFileDeb(TestExtractorBase):
@@ -216,10 +216,8 @@ class TestExtractFileDeb(TestExtractorBase):
 
     def setup_method(self):
         assert inpath("ar"), "Required tool 'ar' not found"
-        download_file(TMUX_DEB, path.join(self.tempdir, "test.deb"))
-        shutil.copyfile(
-            path.join(self.tempdir, "test.deb"), path.join(self.tempdir, "test.ipk")
-        )
+        download_file(TMUX_DEB, self.tempdir / "test.deb")
+        shutil.copyfile(self.tempdir / "test.deb", self.tempdir / "test.ipk")
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -231,14 +229,14 @@ class TestExtractFileDeb(TestExtractorBase):
         async for extracted_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isfile(path.join(extracted_path, "usr", "bin", "tmux"))
+            assert (Path(extracted_path) / "usr" / "bin" / "tmux").is_file()
 
 
 class TestExtractFileCab(TestExtractorBase):
     """Tests for the cab file extractor"""
 
     def setup_method(self):
-        shutil.copyfile(CAB_TEST_FILE_PATH, path.join(self.tempdir, "test.cab"))
+        shutil.copyfile(CAB_TEST_FILE_PATH, self.tempdir / "test.cab")
 
     @pytest.fixture
     def extension_list(self) -> List[str]:
@@ -250,7 +248,7 @@ class TestExtractFileCab(TestExtractorBase):
         async for extracted_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isfile(path.join(extracted_path, "usr", "bin", "python3.8"))
+            assert (Path(extracted_path) / "usr" / "bin" / "python3.8").is_file()
 
 
 class TestExtractFileZip(TestExtractorBase):
@@ -268,7 +266,7 @@ class TestExtractFileZip(TestExtractorBase):
     @pytest.fixture(autouse=True)
     def setup_method(self, extension_list: List[str]):
         for filename in [f"test{extension}" for extension in extension_list]:
-            zippath = path.join(self.tempdir, filename)
+            zippath = self.tempdir / filename
             with ZipFile(zippath, "w") as zipfile:
                 zipfile.writestr(ZipInfo("test.txt"), "feedface")
 
@@ -278,4 +276,4 @@ class TestExtractFileZip(TestExtractorBase):
         async for dir_path in self.extract_files(
             [f"test{extension}" for extension in extension_list]
         ):
-            assert path.isdir(dir_path)
+            assert Path(dir_path).is_dir()

--- a/test/test_file.py
+++ b/test/test_file.py
@@ -4,14 +4,14 @@
 """
 CVE-bin-tool file tests
 """
-import os
+from pathlib import Path
 
 import pytest
 
 from cve_bin_tool.async_utils import NamedTemporaryFile, aio_rmfile
 from cve_bin_tool.file import aio_is_binary
 
-ASSETS_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets")
+ASSETS_PATH = Path(__file__).parent.resolve() / "assets"
 
 
 class TestFile:
@@ -46,9 +46,9 @@ class TestFile:
     @pytest.mark.asyncio
     async def test_single_byte_file(self):
         """file single-byte"""
-        assert not await aio_is_binary(os.path.join(ASSETS_PATH, "single-byte.txt"))
+        assert not await aio_is_binary(str(ASSETS_PATH / "single-byte.txt"))
 
     @pytest.mark.asyncio
     async def test_windows(self):
         """file single-byte"""
-        assert await aio_is_binary(os.path.join(ASSETS_PATH, "windows.txt"))
+        assert await aio_is_binary(str(ASSETS_PATH / "windows.txt"))

--- a/test/test_input_engine.py
+++ b/test/test_input_engine.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
 import re
 from ast import literal_eval
 from collections import defaultdict
+from pathlib import Path
 
 import pytest
 
@@ -20,9 +20,10 @@ from cve_bin_tool.util import ProductInfo
 
 
 class TestInputEngine:
-    CSV_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "csv")
-    JSON_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "json")
-    VEX_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "vex")
+    TMP_DIR = Path(__file__).parent.resolve()
+    CSV_PATH = TMP_DIR / "csv"
+    JSON_PATH = TMP_DIR / "json"
+    VEX_PATH = TMP_DIR / "vex"
     PARSED_TRIAGE_DATA = {
         ProductInfo("haxx", "curl", "7.59.0"): {
             "default": {"comments": "", "remarks": Remarks.NewFound, "severity": ""},
@@ -87,8 +88,8 @@ class TestInputEngine:
     @pytest.mark.parametrize(
         "filepath",
         (
-            os.path.join(CSV_PATH, "nonexistent.csv"),
-            os.path.join(JSON_PATH, "nonexistent.json"),
+            str(CSV_PATH / "nonexistent.csv"),
+            str(JSON_PATH / "nonexistent.json"),
         ),
     )
     def test_nonexistent_file(self, filepath):
@@ -99,8 +100,8 @@ class TestInputEngine:
     @pytest.mark.parametrize(
         "filepath, exception",
         (
-            (os.path.join(CSV_PATH, "bad.csv"), InvalidCsvError),
-            (os.path.join(JSON_PATH, "bad.json"), InvalidJsonError),
+            (str(CSV_PATH / "bad.csv"), InvalidCsvError),
+            (str(JSON_PATH / "bad.json"), InvalidJsonError),
         ),
     )
     def test_invalid_file(self, filepath, exception):
@@ -111,13 +112,13 @@ class TestInputEngine:
     @pytest.mark.parametrize(
         "filepath, missing_fields",
         (
-            (os.path.join(CSV_PATH, "bad_product.csv"), {"product"}),
+            (str(CSV_PATH / "bad_product.csv"), {"product"}),
             (
-                os.path.join(CSV_PATH, "bad_heading.csv"),
+                str(CSV_PATH / "bad_heading.csv"),
                 {"vendor", "product", "version"},
             ),
             (
-                os.path.join(JSON_PATH, "bad_heading.json"),
+                str(JSON_PATH / "bad_heading.json"),
                 {"vendor", "product", "version"},
             ),
         ),
@@ -135,8 +136,8 @@ class TestInputEngine:
     @pytest.mark.parametrize(
         "filepath, parsed_data",
         (
-            (os.path.join(CSV_PATH, "test_triage.csv"), PARSED_TRIAGE_DATA),
-            (os.path.join(JSON_PATH, "test_triage.json"), PARSED_TRIAGE_DATA),
+            (str(CSV_PATH / "test_triage.csv"), PARSED_TRIAGE_DATA),
+            (str(JSON_PATH / "test_triage.json"), PARSED_TRIAGE_DATA),
         ),
     )
     def test_valid_file(self, filepath, parsed_data):
@@ -146,8 +147,8 @@ class TestInputEngine:
     @pytest.mark.parametrize(
         "filepath, parsed_data",
         (
-            (os.path.join(VEX_PATH, "test_triage.vex"), VEX_TRIAGE_DATA),
-            (os.path.join(VEX_PATH, "bad.vex"), defaultdict(dict)),
+            (str(VEX_PATH / "test_triage.vex"), VEX_TRIAGE_DATA),
+            (str(VEX_PATH / "bad.vex"), defaultdict(dict)),
         ),
     )
     def test_vex_file(self, filepath, parsed_data):

--- a/test/test_json.py
+++ b/test/test_json.py
@@ -9,8 +9,8 @@ This uses the schemas mentioned here: https://nvd.nist.gov/vuln/Data-Feeds/JSON-
 import datetime
 import gzip
 import json
-import os
 import unittest
+from pathlib import Path
 from test.utils import LONG_TESTS
 
 import pytest
@@ -40,7 +40,7 @@ class TestJSON:
         """Validate latest nvd json file against their published schema"""
         # Open the latest nvd file on disk
         with gzip.open(
-            os.path.join(DISK_LOCATION_DEFAULT, f"nvdcve-1.1-{year}.json.gz"),
+            Path(DISK_LOCATION_DEFAULT) / f"nvdcve-1.1-{year}.json.gz",
             "rb",
         ) as json_file:
             nvd_json = json.loads(json_file.read())

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 Anthony Harrison
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
+from pathlib import Path
 
 import pytest
 
@@ -9,9 +9,8 @@ from cve_bin_tool.version_scanner import VersionScanner
 
 
 class TestLanguageScanner:
-    TEST_FILE_PATH = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), "language_data"
-    )
+    TEST_FILE_PATH = Path(__file__).parent.resolve() / "language_data"
+
     JAVASCRIPT_PRODUCTS = [
         "cache",
         "core",
@@ -23,7 +22,7 @@ class TestLanguageScanner:
 
     @pytest.mark.parametrize(
         "filename, product_name",
-        (((os.path.join(TEST_FILE_PATH, "pom.xml")), "commons_io"),),
+        (((str(TEST_FILE_PATH / "pom.xml")), "commons_io"),),
     )
     def test_java_package(self, filename: str, product_name: str) -> None:
         scanner = VersionScanner()
@@ -35,9 +34,7 @@ class TestLanguageScanner:
         assert product_info.product == product_name
         assert file_path == filename
 
-    @pytest.mark.parametrize(
-        "filename", ((os.path.join(TEST_FILE_PATH, "pom_fail.xml")),)
-    )
+    @pytest.mark.parametrize("filename", ((str(TEST_FILE_PATH / "pom_fail.xml")),))
     def test_java_package_none_found(self, filename: str) -> None:
         scanner = VersionScanner()
         scanner.file_stack.append(filename)
@@ -48,7 +45,7 @@ class TestLanguageScanner:
         assert product is None
 
     @pytest.mark.parametrize(
-        "filename", ((os.path.join(TEST_FILE_PATH, "package-lock1.json")),)
+        "filename", ((str(TEST_FILE_PATH / "package-lock1.json")),)
     )
     def test_javascript_package(self, filename: str) -> None:
         scanner = VersionScanner()
@@ -62,9 +59,7 @@ class TestLanguageScanner:
         assert found_product == self.JAVASCRIPT_PRODUCTS
         assert file_path == filename
 
-    @pytest.mark.parametrize(
-        "filename", ((os.path.join(TEST_FILE_PATH, "package.json")),)
-    )
+    @pytest.mark.parametrize("filename", ((str(TEST_FILE_PATH / "package.json")),))
     def test_javascript_package_none_found(self, filename: str) -> None:
         scanner = VersionScanner()
         scanner.file_stack.append(filename)

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -1,9 +1,9 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
 import re
 from ast import literal_eval
+from pathlib import Path
 
 import pytest
 
@@ -20,10 +20,7 @@ from cve_bin_tool.util import ProductInfo, Remarks
 
 class TestMergeReports:
 
-    INTERMEDIATE_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "json")
-    MERGED_TRIAGE_PATH = os.path.join(
-        os.path.abspath(os.path.dirname(__file__)), "json"
-    )
+    INTERMEDIATE_PATH = Path(__file__).parent.resolve() / "json"
 
     MERGED_TRIAGE_DATA = {
         ProductInfo(vendor="libjpeg-turbo", product="libjpeg-turbo", version="2.0.1"): {
@@ -50,7 +47,7 @@ class TestMergeReports:
 
     @pytest.mark.parametrize(
         "filepaths, exception",
-        (([os.path.join(INTERMEDIATE_PATH, "bad.json")], InvalidJsonError),),
+        (([str(INTERMEDIATE_PATH / "bad.json")], InvalidJsonError),),
     )
     def test_invalid_file(self, filepaths, exception):
         merged_cves = MergeReports(
@@ -63,11 +60,11 @@ class TestMergeReports:
         "filepaths,missing_fields",
         (
             (
-                [os.path.join(INTERMEDIATE_PATH, "bad_intermediate.json")],
+                [str(INTERMEDIATE_PATH / "bad_intermediate.json")],
                 {"metadata", "report"},
             ),
             (
-                [os.path.join(INTERMEDIATE_PATH, "bad_metadata.json")],
+                [str(INTERMEDIATE_PATH / "bad_metadata.json")],
                 REQUIRED_INTERMEDIATE_METADATA,
             ),
         ),
@@ -87,7 +84,7 @@ class TestMergeReports:
         "filepaths, merged_data",
         (
             (
-                [os.path.join(INTERMEDIATE_PATH, "test_intermediate.json")],
+                [str(INTERMEDIATE_PATH / "test_intermediate.json")],
                 MERGED_TRIAGE_DATA,
             ),
         ),
@@ -106,7 +103,7 @@ class TestMergeReports:
 
     @pytest.mark.parametrize(
         "filepaths",
-        (([os.path.join(INTERMEDIATE_PATH, "test_intermediate.json")]),),
+        (([str(INTERMEDIATE_PATH / "test_intermediate.json")]),),
     )
     def test_valid_cve_scanner_instance(self, filepaths):
 

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -8,10 +8,10 @@ import csv
 import importlib.util
 import json
 import logging
-import os
 import tempfile
 import unittest
 from datetime import datetime
+from pathlib import Path
 
 from rich.console import Console
 
@@ -684,7 +684,7 @@ class TestOutputEngine(unittest.TestCase):
         self.output_engine.generate_vex(self.MOCK_OUTPUT, "test.vex")
         with open("test.vex") as f:
             self.assertEqual(json.load(f), self.VEX_FORMATTED_OUTPUT[0])
-        os.remove("test.vex")
+        Path("test.vex").unlink()
 
     @unittest.skipUnless(
         importlib.util.find_spec("reportlab") is not None
@@ -785,7 +785,7 @@ class TestOutputEngine(unittest.TestCase):
             result = f.read()
 
         self.assertIn(expected_output, result)
-        os.unlink(tmpf.name)  # deleting tempfile
+        Path(tmpf.name).unlink()  # deleting tempfile
 
     def test_output_html(self):
         """Test formatting output as HTML"""
@@ -807,7 +807,7 @@ class TestOutputEngine(unittest.TestCase):
 
         # sample report
         with open(
-            os.path.join(os.path.dirname(__file__), "sample_report", "html_report.html")
+            Path(__file__).parent.resolve() / "sample_report" / "html_report.html"
         ) as report:
             expected_output = report.read()
             report.close()
@@ -869,16 +869,16 @@ class TestOutputEngine(unittest.TestCase):
         contains_filename = False
         contains_msg = False
 
-        filename = self.output_engine.filename
+        filename = Path(self.output_engine.filename)
 
-        if os.path.isfile(filename):
+        if filename.is_file():
             contains_filename = True
 
         if "Output stored at" in cm.output[0]:
             contains_msg = True
 
         # reset everything back
-        os.remove(filename)
+        filename.unlink()
         self.output_engine.filename = ""
 
         self.assertEqual(contains_filename, True)
@@ -918,8 +918,8 @@ class TestOutputEngine(unittest.TestCase):
                 contains_fail2write = True
 
         # remove the generated files and reset updated variables
-        os.remove("testfile.csv")
-        os.remove(self.output_engine.filename)
+        Path("testfile.csv").unlink()
+        Path(self.output_engine.filename).unlink()
         self.output_engine.filename = ""
 
         # assert
@@ -949,7 +949,7 @@ class TestOutputEngine(unittest.TestCase):
                 contains_sb = True
 
         # remove the generated files and reset updated variables
-        os.remove(self.output_engine.filename)
+        Path(self.output_engine.filename).unlink()
         self.output_engine.filename = ""
 
         # assert

--- a/test/test_package_list_parser.py
+++ b/test/test_package_list_parser.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import subprocess
-from os.path import dirname, join
+from pathlib import Path
 
 import distro
 import pytest
@@ -19,7 +19,7 @@ from cve_bin_tool.util import ProductInfo
 
 
 class TestPackageListParser:
-    TXT_PATH = join(dirname(__file__), "txt")
+    TXT_PATH = Path(__file__).parent.resolve() / "txt"
 
     REQ_PARSED_TRIAGE_DATA = {
         ProductInfo(vendor="httplib2_project*", product="httplib2", version="0.18.1"): {
@@ -78,14 +78,14 @@ class TestPackageListParser:
         },
     }
 
-    @pytest.mark.parametrize("filepath", [join(TXT_PATH, "nonexistent.txt")])
+    @pytest.mark.parametrize("filepath", [str(TXT_PATH / "nonexistent.txt")])
     def test_nonexistent_txt(self, filepath):
         package_list = PackageListParser(filepath, error_mode=ErrorMode.FullTrace)
         with pytest.raises(FileNotFoundError):
             package_list.parse_list()
 
     @pytest.mark.parametrize(
-        "filepath, exception", [(join(TXT_PATH, "empty.txt"), EmptyTxtError)]
+        "filepath, exception", [(str(TXT_PATH / "empty.txt"), EmptyTxtError)]
     )
     def test_empty_txt(self, filepath, exception):
         package_list = PackageListParser(filepath, error_mode=ErrorMode.FullTrace)
@@ -93,7 +93,7 @@ class TestPackageListParser:
             package_list.parse_list()
 
     @pytest.mark.parametrize(
-        "filepath, exception", [(join(TXT_PATH, "not_txt.csv"), InvalidListError)]
+        "filepath, exception", [(str(TXT_PATH / "not_txt.csv"), InvalidListError)]
     )
     def test_not_txt(self, filepath, exception):
         package_list = PackageListParser(filepath, error_mode=ErrorMode.FullTrace)
@@ -102,7 +102,7 @@ class TestPackageListParser:
 
     @pytest.mark.parametrize(
         "filepath, parsed_data",
-        [(join(TXT_PATH, "test_requirements.txt"), REQ_PARSED_TRIAGE_DATA)],
+        [(str(TXT_PATH / "test_requirements.txt"), REQ_PARSED_TRIAGE_DATA)],
     )
     def test_valid_requirements(self, filepath, parsed_data):
         # packages is installed from test_requirements with specific versions for the test to pass
@@ -118,7 +118,7 @@ class TestPackageListParser:
     )
     @pytest.mark.parametrize(
         "filepath",
-        [(join(TXT_PATH, "test_broken_linux_list.txt"))],
+        [str(TXT_PATH / "test_broken_linux_list.txt")],
     )
     def test_invalid_linux_list(self, filepath, caplog):
         package_list = PackageListParser(filepath, error_mode=ErrorMode.FullTrace)
@@ -133,7 +133,7 @@ class TestPackageListParser:
     )
     @pytest.mark.parametrize(
         "filepath, parsed_data",
-        [(join(TXT_PATH, "test_ubuntu_list.txt"), UBUNTU_PARSED_TRIAGE_DATA)],
+        [(str(TXT_PATH / "test_ubuntu_list.txt"), UBUNTU_PARSED_TRIAGE_DATA)],
     )
     def test_valid_ubuntu_list(self, filepath, parsed_data):
         package_list = PackageListParser(filepath, error_mode=ErrorMode.FullTrace)

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -5,26 +5,23 @@ import csv
 import re
 import subprocess
 from importlib.metadata import version
-from os.path import dirname, join
+from pathlib import Path
 
-ROOT_PATH = join(dirname(__file__), "..")
+ROOT_PATH = Path(__file__).parent.parent
 
-REQ_TXT = join(ROOT_PATH, "requirements.txt")
-REQ_CSV = join(ROOT_PATH, "requirements.csv")
-DOC_TXT = join(ROOT_PATH, "doc", "requirements.txt")
-DOC_CSV = join(ROOT_PATH, "doc", "requirements.csv")
+REQ_TXT = (ROOT_PATH / "requirements.txt").__str__()
+REQ_CSV = (ROOT_PATH / "requirements.csv").__str__()
+DOC_TXT = (ROOT_PATH / "doc" / "requirements.txt").__str__()
+DOC_CSV = (ROOT_PATH / "doc" / "requirements.csv").__str__()
 
-SCAN_CSV = join(ROOT_PATH, "cve_bin_tool_requirements.csv")
+SCAN_CSV = (ROOT_PATH / "cve_bin_tool_requirements.csv").__str__()
 
-HTML_DEP_PATH = join(
-    ROOT_PATH,
-    "cve_bin_tool",
-    "output_engine",
-    "html_reports",
-    "js",
+HTML_DEP_PATH_PATHLIB = (
+    ROOT_PATH / "cve_bin_tool" / "output_engine" / "html_reports" / "js"
 )
+HTML_DEP_PATH = HTML_DEP_PATH_PATHLIB.__str__()
 
-HTML_DEP_CSV = join(HTML_DEP_PATH, "dependencies.csv")
+HTML_DEP_CSV = (HTML_DEP_PATH_PATHLIB / "dependencies.csv").__str__()
 
 # Dependencies that currently have CVEs
 # Remove from the list once they are updated

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -9,19 +9,19 @@ from pathlib import Path
 
 ROOT_PATH = Path(__file__).parent.parent
 
-REQ_TXT = (ROOT_PATH / "requirements.txt").__str__()
-REQ_CSV = (ROOT_PATH / "requirements.csv").__str__()
-DOC_TXT = (ROOT_PATH / "doc" / "requirements.txt").__str__()
-DOC_CSV = (ROOT_PATH / "doc" / "requirements.csv").__str__()
+REQ_TXT = str(ROOT_PATH / "requirements.txt")
+REQ_CSV = str(ROOT_PATH / "requirements.csv")
+DOC_TXT = str(ROOT_PATH / "doc" / "requirements.txt")
+DOC_CSV = str(ROOT_PATH / "doc" / "requirements.csv")
 
-SCAN_CSV = (ROOT_PATH / "cve_bin_tool_requirements.csv").__str__()
+SCAN_CSV = str(ROOT_PATH / "cve_bin_tool_requirements.csv")
 
 HTML_DEP_PATH_PATHLIB = (
     ROOT_PATH / "cve_bin_tool" / "output_engine" / "html_reports" / "js"
 )
-HTML_DEP_PATH = HTML_DEP_PATH_PATHLIB.__str__()
+HTML_DEP_PATH = str(HTML_DEP_PATH_PATHLIB)
 
-HTML_DEP_CSV = (HTML_DEP_PATH_PATHLIB / "dependencies.csv").__str__()
+HTML_DEP_CSV = str(HTML_DEP_PATH_PATHLIB / "dependencies.csv")
 
 # Dependencies that currently have CVEs
 # Remove from the list once they are updated

--- a/test/test_sbom.py
+++ b/test/test_sbom.py
@@ -1,7 +1,7 @@
 # Copyright (C) 2021 Anthony Harrison
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-import os
+from pathlib import Path
 from typing import Dict
 
 import pytest
@@ -12,7 +12,7 @@ from cve_bin_tool.util import ProductInfo
 
 
 class TestSBOM:
-    SBOM_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "sbom")
+    SBOM_PATH = Path(__file__).parent.resolve() / "sbom"
     PARSED_SBOM_DATA = {
         ProductInfo(vendor="gnu", product="glibc", version="2.11.1"): {
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
@@ -22,7 +22,7 @@ class TestSBOM:
 
     @pytest.mark.parametrize(
         "filepath",
-        (os.path.join(SBOM_PATH, "nonexistent.spdx.json"),),
+        (str(SBOM_PATH / "nonexistent.spdx.json"),),
     )
     def test_nonexistent_file(self, filepath: str):
         sbom_engine = SBOMManager(filepath)
@@ -31,9 +31,9 @@ class TestSBOM:
     @pytest.mark.parametrize(
         "filename, sbom_type",
         (
-            ((os.path.join(SBOM_PATH, "bad.csv")), "spdx"),
-            ((os.path.join(SBOM_PATH, "bad.csv")), "cyclonedx"),
-            ((os.path.join(SBOM_PATH, "bad.csv")), "swid"),
+            (str(SBOM_PATH / "bad.csv"), "spdx"),
+            (str(SBOM_PATH / "bad.csv"), "cyclonedx"),
+            (str(SBOM_PATH / "bad.csv"), "swid"),
         ),
     )
     def test_invalid_file(self, filename: str, sbom_type: str):
@@ -43,8 +43,8 @@ class TestSBOM:
     @pytest.mark.parametrize(
         "filename, sbom_type",
         (
-            ((os.path.join(SBOM_PATH, "bad.csv")), "sbom"),
-            ((os.path.join(SBOM_PATH, "bad.csv")), "SPDX"),
+            (str(SBOM_PATH / "bad.csv"), "sbom"),
+            (str(SBOM_PATH / "bad.csv"), "SPDX"),
         ),
     )
     def test_invalid_type(self, filename: str, sbom_type: str):
@@ -54,12 +54,12 @@ class TestSBOM:
     @pytest.mark.parametrize(
         "filename, spdx_parsed_data",
         (
-            (os.path.join(SBOM_PATH, "spdx_test.spdx"), PARSED_SBOM_DATA),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.rdf"), PARSED_SBOM_DATA),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.json"), PARSED_SBOM_DATA),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.xml"), PARSED_SBOM_DATA),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.yml"), PARSED_SBOM_DATA),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.yaml"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "spdx_test.spdx"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "spdx_test.spdx.rdf"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "spdx_test.spdx.json"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "spdx_test.spdx.xml"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "spdx_test.spdx.yml"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "spdx_test.spdx.yaml"), PARSED_SBOM_DATA),
         ),
     )
     def test_valid_spdx_file(
@@ -71,8 +71,8 @@ class TestSBOM:
     @pytest.mark.parametrize(
         "filename, cyclonedx_parsed_data",
         (
-            (os.path.join(SBOM_PATH, "cyclonedx_test.xml"), PARSED_SBOM_DATA),
-            (os.path.join(SBOM_PATH, "cyclonedx_test.json"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "cyclonedx_test.xml"), PARSED_SBOM_DATA),
+            (str(SBOM_PATH / "cyclonedx_test.json"), PARSED_SBOM_DATA),
         ),
     )
     def test_valid_cyclonedx_file(
@@ -83,7 +83,7 @@ class TestSBOM:
 
     @pytest.mark.parametrize(
         "filename, swid_parsed_data",
-        ((os.path.join(SBOM_PATH, "swid_test.xml"), PARSED_SBOM_DATA),),
+        ((str(SBOM_PATH / "swid_test.xml"), PARSED_SBOM_DATA),),
     )
     def test_valid_swid_file(
         self, filename: str, swid_parsed_data: Dict[ProductInfo, TriageData]
@@ -94,18 +94,18 @@ class TestSBOM:
     @pytest.mark.parametrize(
         "filename, sbom_type, validate",
         (
-            (os.path.join(SBOM_PATH, "swid_test.xml"), "spdx", True),
-            (os.path.join(SBOM_PATH, "swid_test.xml"), "cyclondedx", True),
-            (os.path.join(SBOM_PATH, "swid_test.xml"), "spdx", False),
-            (os.path.join(SBOM_PATH, "swid_test.xml"), "cyclondedx", False),
-            (os.path.join(SBOM_PATH, "cyclonedx_test.xml"), "spdx", True),
-            (os.path.join(SBOM_PATH, "cyclonedx_test.xml"), "swid", True),
-            (os.path.join(SBOM_PATH, "cyclonedx_test.xml"), "spdx", False),
-            (os.path.join(SBOM_PATH, "cyclonedx_test.xml"), "swid", False),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.xml"), "cyclonedx", True),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.xml"), "swid", True),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.xml"), "cyclonedx", False),
-            (os.path.join(SBOM_PATH, "spdx_test.spdx.xml"), "swid", False),
+            (str(SBOM_PATH / "swid_test.xml"), "spdx", True),
+            (str(SBOM_PATH / "swid_test.xml"), "cyclondedx", True),
+            (str(SBOM_PATH / "swid_test.xml"), "spdx", False),
+            (str(SBOM_PATH / "swid_test.xml"), "cyclondedx", False),
+            (str(SBOM_PATH / "cyclonedx_test.xml"), "spdx", True),
+            (str(SBOM_PATH / "cyclonedx_test.xml"), "swid", True),
+            (str(SBOM_PATH / "cyclonedx_test.xml"), "spdx", False),
+            (str(SBOM_PATH / "cyclonedx_test.xml"), "swid", False),
+            (str(SBOM_PATH / "spdx_test.spdx.xml"), "cyclonedx", True),
+            (str(SBOM_PATH / "spdx_test.spdx.xml"), "swid", True),
+            (str(SBOM_PATH / "spdx_test.spdx.xml"), "cyclonedx", False),
+            (str(SBOM_PATH / "spdx_test.spdx.xml"), "swid", False),
         ),
     )
     def test_invalid_xml(self, filename: str, sbom_type: str, validate: bool):

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -193,7 +193,7 @@ class TestScanner:
                 dirpath.mkdir()
         # Check if we've already made a condensed version of the file, if we
         # have, we're done.
-        condensed_path = condensed_dir / package_name + ".tar.gz"
+        condensed_path = condensed_dir / (package_name + ".tar.gz")
         if condensed_path.is_file:
             return str(condensed_path)
         # Download the file if we don't have a condensed version of it and we

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -15,6 +15,7 @@ import tarfile
 import tempfile
 import unittest
 import unittest.mock
+from pathlib import Path
 from test.utils import LONG_TESTS, download_file
 
 import pytest
@@ -23,7 +24,6 @@ from cve_bin_tool.checkers import __all__ as all_test_name
 from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.version_scanner import VersionScanner
 
-BINARIES_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "binaries")
 # load test data
 test_data = list(
     map(lambda x: importlib.import_module(f"test.test_data.{x}"), all_test_name[2:])
@@ -93,7 +93,7 @@ class TestScanner:
             f.writelines(common_signatures)
             filename = f.name
         for params in self.scanner.scan_file(
-            os.path.join(self.mapping_test_dir, filename)
+            str(Path(self.mapping_test_dir) / filename)
         ):
             if params:
                 pytest.fail(msg=f"Checker has detected false positive: {params}")
@@ -127,7 +127,7 @@ class TestScanner:
 
             list_products = set()
             list_versions = set()
-            expected_path = os.path.join(self.mapping_test_dir, filename)
+            expected_path = str(Path(self.mapping_test_dir) / filename)
             for scan_info in self.scanner.recursive_scan(expected_path):
                 if scan_info:
                     product_info, file_path = scan_info
@@ -185,25 +185,26 @@ class TestScanner:
 
     def condensed_filepath(self, url, package_name):
         # Make directories for downloads and to store condensed versions
-        downloads_dir = os.path.join(os.path.dirname(__file__), "downloads")
-        condensed_dir = os.path.join(os.path.dirname(__file__), "condensed-downloads")
+        tmp_dir = Path(__file__).parent.resolve()
+        downloads_dir = tmp_dir / "downloads"
+        condensed_dir = tmp_dir / "condensed-downloads"
         for dirpath in [downloads_dir, condensed_dir]:
-            if not os.path.isdir(dirpath):
-                os.mkdir(dirpath)
+            if not dirpath.is_dir():
+                dirpath.mkdir()
         # Check if we've already made a condensed version of the file, if we
         # have, we're done.
-        condensed_path = os.path.join(condensed_dir, package_name + ".tar.gz")
-        if os.path.isfile(condensed_path):
-            return condensed_path
+        condensed_path = condensed_dir / package_name + ".tar.gz"
+        if condensed_path.is_file:
+            return str(condensed_path)
         # Download the file if we don't have a condensed version of it and we
         # don't have it downloaded already
-        download_path = os.path.join(downloads_dir, package_name)
-        if not os.path.isfile(download_path):
+        download_path = downloads_dir / package_name
+        if not download_path.is_file:
             download_file(url + package_name, download_path)
         # Make the condensed version of the file
-        self.make_condensed_from_download(download_path, condensed_path)
+        self.make_condensed_from_download(str(download_path), str(condensed_path))
         # Return the condensed version
-        return condensed_path
+        return str(condensed_path)
 
     @pytest.mark.parametrize(
         "url, package_name, product, version",
@@ -261,16 +262,14 @@ class TestScanner:
         """Test that the scanner doesn't scan symlinks"""
         if sys.platform.startswith("linux"):
             # we can only do this in linux since symlink is privilege operation in windows
-            os.symlink("non-existant-file", "non-existant-link")
+            non_existant_link = Path("non-existant-link")
+            non_existant_link_path = non_existant_link.resolve()
+            non_existant_link.symlink_to("non-existant-file")
             try:
                 with pytest.raises(StopIteration):
-                    next(
-                        self.scanner.scan_file(
-                            os.path.join(self.mapping_test_dir, "non-existant-link")
-                        )
-                    )
+                    next(self.scanner.scan_file(str(non_existant_link_path)))
             finally:
-                os.unlink("non-existant-link")
+                non_existant_link.unlink()
 
     def test_cannot_open_file(self, caplog):
         """Test behaviour when file cannot be opened"""
@@ -278,7 +277,7 @@ class TestScanner:
         with pytest.raises(StopIteration):
             next(
                 self.scanner.scan_file(
-                    os.path.join(self.mapping_test_dir, "non-existant-file")
+                    str(Path(self.mapping_test_dir) / "non-existant-file")
                 )
             )
         assert str.find("Invalid file", caplog.text)

--- a/test/test_strings.py
+++ b/test/test_strings.py
@@ -4,14 +4,15 @@
 """
 CVE-bin-tool Strings tests
 """
-import os
+
+from pathlib import Path
 
 import pytest
 
 from cve_bin_tool.async_utils import aio_run_command
 from cve_bin_tool.strings import Strings
 
-ASSETS_PATH = os.path.join(os.path.abspath(os.path.dirname(__file__)), "assets")
+ASSETS_PATH = Path(__file__).parent.resolve() / "assets"
 
 
 class TestStrings:
@@ -25,7 +26,7 @@ class TestStrings:
     async def _parse_test(self, filename):
         """Helper function to parse a binary file and check whether
         the given string is in the parsed result"""
-        self.strings.filename = os.path.join(ASSETS_PATH, filename)
+        self.strings.filename = str(ASSETS_PATH / filename)
         binutils_strings, _, _ = await aio_run_command(
             ["strings", self.strings.filename]
         )


### PR DESCRIPTION
closes #1713 

- [x] cve_bin_tool/extractor.py
- [x] test/test_extractor.py
- [x] test/test_requirements.py
- [x] test/test_input_engine.py
- [x] test/test_scanner.py
- [x] test/test_cli.py
- [x] test/test_sbom.py
- [x] test/test_json.py
- [x] test/test_file.py
- [x] test/test_config.py
- [x] test/test_merge.py
- [x] test/test_strings.py
- [x] test/test_language_scanner.py
- [x] test/test_package_list_parser.py
- [x] test/test_output_engine.py
