### PR TITLE
fix: fix cups CPE ID

### DIFF
--- a/cve_bin_tool/checkers/cups.py
+++ b/cve_bin_tool/checkers/cups.py
@@ -5,7 +5,10 @@
 """
 CVE checker for cups
 
+https://www.cvedetails.com/product/14145/Apple-Cups.html?vendor_id=49
+https://www.cvedetails.com/product/6857/Cups-Cups.html?vendor_id=3886
 https://www.cvedetails.com/product/1219/Easy-Software-Products-Cups.html?vendor_id=713
+https://www.cvedetails.com/product/116209/Openprinting-Cups.html?vendor_id=27340
 
 """
 
@@ -24,4 +27,9 @@ class CupsChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"cups"]
     VERSION_PATTERNS = [r"CUPS v([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PRODUCT = [("easy_software_products", "cups")]
+    VENDOR_PRODUCT = [
+        ("apple", "cups"),
+        ("cups", "cups"),
+        ("easy_software_products", "cups"),
+        ("openprinting", "cups"),
+    ]


### PR DESCRIPTION
`cpe:2.3:a:apple:cups`, `cpe:2.3:a:cups:cups` and
`cpe:2.3:a:openprinting:cups` are valid CPE IDs for cups:
https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Aapple%3Acups https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Acups%3Acups https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Aopenprinting%3Acups

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>