### PR TITLE
ci: disable py3.7 tests causing sporadic failures

### DIFF
--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -131,6 +131,7 @@ class TestExtractFileRpm(TestExtractorBase):
         return self.extractor.file_extractors[self.extractor.extract_file_rpm]
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
     async def test_extract_file_rpm(self, extension_list: List[str]):
         """Test the rpm file extraction"""
         async for extracted_path in self.extract_files(
@@ -163,6 +164,7 @@ class TestExtractFileZst(TestExtractorBase):
         return self.extractor.file_extractors[self.extractor.extract_file_zst]
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
     async def test_extract_file_zst(self, extension_list: List[str]):
         """Test the zst file extraction"""
         async for extracted_path in self.extract_files(
@@ -231,6 +233,7 @@ class TestExtractFileRpmWithZstd(TestExtractorBase):
         return self.extractor.file_extractors[self.extractor.extract_file_rpm]
 
     @pytest.mark.asyncio
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
     async def test_extract_file_rpm(self, extension_list: List[str]):
         """Test the rpm file extraction in windows with zstd"""
         async for extracted_path in self.extract_files(

--- a/test/test_helper_script.py
+++ b/test/test_helper_script.py
@@ -54,6 +54,7 @@ class TestHelperScript:
         hs = HelperScript(filename)
         assert (product_name, version_name) == hs.parse_filename(filename)
 
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
     def test_scan_files_no_product(self, caplog):
         args = {
             "filenames": [
@@ -88,6 +89,7 @@ class TestHelperScript:
                 in caplog.text
             )
 
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
     def test_scan_files_common(self, capfd):
         args = {
             "filenames": [
@@ -106,6 +108,7 @@ class TestHelperScript:
         assert "VERSION_PATTERNS" not in out
         assert "VENDOR_PRODUCT" not in out
 
+    @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
     def test_scan_files_single(self, capfd):
         args = {
             "filenames": [


### PR DESCRIPTION
* fixes #1927

We're still seeing the occasional py3.7 failure, and I want to clean that up before hacktoberfest since it slows down PR approvals. I think these are the last of the ones I've seen fail, but I wouldn't swear I've gotten them all forever since we still don't know what's causing these other than it seems to be related to mock and possibly file accesses and only occurs on python 3.7.