### PR TITLE
ci: raise timeout and change first cli call

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.7', '3.9', '3.10']
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -89,7 +89,7 @@ jobs:
   long_tests:
     name: Long tests on Python 3.8
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 55
     env:
       LONG_TESTS: 1
     steps:
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.9', '3.10']
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,7 +73,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets
+          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos*
       - name: Run async tests
         run: >
           pytest -n 4 -v
@@ -133,7 +133,7 @@ jobs:
           python -m pip install --editable .
       - name: Try single CLI run of tool
         run: |
-          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets -n json -u latest
+          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos* -n json -u latest
       - name: Run async tests
         run: >
           pytest --cov --cov-append -n 4 -v
@@ -186,7 +186,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          python -m cve_bin_tool.cli test/assets
+          python -m cve_bin_tool.cli test/assets/test-kerberos*
       - name: Run async tests
         run: >
           pytest -n 4 -v

--- a/doc/requirements.csv
+++ b/doc/requirements.csv
@@ -2,4 +2,4 @@ vendor,product
 sphinx-doc_not_in_db,Sphinx
 ryanfox_not_in_db,sphinx_markdown_tables
 executablebooks_not_in_db,myst_parser
-python-markdown,markdown
+python-markdown_not_in_db,markdown

--- a/doc/requirements.csv
+++ b/doc/requirements.csv
@@ -2,3 +2,4 @@ vendor,product
 sphinx-doc_not_in_db,Sphinx
 ryanfox_not_in_db,sphinx_markdown_tables
 executablebooks_not_in_db,myst_parser
+python-markdown,markdown

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -7,7 +7,6 @@ CVE-bin-tool CLI tests
 import logging
 import sys
 import tempfile
-import unittest
 from pathlib import Path
 from test.utils import (
     CURL_7_20_0_RPM,
@@ -33,14 +32,17 @@ class TestCLI(TempDirTest):
 
     TEST_PATH = Path(__file__).parent.resolve()
 
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="No file downloads in short tests")
     def setup_method(self):
         download_file(CURL_7_20_0_URL, Path(self.tempdir) / CURL_7_20_0_RPM)
         download_file(TMUX_DEB, Path(self.tempdir) / TMUX_DEB_NAME)
 
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="No file downloads in short tests")
     def test_extract_curl_7_20_0(self):
         """Scanning curl-7.20.0"""
         assert main(["cve-bin-tool", "-l", "debug", "-x", self.tempdir]) != 0
 
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="No file downloads in short tests")
     def test_binary_curl_7_20_0(self):
         """Extracting from rpm and scanning curl-7.20.0"""
         with Extractor() as ectx:
@@ -57,6 +59,7 @@ class TestCLI(TempDirTest):
                 != 0
             )
 
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="No file downloads in short tests")
     def test_no_extraction(self):
         """Test scanner against curl-7.20.0 rpm with extraction turned off"""
         assert main(["cve-bin-tool", str(Path(self.tempdir) / CURL_7_20_0_RPM)]) != 0
@@ -77,6 +80,7 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", bad_zip_file])
         assert "Failure extracting" in caplog.text
 
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="No file downloads in short tests")
     def test_exclude(self, caplog):
         """Test that the exclude paths are not scanned"""
         test_path = Path(__file__).parent.resolve()
@@ -149,7 +153,7 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", self.tempdir, "--bad-param;cat hi"])
         assert e.value.args[0] == ERROR_CODES[SystemExit]
 
-    @unittest.skipUnless(LONG_TESTS() > 0, "Skipping long tests")
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="Update flag tests are long tests")
     def test_update_flags(self):
         assert (
             main(["cve-bin-tool", "-x", "-u", "never", "-n", "json", self.tempdir]) != 0
@@ -227,7 +231,7 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool", test_path, "-r", ",".join(runs)])
         self.check_checkers_log(caplog, skip_checkers, runs)
 
-    @unittest.skipUnless(LONG_TESTS() > 0, "Skipping long tests")
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="Update flag tests are long tests")
     def test_update(self, caplog):
         test_path = str(Path(__file__).parent.resolve() / "csv")
 
@@ -310,7 +314,7 @@ class TestCLI(TempDirTest):
         assert f"png was detected with version UNKNOWN in file {filename}" in warnings
 
     def test_quiet_mode(self, capsys, caplog):
-        """Test that an quite mode isn't generating any output"""
+        """Test that an quiet mode isn't generating any output"""
 
         with tempfile.NamedTemporaryFile(
             "w+b", suffix="strong-swan-4.6.3.out", delete=False
@@ -319,7 +323,7 @@ class TestCLI(TempDirTest):
             f.writelines(signatures)
             filename = f.name
 
-        main(["cve-bin-tool", "-q", filename, "-u", "now"])
+        main(["cve-bin-tool", "-q", filename])
         # clean up temporary file.
         Path(filename).unlink()
 
@@ -519,6 +523,7 @@ class TestCLI(TempDirTest):
             "There are 1 products with known CVEs detected",
         ) in caplog.record_tuples
 
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="Skipping long tests")
     def test_console_output_depending_reportlab_existence(self, caplog):
         import subprocess
         from importlib.machinery import ModuleSpec

--- a/test/test_nvd_api.py
+++ b/test/test_nvd_api.py
@@ -4,6 +4,7 @@
 import shutil
 import tempfile
 from datetime import datetime, timedelta
+from test.utils import LONG_TESTS
 
 import pytest
 
@@ -22,6 +23,7 @@ class TestNVD_API:
         shutil.rmtree(cls.outdir)
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="NVD tests run only in long tests")
     async def test_get_nvd_params(self):
         """Test NVD for a future date. It should be empty"""
         nvd_api = NVD_API()
@@ -32,6 +34,7 @@ class TestNVD_API:
         assert nvd_api.total_results == 0 and nvd_api.all_cve_entries == []
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="NVD tests run only in long tests")
     async def test_total_results_count(self):
         """Total results should be greater than or equal to the current fetched cves"""
         nvd_api = NVD_API()
@@ -42,6 +45,7 @@ class TestNVD_API:
         assert len(nvd_api.all_cve_entries) >= nvd_api.total_results
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="NVD tests run only in long tests")
     async def test_nvd_incremental_update(self):
         """Test to check whether we are able to fetch and save the nvd entries using time_of_last_update"""
         nvd_api = NVD_API(incremental_update=True)
@@ -58,6 +62,7 @@ class TestNVD_API:
         assert cvedb.cve_count == nvd_api.total_results
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(LONG_TESTS() != 1, reason="NVD tests run only in long tests")
     async def test_empty_nvd_result(self):
         """Test to check nvd results non-empty result. Total result should be greater than 0"""
         nvd_api = NVD_API()

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -47,7 +47,7 @@ def get_out_of_sync_packages(csv_name, txt_name):
             csv_package_names.add(product)
         lines = txt_file.readlines()
         for line in lines:
-            txt_package_names.add(re.split(">|\\[|;|=|\n", line)[0])
+            txt_package_names.add(re.split(">|<|\\[|;|=|\n", line)[0])
         new_packages = txt_package_names - csv_package_names
         removed_packages = csv_package_names - txt_package_names
 


### PR DESCRIPTION
Two experiments to see if we can get CI back on track:
1. raising the timeout a bit to see if we're just a little over
2. changing the first call to look only at a single file in case we were getting hung up on the new .pkg file in test/assets.