### PR TITLE
refactor: extract `parse_strings` method to `strings.py`

### DIFF
--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -18,6 +18,7 @@ from cve_bin_tool.cvedb import CVEDB, DBNAME, DISK_LOCATION_DEFAULT
 from cve_bin_tool.error_handler import ErrorHandler, ErrorMode, UnknownArchiveType
 from cve_bin_tool.extractor import Extractor, TempDirExtractorContext
 from cve_bin_tool.log import LOGGER
+from cve_bin_tool.strings import parse_strings
 from cve_bin_tool.util import DirWalk
 from cve_bin_tool.version_scanner import VersionScanner
 
@@ -63,7 +64,7 @@ class HelperScript:
         """Parses executable file for common patterns, version strings and common filename patterns"""
 
         LOGGER.debug(f"{filename} <--- this is an ELF binary")
-        file_content = self.version_scanner.parse_strings(filename)
+        file_content = parse_strings(filename)
 
         matches = self.search_pattern(
             file_content, self.product_name, self.version_number

--- a/cve_bin_tool/parsers/python.py
+++ b/cve_bin_tool/parsers/python.py
@@ -6,8 +6,8 @@ import subprocess
 from re import MULTILINE, compile, search
 
 from cve_bin_tool.parsers import Parser
-from cve_bin_tool.strings import Strings
-from cve_bin_tool.util import ProductInfo, ScanInfo, inpath
+from cve_bin_tool.strings import parse_strings
+from cve_bin_tool.util import ProductInfo, ScanInfo
 
 
 class PythonRequirementsParser(Parser):
@@ -44,17 +44,6 @@ class PythonParser(Parser):
     def __init__(self, cve_db, logger):
         super().__init__(cve_db, logger)
 
-    def parse_strings(self, filename):
-        """parse binary file's strings"""
-        if inpath("strings"):
-            # use "strings" on system if available (for performance)
-            lines = subprocess.check_output(["strings", filename]).decode("utf-8")
-        else:
-            # Otherwise, use python implementation
-            s = Strings(filename)
-            lines = s.parse()
-        return lines
-
     def find_vendor(self, product, version):
         vendor_package_pair = self.cve_db.get_vendor_product_pairs(product)
         if vendor_package_pair != []:
@@ -71,7 +60,7 @@ class PythonParser(Parser):
         The ProductInfo is computed without the help of any checkers from PKG-INFO or METADATA.
         """
         self.filename = filename
-        lines = self.parse_strings(self.filename)
+        lines = parse_strings(self.filename)
         lines = "\n".join(lines.splitlines()[:3])
         try:
             product = search(compile(r"^Name: (.+)$", MULTILINE), lines).group(1)

--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -7,9 +7,11 @@ the tool is able to support other operating systems like Windows
 and MacOS.
 """
 
+import subprocess
 from typing import ClassVar, List, Set
 
 from cve_bin_tool.async_utils import FileIO, run_coroutine
+from cve_bin_tool.util import inpath
 
 
 class Strings:
@@ -37,3 +39,17 @@ class Strings:
 
     def parse(self) -> str:
         return run_coroutine(self.aio_parse())
+
+
+def parse_strings(filename: str) -> str:
+    """parse binary file's strings"""
+
+    if inpath("strings"):
+        # use "strings" on system if available (for performance)
+        data = subprocess.check_output(["strings", filename])
+        lines = data.decode("utf-8", errors="backslashreplace")
+    else:
+        # Otherwise, use python implementation
+        s = Strings(filename)
+        lines = s.parse()
+    return lines

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -16,7 +16,7 @@ from cve_bin_tool.extractor import Extractor, TempDirExtractorContext
 from cve_bin_tool.file import is_binary
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.parsers.parse import parse, valid_files
-from cve_bin_tool.strings import Strings
+from cve_bin_tool.strings import parse_strings
 from cve_bin_tool.util import DirWalk, ProductInfo, ScanInfo, inpath
 
 if sys.version_info >= (3, 8):
@@ -140,19 +140,6 @@ class VersionScanner:
 
         return True, output
 
-    def parse_strings(self, filename: str) -> str:
-        """parse binary file's strings"""
-
-        if inpath("strings"):
-            # use "strings" on system if available (for performance)
-            data = subprocess.check_output(["strings", filename])
-            lines = data.decode("utf-8", errors="backslashreplace")
-        else:
-            # Otherwise, use python implementation
-            s = Strings(filename)
-            lines = s.parse()
-        return lines
-
     def scan_file(self, filename: str) -> Iterator[ScanInfo]:
         """Scans a file to see if it contains any of the target libraries,
         and whether any of those contain CVEs"""
@@ -176,7 +163,7 @@ class VersionScanner:
             return None
 
         # parse binary file's strings
-        lines = self.parse_strings(filename)
+        lines = parse_strings(filename)
 
         if output:
             valid_file = False


### PR DESCRIPTION
Extract `parse_strings` method to `strings.py` instead of `util.py` to avoid circular imports.

Closes #1966.