### PR TITLE
docs: Add atheris protobuf setup to readme

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -25,6 +25,7 @@ backends
 backport
 backported
 bash
+bazel
 bcca
 bdbd
 bdist
@@ -87,6 +88,7 @@ cvss
 cyberciti
 cygwin
 dbus
+dearmor
 debian
 debuginfo
 devops
@@ -139,6 +141,8 @@ gnupg
 gnutls
 google
 Google
+googleapis
+gpg
 gpgme
 grep
 GSo
@@ -172,6 +176,7 @@ irssi
 itertools
 jacksondatabind
 javascript
+jdk
 jerinjtitus
 jquery
 json
@@ -197,6 +202,7 @@ libjpeg
 liblas
 libnss
 libpng
+libprotobuf
 libraryname
 librsvg
 libseccomp
@@ -298,6 +304,7 @@ postgresql
 Prajwal
 Prasath
 printf
+protobuf
 pspp
 Purvanshsingh
 pybabel

--- a/fuzz/Readme.md
+++ b/fuzz/Readme.md
@@ -43,7 +43,14 @@ An example setup script used on Ubuntu 20.04 LTS:
 
 # Get system python.  Defaulting to 3.9 for now.
 # Note that this is the Ubuntu 20.04 requirements; other systems may differ
-sudo apt install python3.9 python3-virtualenv cabextract
+sudo apt install python3.9 python3-virtualenv cabextract python3-pip
+
+# Prep repos for installing Bazel, required to build atheris-protobuff-mutator wheel
+# Instructions adapted from https://docs.bazel.build/versions/5.2.0/install-ubuntu.html
+sudo apt install apt-transport-https curl gnupg
+curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg
+sudo apt-key add bazel.gpg
+echo "deb [arch=amd64] https://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 
 # set up cve-bin-tool code
 mkdir Code
@@ -51,8 +58,10 @@ cd Code
 git clone https://github.com/intel/cve-bin-tool
 
 # set up virtualenv
-virtualenv -p python3.9 ~/venv-fuzz/
-source ~/venv-fuzz/bin/activate
+# Commented out because the atheris-libprotobuf-mutator won't install in a venv
+# because the wheel build fails.
+# virtualenv -p python3.9 ~/venv-fuzz/
+# source ~/venv-fuzz/bin/activate
 
 # Install cve-bin-tool & required packages
 # Note that you need the cve-bin-tool install to get the checkers set up

--- a/fuzz/Readme.md
+++ b/fuzz/Readme.md
@@ -45,7 +45,7 @@ An example setup script used on Ubuntu 20.04 LTS:
 # Note that this is the Ubuntu 20.04 requirements; other systems may differ
 sudo apt install python3.9 python3-virtualenv cabextract python3-pip
 
-# Prep repos for installing Bazel, required to build atheris-protobuff-mutator wheel
+# Prep repos for installing Bazel, required to build atheris-libprotobuf-mutator wheel
 # Instructions adapted from https://docs.bazel.build/versions/5.2.0/install-ubuntu.html
 sudo apt install apt-transport-https curl gnupg
 curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor > bazel.gpg


### PR DESCRIPTION
Adding instructions on setting up atheris's protobuf stuff to Readme, since it's not entirely obvious. This is mostly so I can run a script on the ubuntu cloud machines I'm playing with for running longer-term fuzzing.