### PR TITLE
test: Add triage to requirements test to address aiohttp disputed cve

### DIFF
--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -11,6 +11,7 @@ ROOT_PATH = Path(__file__).parent.parent
 
 REQ_TXT = str(ROOT_PATH / "requirements.txt")
 REQ_CSV = str(ROOT_PATH / "requirements.csv")
+TRIAGE_JSON = str(ROOT_PATH / "triage.json")
 DOC_TXT = str(ROOT_PATH / "doc" / "requirements.txt")
 DOC_CSV = str(ROOT_PATH / "doc" / "requirements.csv")
 
@@ -128,7 +129,15 @@ def test_requirements():
             writer.writerow(row)
 
     cve_check = subprocess.run(
-        ["python", "-m", "cve_bin_tool.cli", "--input-file", SCAN_CSV]
+        [
+            "python",
+            "-m",
+            "cve_bin_tool.cli",
+            "--input-file",
+            SCAN_CSV,
+            "--merge",
+            TRIAGE_JSON,
+        ]
     )
     assert (
         cve_check.returncode == 0

--- a/triage.json
+++ b/triage.json
@@ -1,0 +1,25 @@
+{
+    "metadata": {
+        "timestamp": "2022-07-05.16-08-33",
+        "tag": "",
+        "scanned_dir": "",
+        "products_with_cve": 1,
+        "products_without_cve": 9,
+        "total_files": 0
+    },
+    "report": [
+        {
+            "vendor": "aiohttp_project",
+            "product": "aiohttp",
+            "version": "3.8.1",
+            "cve_number": "CVE-2022-33124",
+            "severity": "MEDIUM",
+            "score": "5.5",
+            "cvss_version": "3",
+            "cvss_vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+            "paths": "",
+            "remarks": "Ignored",
+            "comments": "See https://github.com/intel/cve-bin-tool/issues/1741"
+        }
+    ]
+}


### PR DESCRIPTION
This is the start of a PR to add triage (a merged report) into the requirements test so that we can ignore the current aiohttp CVE which is unfixed and may be disputed.

[x] add triage data for aiohttp
[x] Update test to use triage data provided
[] update test so it handles ignored CVEs correctly
[] update merge reports documentation to give list of acceptable options in the "remarks" field.