### PR TITLE
ci(spelling): Pull in permissions from check-spelling/spell-check-this

### DIFF
--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -4,6 +4,10 @@ on: [push, pull_request]
 jobs:
   spelling:
     name: Spell checking
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: read
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Hi,

I'm providing a small change to the workflow.

By default permissions for GitHub workflows are very permissive. It's possible for an org to lock down permissions, but most organizations don't.

Since you're just relying on users reading the output from the workflow, there's no reason to allow the permission to have any write permissions.

This is generally listed here:
https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#restricting-permissions-for-tokens