### PR TITLE
chore(deps): bump html5lib version for dependabot

### DIFF
--- a/test/test_package_list_parser.py
+++ b/test/test_package_list_parser.py
@@ -30,7 +30,7 @@ class TestPackageListParser:
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
             "paths": {""},
         },
-        ProductInfo(vendor="html5lib*", product="html5lib", version="0.99999999"): {
+        ProductInfo(vendor="html5lib*", product="html5lib", version="0.999999999"): {
             "default": {"remarks": Remarks.NewFound, "comments": "", "severity": ""},
             "paths": {""},
         },

--- a/test/txt/test_requirements.txt
+++ b/test/txt/test_requirements.txt
@@ -1,3 +1,3 @@
-html5lib==0.99999999
+html5lib==0.999999999
 httplib2==0.18.1
 requests==2.25.1


### PR DESCRIPTION
* Replaces #1755

html5lib has a vulnerability and is coming up in our dependabot scans because it appears in a test.  The bot bumped the requirements file but I needed to also update the relevant test at the same time so CI would pass.