### PR TITLE
fix(strings): Handle Unicode decoding errors instead of crashing

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -145,7 +145,8 @@ class VersionScanner:
 
         if inpath("strings"):
             # use "strings" on system if available (for performance)
-            lines = subprocess.check_output(["strings", filename]).decode("utf-8")
+            data = subprocess.check_output(["strings", filename])
+            lines = data.decode("utf-8", errors="backslashreplace")
         else:
             # Otherwise, use python implementation
             s = Strings(filename)


### PR DESCRIPTION
When running `cve-bin-tool` on some of my projects, I get an `UnicodeDecodeError` upon decoding the output of `strings`. I thought it was best to handle it instead of completely stopping.

It is using the `"backslashreplace"` error handler which will use the hex form of the byte value with format `\xhh`.

Error example:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xff in position 853: invalid start byte
```

It would thus keep `\xff` in this case.