### PR TITLE
fix: Decode error during file scan in version_scanner.py (#1742)

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -109,9 +109,13 @@ class VersionScanner:
         output: str | None = None
         if inpath("file"):
             # use system file if available (for performance reasons)
-            output = subprocess.check_output(["file", filename]).decode(
-                sys.stdout.encoding
-            )
+            try:
+                output = subprocess.check_output(["file", filename]).decode(
+                    sys.stdout.encoding
+                )
+            except Exception as e:
+                output = "cannot open"
+                self.logger.warning(f"Unable to open {filename}: {repr(e)}")
 
             if "cannot open" in output:
                 self.logger.warning(f"Unopenable file {filename} cannot be scanned")


### PR DESCRIPTION
Fixed: #1742 

### Summary
Wrapped the `decode` method in try/except to catch the exception and log it. Error was in the `version_scanner.py` on line 112.