### PR TITLE
fix(ci): use json method to get data from NVD

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,7 +73,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos*
+          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos* -n json
       - name: Run async tests
         run: >
           pytest -n 4 -v
@@ -186,7 +186,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          python -m cve_bin_tool.cli test/assets/test-kerberos*
+          python -m cve_bin_tool.cli test/assets/test-kerberos* -n json
       - name: Run async tests
         run: >
           pytest -n 4 -v
@@ -205,8 +205,7 @@ jobs:
           CACHE_NUMBER: 0
         with:
           path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
             hashFiles('requirements.txt') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -73,7 +73,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos* -n json
+          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
       - name: Run async tests
         run: >
           pytest -n 4 -v
@@ -133,7 +133,7 @@ jobs:
           python -m pip install --editable .
       - name: Try single CLI run of tool
         run: |
-          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos* -n json -u latest
+          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json -u latest
       - name: Run async tests
         run: >
           pytest --cov --cov-append -n 4 -v
@@ -186,7 +186,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          python -m cve_bin_tool.cli test/assets/test-kerberos* -n json
+          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
       - name: Run async tests
         run: >
           pytest -n 4 -v


### PR DESCRIPTION
this could probably fix the ci, the long tests were not using the api method to get data from NVD, it was using the json method and the "Try single CLI run of tool" step was passing, so i just changed the method for all tests to use json method to fetch data from NVD.

#1811