### PR TITLE
fix: fix zlib CPE ID

### DIFF
--- a/cve_bin_tool/checkers/zlib.py
+++ b/cve_bin_tool/checkers/zlib.py
@@ -7,6 +7,7 @@ CVE checker for zlib
 --------
 References:
 http://www.cvedetails.com/vulnerability-list/vendor_id-72/product_id-1820/GNU-Zlib.html
+https://www.cvedetails.com/vulnerability-list/vendor_id-13265/product_id-111843/Zlib-Zlib.html
 https://zlib.net/ChangeLog.txt
 
 RSS feed: http://www.cvedetails.com/vulnerability-feed.php?vendor_id=72&product_id=1820&version_id=&orderby=2&cvssscoremin=0
@@ -30,7 +31,7 @@ class ZlibChecker(Checker):
         r"inflate ([01]+\.[0-9]+\.[0-9]+) ",
         r"libz.so.([01]+\.[0-9]+\.[0-9]+)",  # patterns like this aren't ideal
     ]
-    VENDOR_PRODUCT = [("gnu", "zlib")]
+    VENDOR_PRODUCT = [("gnu", "zlib"), ("zlib", "zlib")]
 
 
 """


### PR DESCRIPTION
`cpe:2.3:a:gnu:zlib` has been deprecated since "2022-06-22T16:40:44.440Z": https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Agnu%3Azlib

`cpe:2.3:a:zlib:zlib` is the new correct CPE ID for zlib: https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Azlib%3Azlib

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>