### PR TITLE
refactor: add type-hints for test/test_scanner.py

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -16,8 +16,8 @@ import tempfile
 import unittest
 import unittest.mock
 from pathlib import Path
-from typing import List
 from test.utils import LONG_TESTS, download_file
+from typing import List
 
 import pytest
 from pytest_mock import MockerFixture

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -13,10 +13,10 @@ import shutil
 import sys
 import tarfile
 import tempfile
-from typing import List
 import unittest
 import unittest.mock
 from pathlib import Path
+from typing import List
 from test.utils import LONG_TESTS, download_file
 
 import pytest

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -13,6 +13,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
+from typing import List
 import unittest
 import unittest.mock
 from pathlib import Path
@@ -29,11 +30,11 @@ from cve_bin_tool.version_scanner import VersionScanner
 test_data = list(
     map(lambda x: importlib.import_module(f"test.test_data.{x}"), all_test_name[2:])
 )
-mapping_test_data = map(lambda x: x.mapping_test_data, test_data)  # map[list[dict[str, Union[str, list]]]]
-package_test_data = map(lambda x: x.package_test_data, test_data)  # map[list[dict[str, str]]]
-DISABLED_TESTS_ACTIONS: list[str] = ["gimp"]
-DISABLED_TESTS_LOCAL: list[str] = []
-DISABLED_TESTS_WINDOWS: list[str] = ["libsrtp", "p7zip"]
+mapping_test_data = map(lambda x: x.mapping_test_data, test_data)
+package_test_data = map(lambda x: x.package_test_data, test_data)
+DISABLED_TESTS_ACTIONS: List[str] = ["gimp"]
+DISABLED_TESTS_LOCAL: List[str] = []
+DISABLED_TESTS_WINDOWS: List[str] = ["libsrtp", "p7zip"]
 
 
 class TestScanner:

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -29,11 +29,11 @@ from cve_bin_tool.version_scanner import VersionScanner
 test_data = list(
     map(lambda x: importlib.import_module(f"test.test_data.{x}"), all_test_name[2:])
 )
-mapping_test_data = map(lambda x: x.mapping_test_data, test_data)
-package_test_data = map(lambda x: x.package_test_data, test_data)
-DISABLED_TESTS_ACTIONS = ["gimp"]
-DISABLED_TESTS_LOCAL = []
-DISABLED_TESTS_WINDOWS = ["libsrtp", "p7zip"]
+mapping_test_data = map(lambda x: x.mapping_test_data, test_data)  # map[list[dict[str, Union[str, list]]]]
+package_test_data = map(lambda x: x.package_test_data, test_data)  # map[list[dict[str, str]]]
+DISABLED_TESTS_ACTIONS: list[str] = ["gimp"]
+DISABLED_TESTS_LOCAL: list[str] = []
+DISABLED_TESTS_WINDOWS: list[str] = ["libsrtp", "p7zip"]
 
 
 class TestScanner:


### PR DESCRIPTION
Added type-hints to pass `mypy` tests. #2129