### PR TITLE
ci: disable test_version_in_package_make_download temporarily

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -260,6 +260,9 @@ class TestScanner:
         assert version in list_versions
 
     @pytest.mark.skipif(LONG_TESTS() != 1, reason="Skipping long tests")
+    @pytest.mark.skip(
+        reason="Broken. See https://github.com/intel/cve-bin-tool/issues/2054"
+    )
     def test_version_in_package_make_download(self, mocker: MockerFixture):
 
         url = "https://kojipkgs.fedoraproject.org//packages/python3/3.8.2~rc1/1.fc33/aarch64/"


### PR DESCRIPTION
* related #2054 

This test is currently failing in both linux and windows.  The file in question is correctly detected as python when I run the tool manually, so the problem is likely in the test code itself.  I'm temporarily disabling it while we try to determine a fix or a replacement test.