### PR TITLE
docs: Add Python Community Code of Conduct info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ If you've already contributed to other open source projects, contributing to the
 
 - [CVE Binary Tool Contributor Guide](#cve-binary-tool-contributor-guide)
   - [Imposter syndrome disclaimer](#imposter-syndrome-disclaimer)
+  - [Code of Conduct](#code-of-conduct)
   - [Development Environment](#development-environment)
   - [Getting and maintaining a local copy of the source code](#getting-and-maintaining-a-local-copy-of-the-source-code)
   - [Setting up a virtualenv](#setting-up-a-virtualenv)
@@ -48,6 +49,13 @@ If have questions or want to chat, we have a [gitter chat room](https://gitter.i
 Thank you for contributing!
 
 This section is adapted from [this excellent document from @adriennefriend](https://github.com/adriennefriend/imposter-syndrome-disclaimer)
+
+## Code of Conduct
+
+CVE Binary Tool contributors are asked to adhere to the [Python Community Code of Conduct](https://www.python.org/psf/conduct/).  Please contact [Terri](https://github.com/terriko/) if you have concerns or questions relating to this code of conduct.
+
+Note: The Python Community Code of Conduct is a required part of our particpation in
+Google Summer of Code as a sub-org with the Python Software Foundation.
 
 ## Development Environment
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ This section is adapted from [this excellent document from @adriennefriend](http
 
 CVE Binary Tool contributors are asked to adhere to the [Python Community Code of Conduct](https://www.python.org/psf/conduct/).  Please contact [Terri](https://github.com/terriko/) if you have concerns or questions relating to this code of conduct.
 
-Note: The Python Community Code of Conduct is a required part of our particpation in
+Note: The Python Community Code of Conduct is a required part of our participation in
 Google Summer of Code as a sub-org with the Python Software Foundation.
 
 ## Development Environment

--- a/README.md
+++ b/README.md
@@ -403,10 +403,12 @@ issues](https://github.com/intel/cve-bin-tool/issues).  Be aware that these issu
 not private, so take care when providing output to make sure you are not
 disclosing security issues in other products.
 
-Pull requests are also welcome via git.  
+Pull requests are also welcome via git.
 
 - New contributors should read the [contributor guide](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md) to get started.
 - Folk who already have experience contributing to open source projects may not need the full guide but should still use the [pull request checklist](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md#checklist-for-a-great-pull-request) to make things easy for everyone.
+
+CVE Binary Tool contributors are asked to adhere to the [Python Community Code of Conduct](https://www.python.org/psf/conduct/).  Please contact [Terri](https://github.com/terriko/) if you have concerns or questions relating to this code of conduct.
 
 ## Security Issues
 


### PR DESCRIPTION
Adding some code of conduct info to the main readme and contributors documentation.

Folk participating in Google Summer of Code have always had to adhere to this code of conduct during the course of our participation under the umbrella of the Python Software Foundation, but the [OpenSSF Best Practices Badge requires a Code of Conduct to reach Silver level](https://bestpractices.coreinfrastructure.org/en/projects/5380?criteria_level=1) so it makes most sense to adopt this one year-round and make sure it's documented and clear for all new contributors, not only those who sign up via the GSoC systems.