### PR TITLE
feat: add mypy.ini file to deal with missing imports

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,30 @@
+[mypy]
+
+[mypy-bs4.*]
+ignore_missing_imports = True
+
+[mypy-cvss.*]
+ignore_missing_imports = True
+
+[mypy-defusedxml.*]
+ignore_missing_imports = True
+
+[mypy-jsonschema.*]
+ignore_missing_imports = True
+
+[mypy-pdftotext.*]
+ignore_missing_imports = True
+
+[mypy-plotly.*]
+ignore_missing_imports = True
+
+[mypy-reportlab.*]
+ignore_missing_imports = True
+
+[mypy-rpmfile.*]
+ignore_missing_imports = True
+
+[mypy-setuptools.*]
+ignore_missing_imports = True
+
+

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -27,4 +27,7 @@ ignore_missing_imports = True
 [mypy-setuptools.*]
 ignore_missing_imports = True
 
+[mypy-xmlschema.*]
+ignore_missing_imports = True
+
 


### PR DESCRIPTION
A number of the 3rd party libraries we use don't yet have type hints (and maybe never will) so I've set up a mypy.ini file to guide mypy to ignore those for now.  We could replace this with stubs or remove entries if we want to improve the type checking in the future, but I'm okay with leaving these disabled for our first pass on type hinting.