### PR TITLE
ci: update cached database

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -138,7 +138,7 @@ jobs:
           python -m pip install --editable .
       - name: Try single CLI run of tool
         run: |
-          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json -u latest
+          NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
       - name: Run async tests
         env:
           LONG_TESTS: ${{ steps.git-diff.outputs.value }}

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -1,0 +1,72 @@
+name: Update cached database
+
+on:
+  schedule:
+    # Runs at 00:20 UTC everyday
+    - cron: '20 0 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  NO_EXIT_CVE_NUM: 1
+  nvd_api_key: ${{ secrets.NVD_API_KEY }}
+
+jobs:
+  linux:
+    name: Update linux cached database
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Get date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/cve-bin-tool
+          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
+      - name: Install cve-bin-tool
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade wheel
+          python -m pip install --editable .
+      - name: Update database
+        run: |
+          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -u now
+
+  windows:
+    name: Update windows cached database
+    runs-on: windows-latest
+    timeout-minutes: 20
+    env:
+      NO_EXIT_CVE_NUM: 1
+      PYTHONIOENCODING: 'utf8'
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+      - name: Get date
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(get-date -format "yyyyMMdd")"
+      - uses: actions/cache@v3
+        with:
+          path: ~/.cache/cve-bin-tool
+          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
+      - name: Install cve-bin-tool
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools
+          python -m pip install --upgrade wheel
+          python -m pip install --upgrade .
+      - name: Try single CLI run of tool
+        run: |
+          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -u now

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -45,7 +45,6 @@ jobs:
     runs-on: windows-latest
     timeout-minutes: 20
     env:
-      NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This will run everyday at 00:20, and first it will run the tool and update the database using the api method with the api key (it'll have access to the secrets because it will run on main branch), then it'll cache the updated database, so that all PRs can use the cached db and avoid updating for the rest of the day.

#1811