### PR TITLE
ci: limit `NVD_API_KEY` to reduce codecov jitter

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,6 @@ on:
 env:
   ACTIONS: 1
   LONG_TESTS: 0
-  nvd_api_key: ${{ secrets.NVD_API_KEY }}
 
 jobs:
   docs:
@@ -73,15 +72,21 @@ jobs:
           python -m pip install --upgrade -r dev-requirements.txt
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
+        env:
+          nvd_api_key: ${{ secrets.NVD_API_KEY }}
         run: |
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
       - name: Run async tests
+        env:
+          nvd_api_key: ${{ secrets.NVD_API_KEY }}
         run: >
           pytest -n 4 -v
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
       - name: Run synchronous tests
+        env:
+          nvd_api_key: ${{ secrets.NVD_API_KEY }}
         run: >
           pytest -v
           test/test_cli.py


### PR DESCRIPTION
This workflow runs on both `push` and `pull_request`.

When it runs on `pull_request` from forks, it will not have access to secrets.
Secrets that are conditionally available as environment variables result in
jitter in Codecov reports.

---

I'm not entirely certain which tests care about the `nvd_api_key`, but I filed a ticket with Codecov and they explained that the output reported in https://github.com/intel/cve-bin-tool/pull/1901#issuecomment-1222662124 was because of the `nvd_api_key` environment variable:

```diff
@@             Coverage Diff             @@
##             main    #1901       +/-   ##
===========================================
- Coverage   89.54%   78.83%   -10.72%     
===========================================
  Files         316      316               
  Lines        7224     7224               
  Branches     1176     1176               
===========================================
- Hits         6469     5695      -774     
- Misses        490     1279      +789     
+ Partials      265      250       -15     
```

Based on this section, of the report, I believe the included change should alleviate this and is appropriately targetted:
Flag | Coverage Δ
-- | --
longtests | 78.83% <ø> (+0.11%) | ⬆️
win-longtests | ?
