### PR TITLE
fix: Add word "tool" to exclude list in format_checkers.py

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -395,7 +395,6 @@ tls
 tmp
 TODO
 toml
-tool
 tools
 triaging
 trousers

--- a/cve_bin_tool/format_checkers.py
+++ b/cve_bin_tool/format_checkers.py
@@ -91,7 +91,7 @@ def update_allowed_words(checkers_array: List[str], file_path: str) -> None:
 
     words = sorted(words, key=str.casefold)
 
-    dictionary_words_to_exclude = ["server"]
+    dictionary_words_to_exclude = ["server", "tool"]
     for word in dictionary_words_to_exclude:
         if word in words:
             words.remove(word)


### PR DESCRIPTION
Signed-off-by: JoaoDanielRufino <joaodaniel0405@gmail.com>

- Added `tool` word on https://github.com/intel/cve-bin-tool/blob/main/cve_bin_tool/format_checkers.py#L94
- Removed `tool` word on https://github.com/intel/cve-bin-tool/blob/main/.github/actions/spelling/allow.txt

Closes #2037 