### PR TITLE
fix: add luajit to documentation

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -221,6 +221,7 @@ linux
 lite
 logrotate
 lua
+luajit
 malloc
 Manjaro
 mariadb

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ The following checkers are available for finding components in binary files:
 
 <!--CHECKERS TABLE BEGIN-->
 |   |  |  | Available checkers |  |  |  |
-|--------------- |------------- |---------------- |--------- |--------------- |------------ |--------------- |
+|--------------- |-------------- |---------------- |------------- |--------------- |------------ |---------- |
 | accountsservice |avahi |bash |bind |binutils |bolt |bubblewrap |
 | busybox |bzip2 |commons_compress |cronie |cryptsetup |cups |curl |
 | dbus |dnsmasq |dovecot |dpkg |enscript |expat |ffmpeg |
@@ -268,14 +268,14 @@ The following checkers are available for finding components in binary files:
 | kexectools |libarchive |libbpg |libdb |libebml |libgcrypt |libical |
 | libjpeg_turbo |liblas |libnss |librsvg |libseccomp |libsndfile |libsolv |
 | libsoup |libsrtp |libssh2 |libtiff |libvirt |libvncserver |libxslt |
-| lighttpd |logrotate |lua |mariadb |mdadm |memcached |mtr |
-| mysql |nano |ncurses |nessus |netpbm |nginx |node |
-| ntp |open_vm_tools |openafs |openjpeg |openldap |openssh |openssl |
-| openswan |openvpn |p7zip |pcsc_lite |pigz |png |polarssl_fedora |
-| poppler |postgresql |pspp |python |qt |radare2 |rsyslog |
-| rust |samba |sane_backends |sqlite |strongswan |subversion |sudo |
-| syslogng |systemd |tcpdump |trousers |varnish |webkitgtk |wireshark |
-| wpa_supplicant |xerces |xml2 |zlib |zsh | | |
+| lighttpd |logrotate |lua |luajit |mariadb |mdadm |memcached |
+| mtr |mysql |nano |ncurses |nessus |netpbm |nginx |
+| node |ntp |open_vm_tools |openafs |openjpeg |openldap |openssh |
+| openssl |openswan |openvpn |p7zip |pcsc_lite |pigz |png |
+| polarssl_fedora |poppler |postgresql |pspp |python |qt |radare2 |
+| rsyslog |rust |samba |sane_backends |sqlite |strongswan |subversion |
+| sudo |syslogng |systemd |tcpdump |trousers |varnish |webkitgtk |
+| wireshark |wpa_supplicant |xerces |xml2 |zlib |zsh | |
 <!--CHECKERS TABLE END-->
 
 All the checkers can be found in the checkers directory, as can the

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -137,7 +137,7 @@ which is useful if you're trying the latest code from
 
 <!--CHECKERS TABLE BEGIN-->
 |   |  |  | Available checkers |  |  |  |
-|--------------- |------------- |---------------- |--------- |--------------- |------------ |--------------- |
+|--------------- |-------------- |---------------- |------------- |--------------- |------------ |---------- |
 | accountsservice |avahi |bash |bind |binutils |bolt |bubblewrap |
 | busybox |bzip2 |commons_compress |cronie |cryptsetup |cups |curl |
 | dbus |dnsmasq |dovecot |dpkg |enscript |expat |ffmpeg |
@@ -147,14 +147,14 @@ which is useful if you're trying the latest code from
 | kexectools |libarchive |libbpg |libdb |libebml |libgcrypt |libical |
 | libjpeg_turbo |liblas |libnss |librsvg |libseccomp |libsndfile |libsolv |
 | libsoup |libsrtp |libssh2 |libtiff |libvirt |libvncserver |libxslt |
-| lighttpd |logrotate |lua |mariadb |mdadm |memcached |mtr |
-| mysql |nano |ncurses |nessus |netpbm |nginx |node |
-| ntp |open_vm_tools |openafs |openjpeg |openldap |openssh |openssl |
-| openswan |openvpn |p7zip |pcsc_lite |pigz |png |polarssl_fedora |
-| poppler |postgresql |pspp |python |qt |radare2 |rsyslog |
-| rust |samba |sane_backends |sqlite |strongswan |subversion |sudo |
-| syslogng |systemd |tcpdump |trousers |varnish |webkitgtk |wireshark |
-| wpa_supplicant |xerces |xml2 |zlib |zsh | | |
+| lighttpd |logrotate |lua |luajit |mariadb |mdadm |memcached |
+| mtr |mysql |nano |ncurses |nessus |netpbm |nginx |
+| node |ntp |open_vm_tools |openafs |openjpeg |openldap |openssh |
+| openssl |openswan |openvpn |p7zip |pcsc_lite |pigz |png |
+| polarssl_fedora |poppler |postgresql |pspp |python |qt |radare2 |
+| rsyslog |rust |samba |sane_backends |sqlite |strongswan |subversion |
+| sudo |syslogng |systemd |tcpdump |trousers |varnish |webkitgtk |
+| wireshark |wpa_supplicant |xerces |xml2 |zlib |zsh | |
 <!--CHECKERS TABLE END-->
 
 For a quick overview of usage and how it works, you can also see [the readme file](README.md).


### PR DESCRIPTION
For an unknown reason, the GitHub Action that creates the PR which runs `format_checkers.py` failed (see https://github.com/intel/cve-bin-tool/pull/1705) so fix it by running the script manually

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>