### PR TITLE
ci: temporarily disable tests failing on windows

### DIFF
--- a/test/test_helper_script.py
+++ b/test/test_helper_script.py
@@ -71,6 +71,9 @@ class TestHelperScript:
             assert "PRODUCT_NAME not in arguments" in caplog.text
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Causing failures in CI on windows"
+    )
     def test_scan_files_version(self, caplog):
         args = {
             "filenames": [
@@ -90,6 +93,9 @@ class TestHelperScript:
             )
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Causing failures in CI on windows"
+    )
     def test_scan_files_common(self, capfd):
         args = {
             "filenames": [
@@ -109,6 +115,9 @@ class TestHelperScript:
         assert "VENDOR_PRODUCT" not in out
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Causing failures in CI on windows"
+    )
     def test_scan_files_single(self, capfd):
         args = {
             "filenames": [
@@ -127,6 +136,9 @@ class TestHelperScript:
         assert "VENDOR_PRODUCT" in out
 
     @pytest.mark.skipif(sys.version_info < (3, 8), reason="py3.7 fails sometimes")
+    @pytest.mark.skipif(
+        sys.platform == "win32", reason="Causing failures in CI on windows"
+    )
     def test_scan_files_multiline(self, capfd):
         args = {
             "filenames": [


### PR DESCRIPTION
* related: #2038

These 4 tests are failing fairly consistently on windows in CI.  I still need to investigate further as to why and see if we can get them fixed, but in the interest of having stable CI (particularly with all the hackerfest requests coming in) I'm going to go ahead and disable them temporarily while we investigate.