### PR TITLE
fix: fix filename and root display

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -339,7 +339,7 @@ try:
                 "Applicationlist",
                 ["Vendor", "Product", "Version", "Root", "Filename"],
                 pdfdoc.tblStyle,
-                [10, 10, None, None, None],
+                [10, 10, 10, 15, 15],
             )
             row = 1
             star_warn = False

--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -174,6 +174,23 @@ def _output_console_nowrap(
                 break
 
         # Show table of vulnerable products mapped to filename paths
+        # As path names can be long, these maybe replaced with a note which
+        # is printed at end of table
+
+        def validate_path_length(path_name, path_type):
+            # If long pathname replace with a note
+            if len(path_name) > 45:
+                if [path_name, path_type] not in note_data:
+                    note_data.append([path_name, path_type])
+                return (
+                    path_type
+                    + str(note_data.index([path_name, path_type]))
+                    + " (see below)"
+                )
+            return path_name
+
+        i = 0
+        note_data = []
         for path_remarks in sorted(cve_by_paths):
             color = "yellow"
             console.print(
@@ -195,9 +212,17 @@ def _output_console_nowrap(
                     Text.styled(cve_data["vendor"], color),
                     Text.styled(cve_data["product"], color),
                     Text.styled(cve_data["version"], color),
-                    Text.styled(path_root[0], color),
-                    Text.styled(path_root[1], color),
+                    Text.styled(validate_path_length(path_root[0], "Root "), color),
+                    Text.styled(validate_path_length(path_root[1], "Path "), color),
                 ]
                 table.add_row(*cells)
         # Print the table to the console
         console.print(table)
+        # Show truncated filenames if necessary
+        if len(note_data) > 0:
+            console.print("\n")
+            i = 0
+            for note in note_data:
+                # Note is a tuple [pathname, pathtype]
+                console.print(f"{note[1]}{i} : {note[0]}")
+                i = i + 1

--- a/cve_bin_tool/output_engine/util.py
+++ b/cve_bin_tool/output_engine/util.py
@@ -271,7 +271,8 @@ def group_cve_by_remark(
 
 def format_path(path_element: str) -> List[str]:
     """Extract filenames from path element"""
-    path = path_element.split(" contains ")
+    path = path_element.strip().split(" contains ")
     if len(path) > 1:
-        return [os.path.basename(path[0]), os.path.basename(path[1])]
-    return [os.path.basename(path[0]), " - "]
+        # path_element is an archive. Final element will be the filename
+        return [os.path.basename(path[0]), os.path.basename(path[-1])]
+    return [os.path.dirname(path[0]), os.path.basename(path[0])]

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -560,18 +560,12 @@ class TestOutputEngine(unittest.TestCase):
         "vendor0"
         "product0"
         "1.0"
-        ""
-        "-"
         "vendor0"
         "product0"
         "2.8.6"
-        ""
-        "-"
         "vendor1"
         "product1"
         "3.2.1.0"
-        ""
-        "-"
         "Page 2"
     )
 
@@ -774,7 +768,7 @@ class TestOutputEngine(unittest.TestCase):
 
         output_pdf(self.MOCK_PDF_OUTPUT, False, 1, None, "cve_test.pdf", False, 0)
         with open("cve_test.pdf", "rb") as f:
-            pdf = pdftotext.PDF(f)
+            pdf = pdftotext.PDF(f, physical=True)
             # Only interested in section 3 of the report which contains table of CVEs. This is on the second page
             page = pdf[1]
             # Find start of section 3 header


### PR DESCRIPTION
root is set to filename and filename is set to " - " since https://github.com/intel/cve-bin-tool/commit/a8d9eebbf109448e13a734eadeda1d3f04a3b194 which seems awkward when root is a path and not an archive:

```
╭─────────────────╮
│  NewFound CVEs  │
╰─────────────────╯
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Vendor       ┃ Product        ┃ Version      ┃ Root            ┃ Filename ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ sudo_project │ sudo           │ 1.9.5p2      │ sudo_logsrvd    │  -       │
│ sudo_project │ sudo           │ 1.9.5p2      │ sudo_sendlog    │  -       │
```

So fix this issue with the proposal of @anthonyharrison to get this display when root is a short path:

```
╭─────────────────╮
│  NewFound CVEs  │
╰─────────────────╯
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃ Vendor       ┃ Product        ┃ Version      ┃ Root      ┃ Filename        ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ sudo_project │ sudo           │ 1.9.5p2      │ /usr/sbin │ sudo_logsrvd    │
│ sudo_project │ sudo           │ 1.9.5p2      │ /usr/sbin │ sudo_sendlog    │
```

When the path is long, the display is the following:

```
╭─────────────────╮
│  NewFound CVEs  │
╰─────────────────╯
┏━━━━━━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ Vendor       ┃ Product ┃ Version ┃ Root               ┃ Filename     ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ sudo_project │ sudo    │ 1.9.5p2 │ Root 0 (see below) │ sudo_sendlog │
│ sudo_project │ sudo    │ 1.9.5p2 │ Root 0 (see below) │ sudo_logsrvd │
└──────────────┴─────────┴─────────┴────────────────────┴──────────────┘

Root 0 : /home/oem/cve-bin-tool/test_very_very_long_path
```

When root is an archive, the display is the following:

```
╭─────────────────╮
│  NewFound CVEs  │
╰─────────────────╯
┏━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━┓
┃ Vendor ┃ Product ┃ Version ┃ Root                           ┃ Filename ┃
┡━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━┩
│ gnu    │ bash    │ 4.4.19  │ bash_4.4.18-2ubuntu1_amd64.deb │ bash     │
```

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>