### PR TITLE
ci: move _cli and _test_helper_script to longtests only

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -83,7 +83,6 @@ jobs:
       - name: Run synchronous tests
         run: >
           pytest -v
-          test/test_cli.py
           test/test_cvedb.py
 
   long_tests:
@@ -140,6 +139,7 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
+          --ignore=test/test_helper_script.py
       - name: Run synchronous tests
         run: >
           pytest -v --cov --cov-append --cov-report=xml
@@ -193,10 +193,10 @@ jobs:
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
+          --ignore=test/test_helper_script.py
       - name: Run synchronous tests
         run: >
           pytest -v
-          test/test_cli.py
           test/test_cvedb.py
       - name: Cache conda
         uses: actions/cache@v3


### PR DESCRIPTION
This is an experiment to give a temporary fix for our performance problems, which involves moving two of the longer-to-run test files so they won't be executed as part of the short tests.   They will sill run in the long tests.