### PR TITLE
ci: disable intermittently failing windows tests

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -154,6 +154,9 @@ class TestCLI(TempDirTest):
         assert e.value.args[0] == ERROR_CODES[SystemExit]
 
     @pytest.mark.skipif(LONG_TESTS() != 1, reason="Update flag tests are long tests")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Causing failures in CI on windows only"
+    )
     def test_update_flags(self):
         assert (
             main(["cve-bin-tool", "-x", "-u", "never", "-n", "json", self.tempdir]) != 0

--- a/test/test_cvedb.py
+++ b/test/test_cvedb.py
@@ -3,6 +3,7 @@
 
 import datetime
 import shutil
+import sys
 import tempfile
 from test.utils import LONG_TESTS
 
@@ -27,6 +28,9 @@ class TestCVEDB:
     @pytest.mark.asyncio
     @pytest.mark.skipif(
         LONG_TESTS() != 1, reason="Skipping NVD calls due to rate limits"
+    )
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Causing failures in CI on windows only"
     )
     async def test_refresh_nvd_json(self):
         await self.cvedb.refresh()


### PR DESCRIPTION
* fixes #1968

We've got two more tests that are sporadically failing on windows (but run fine on windows) possibly due to network issues or rate limiting.  In the interest of making CI more stable (especially before new hacktoberfest try to do PRs with us), I'm disabling them for the time being.