### PR TITLE
feat(helper_script): take an executable file as an input

### DIFF
--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -59,51 +59,55 @@ class HelperScript:
         # for scanning files versions
         self.version_scanner = VersionScanner()
 
+    def parse_execfile(self, filename: str) -> list[str] | None:
+        """Parses executable file for common patterns, version strings and common filename patterns"""
+
+        LOGGER.debug(f"{filename} <--- this is an ELF binary")
+        file_content = self.version_scanner.parse_strings(filename)
+
+        matches = self.search_pattern(
+            file_content, self.product_name, self.version_number
+        )
+
+        # searching for version strings in the found matches
+        version_string = self.search_version_string(matches)
+        self.version_pattern += version_string
+
+        # if version string is found in file, append it to filename_pattern
+        if version_string:
+            if sys.platform == "win32":
+                self.filename_pattern.append(filename.split("\\")[-1])
+            else:
+                self.filename_pattern.append(filename.split("/")[-1])
+            LOGGER.info(f"matches for {self.product_name} found in {filename}")
+
+            for i in matches:
+                if ("/" not in i and "!" not in i) and len(i) > self.string_length:
+                    self.contains_patterns.append(i)
+
+        LOGGER.debug(f"{self.filename_pattern}")
+        return matches
+
     def extract_and_parse_file(self, filename: str) -> list[str] | None:
         """extracts and parses the file for common patterns, version strings and common filename patterns"""
 
-        self.parse_filename(filename)
+        # if the file is ELF binary file, don't try to parse its filename or extract it
+        if self.version_scanner.is_executable(filename)[0]:
+            return self.parse_execfile(filename)
+        else:
+            self.parse_filename(filename)
 
-        with self.extractor as ectx:
-            if ectx.can_extract(filename):
-                binary_string_list: list[str] = []
-                for filepath in self.walker([ectx.extract(filename)]):
-                    clean_path = self.version_scanner.clean_file_path(filepath)
-                    LOGGER.debug(f"checking whether {clean_path} is binary")
+            with self.extractor as ectx:
+                if ectx.can_extract(filename):
+                    binary_string_list: list[str] = []
+                    for filepath in self.walker([ectx.extract(filename)]):
+                        clean_path = self.version_scanner.clean_file_path(filepath)
+                        LOGGER.debug(f"checking whether {clean_path} is binary")
 
-                    # see if the file is ELF binary file and parse for strings
-                    is_exec = self.version_scanner.is_executable(filepath)[0]
-                    if is_exec:
-                        LOGGER.debug(f"{clean_path} <--- this is an ELF binary")
-                        file_content = self.version_scanner.parse_strings(filepath)
-
-                        matches = self.search_pattern(
-                            file_content, self.product_name, self.version_number
-                        )
-
-                        # searching for version strings in the found matches
-                        version_string = self.search_version_string(matches)
-                        self.version_pattern += version_string
-
-                        # if version string is found in file, append it to filename_pattern
-                        if version_string:
-                            if sys.platform == "win32":
-                                self.filename_pattern.append(filepath.split("\\")[-1])
-                            else:
-                                self.filename_pattern.append(filepath.split("/")[-1])
-                            LOGGER.info(
-                                f"matches for {self.product_name} found in {clean_path}"
-                            )
-
-                            binary_string_list += matches
-
-                            for i in matches:
-                                if ("/" not in i and "!" not in i) and len(
-                                    i
-                                ) > self.string_length:
-                                    self.contains_patterns.append(i)
-
-                        LOGGER.debug(f"{self.filename_pattern}")
+                        # see if the file is ELF binary file and parse for strings
+                        is_exec = self.version_scanner.is_executable(filepath)[0]
+                        if is_exec:
+                            binary_string_list += self.parse_execfile(filepath)
 
                 if not self.multiline_pattern:
                     self.version_pattern = [


### PR DESCRIPTION
Allow the user to give an executable file as an input,  e.g.:

`cve-bin-tool /usr/sbin/dnsmasq`

or

`cve-bin-tool /usr/lib/x86_64-linux-gnu/libarchive.so.13.6.0`

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>