### PR TITLE
feat(format_checkers.py): exclude dictionary words from allow.txt

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -353,7 +353,6 @@ sannanansari
 Saurabh
 sbs
 sdk
-server
 shreyamalviya
 somefile
 sottile

--- a/cve_bin_tool/format_checkers.py
+++ b/cve_bin_tool/format_checkers.py
@@ -91,6 +91,11 @@ def update_allowed_words(checkers_array: List[str], file_path: str) -> None:
 
     words = sorted(words, key=str.casefold)
 
+    dictionary_words_to_exclude = ["server"]
+    for word in dictionary_words_to_exclude:
+        if word in words:
+            words.remove(word)
+
     with open(file_path, "w+") as fileObj:
         fileObj.writelines("\n".join(words) + "\n\n")
 


### PR DESCRIPTION
closes #1956