### PR TITLE
fix: update database before merging

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -436,34 +436,6 @@ def main(argv=None):
         version_check = args["disable_version_check"]
         db_update = args["update"]
 
-    # Check for PDF support
-    output_format = args["format"]
-    if output_format == "pdf" and importlib.util.find_spec("reportlab") is None:
-        LOGGER.info("PDF output not available. Default to console.")
-        LOGGER.info(
-            "If you want to produce PDF output, please install reportlab using pip install reportlab"
-        )
-        output_format = "console"
-
-    merged_reports = None
-    if args["merge"]:
-        LOGGER.info(
-            "You can use -f --format and -o --output-file for saving merged intermediate reports in a file"
-        )
-        merged_reports = MergeReports(
-            merge_files=args["merge"], score=score, filter_tag=args["filter"]
-        )
-        if args["input_file"]:
-            LOGGER.warning(
-                "Ignoring -i --input-file while merging intermediate reports"
-            )
-            args["input_file"] = None
-        merge_cve_scanner = merged_reports.merge_intermediate()
-    elif args["filter"] and not args["merge"]:
-        LOGGER.warning(
-            "Use -F --filter only when you want to filter out intermediate reports on the basis of tag"
-        )
-
     source_nvd = nvd_source.NVD_Source(
         nvd_type=args["nvd"],
         incremental_update=True if db_update == "latest" and args["nvd"] else False,
@@ -536,6 +508,34 @@ def main(argv=None):
     LOGGER.info(f"CVE database last updated on {db_date}")
 
     cvedb_orig.remove_cache_backup()
+
+    # Check for PDF support
+    output_format = args["format"]
+    if output_format == "pdf" and importlib.util.find_spec("reportlab") is None:
+        LOGGER.info("PDF output not available. Default to console.")
+        LOGGER.info(
+            "If you want to produce PDF output, please install reportlab using pip install reportlab"
+        )
+        output_format = "console"
+
+    merged_reports = None
+    if args["merge"]:
+        LOGGER.info(
+            "You can use -f --format and -o --output-file for saving merged intermediate reports in a file"
+        )
+        merged_reports = MergeReports(
+            merge_files=args["merge"], score=score, filter_tag=args["filter"]
+        )
+        if args["input_file"]:
+            LOGGER.warning(
+                "Ignoring -i --input-file while merging intermediate reports"
+            )
+            args["input_file"] = None
+        merge_cve_scanner = merged_reports.merge_intermediate()
+    elif args["filter"] and not args["merge"]:
+        LOGGER.warning(
+            "Use -F --filter only when you want to filter out intermediate reports on the basis of tag"
+        )
 
     # Input validation
     if (


### PR DESCRIPTION
i noticed a spike in the number of failed CIs, so i investigated a little and found out if there is no cached db to use, it was failing to create a db during the run, so i just moved the block of code that was handling db related tasks before the block of code that was handling merging.

![image](https://user-images.githubusercontent.com/64733912/178318676-3ae35aeb-63b9-4c78-824f-269b87d98bad.png)
