### PR TITLE
test(csv2cve): 5 new cves in haxx.curl

### DIFF
--- a/test/test_csv2cve.py
+++ b/test/test_csv2cve.py
@@ -32,7 +32,7 @@ class TestCSV2CVE:
 
         for cve in [
             "3 CVE(s) in mit.kerberos v1.15.1",
-            "55 CVE(s) in haxx.curl v7.34.0",
+            "60 CVE(s) in haxx.curl v7.34.0",
             "9 CVE(s) in mit.kerberos_5 v1.15.1",
         ]:
             assert (


### PR DESCRIPTION
csv2cve tests are failing because someone found 5 new cves in the version of curl that we used for testing.