### PR TITLE
ci: reduce timeouts back to normal

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.7', '3.9', '3.10']
-    timeout-minutes: 30
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -89,7 +89,7 @@ jobs:
   long_tests:
     name: Long tests on Python 3.8
     runs-on: ubuntu-latest
-    timeout-minutes: 55
+    timeout-minutes: 45
     env:
       LONG_TESTS: 1
     steps:
@@ -159,7 +159,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.9', '3.10']
-    timeout-minutes: 40
+    timeout-minutes: 30
     env:
       NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'


### PR DESCRIPTION
I upped all our timeouts by 10 minutes yesterday to see if just a little more time would solve some tests, but it didn't help considerably so I'm reverting the change.