### PR TITLE
fix: slow incremental updates for OSV

### DIFF
--- a/cve_bin_tool/data_sources/osv_source.py
+++ b/cve_bin_tool/data_sources/osv_source.py
@@ -35,6 +35,7 @@ class OSV_Source(Data_Source):
 
         self.error_mode = error_mode
         self.incremental_update = incremental_update
+        self.incremental_threshold = 30
 
         self.osv_url = self.OSV_URL
         self.gs_url = self.OSV_GS_URL
@@ -68,9 +69,13 @@ class OSV_Source(Data_Source):
             return content
 
     async def get_ecosystem_incremental(self, ecosystem, time_of_last_update, session):
-        """Fetches list of new CVEs and uses get_ecosystem to get them."""
+        """Fetches list of new CVEs and uses get_ecosystem to get them, if CVEs are greater than threshold value returns just the name of ecosystem."""
 
         newfiles = await self.get_newfiles(ecosystem, time_of_last_update)
+
+        # skip ecosystem if there are too many individual CVEs to download
+        if len(newfiles) > self.incremental_threshold:
+            return ecosystem
 
         tasks = []
 
@@ -85,6 +90,8 @@ class OSV_Source(Data_Source):
 
             async with FileIO(filepath, "w") as f:
                 await f.write(r)
+
+        return None
 
     def parse_filename(self, str):
         str = str.split("  ")
@@ -161,14 +168,25 @@ class OSV_Source(Data_Source):
             if len(newfiles) == totalfiles:
                 self.incremental_update = False
 
+        # ecosystems to download all.zip for if CVEs are greater than threshold or incremental update is false
+        ecosystems = [] if self.incremental_update else self.ecosystems
+
         if self.incremental_update and self.db.dbpath.exists():
-            for ecosystem in self.ecosystems:
-                await self.get_ecosystem_incremental(
-                    ecosystem, time_of_last_update, self.session
-                )
-        else:
             tasks = []
             for ecosystem in self.ecosystems:
+                task = self.get_ecosystem_incremental(
+                    ecosystem, time_of_last_update, self.session
+                )
+
+                tasks.append(task)
+
+            for skipped_ecosystem in await asyncio.gather(*tasks):
+                if skipped_ecosystem:
+                    ecosystems.append(skipped_ecosystem)
+
+        if len(ecosystems) > 0:
+            tasks = []
+            for ecosystem in ecosystems:
                 eco_url = self.osv_url + ecosystem + "/all.zip"
                 task = self.get_ecosystem(eco_url, self.session, mode="bytes")
 


### PR DESCRIPTION
fixes #1932 

CVEs will only be incrementally downloaded for an ecosystem if they are above a threshold value, otherwise zip file containing all the CVEs will be downloaded as it is faster.