### PR TITLE
ci: add scan.coverity.com workflow

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,0 +1,17 @@
+# Your .github/workflows/coverity.yml file.
+name: Coverity Scan
+
+# We only want to test official release code, not every pull request.
+on:
+  push:
+    branches: [main]
+
+jobs:
+  coverity:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: vapier/coverity-scan-action@v1
+      with:
+        email: ${{ secrets.COVERITY_SCAN_EMAIL }}
+        token: ${{ secrets.COVERITY_SCAN_TOKEN }}

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -15,3 +15,4 @@ jobs:
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}
+        build_language: "other"


### PR DESCRIPTION
Trying out the unofficial coverity github action to provide automated builds for scan.coverity.com static analysis.