### PR TITLE
ci: set coverity build command to --no-command

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -15,4 +15,5 @@ jobs:
       with:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}
-        build_language: "other"
+        build_language: 'other'
+        command: '--no-command'


### PR DESCRIPTION
Coverity is failing on main because it's trying to run "make" and it should be using `--no-command` to do a filesystem scan for python files.