### PR TITLE
Removing redundant conditions in version_scanner.py #1783

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -119,18 +119,18 @@ class VersionScanner:
                 self.logger.warning(f"Unopenable file {filename} cannot be scanned")
                 return False, None
 
-            if (
-                ("LSB " not in output)
-                and ("LSB shared" not in output)
-                and ("LSB executable" not in output)
-                and ("PE32 executable" not in output)
-                and ("PE32+ executable" not in output)
-                and ("Mach-O" not in output)
-                and ("PKG-INFO: " not in output)
-                and ("METADATA: " not in output)
-                and ("pom.xml" not in output)
-                and ("package-lock.json" not in output)
-            ):
+            formats_list = [
+                "LSB ",
+                "PE32 executable",
+                "PE32+ executable",
+                "Mach-O",
+                "PKG-INFO: ",
+                "METADATA: ",
+                "pom.xml",
+                "package-lock.json"
+            ]
+
+            if all(fm not in output for fm in formats_list):
                 return False, None
         # otherwise use python implementation of file
         elif not is_binary(filename):


### PR DESCRIPTION
Removing redundant conditions in version_scanner.py #1783 (multiple "LSB" strings), and merge to one single line if command.
`
if all(fm not in output for fm in formats_list):
    return False, None
`