### PR TITLE
fix: Removed server from list of allowed words list

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -345,7 +345,6 @@ sannanansari
 Saurabh
 sbs
 sdk
-server
 shreyamalviya
 somefile
 sottile


### PR DESCRIPTION
Fixed #1914 
Removed server from allowed list of words.