### PR TITLE
Only run update-cache if you are the main repository

### DIFF
--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   linux:
+    if: github.repository == 'intel/cve-bin-tool'
     name: Update linux cached database
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -41,6 +42,7 @@ jobs:
           python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -u now
 
   windows:
+    if: github.repository == 'intel/cve-bin-tool'
     name: Update windows cached database
     runs-on: windows-latest
     timeout-minutes: 20


### PR DESCRIPTION
This *SHOULD* resolve #1950 by only running the job *IF* the repository is 'intel/cve-bin-tool'.  It's probably also worth adding a check for the NVD_API_KEY as well just to be on the safe side, but I believe this resolves it (noting this is somewhat hard to actually test, for obvious reasons).

Signed-off-by: John 'Warthog9' Hawley <warthog9@eaglescrag.net>