### PR TITLE
ci: fix windows cli test run

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -186,7 +186,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          python -m cve_bin_tool.cli test/assets/test-kerberos*
+          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out
       - name: Run async tests
         run: >
           pytest -n 4 -v


### PR DESCRIPTION
Windows tests are currently failing because it doesn't like kerberos* specified on the command line.  This is a test to see if naming the file explicitly is sufficient to fix them.