### PR TITLE
fix: fix strings call

### DIFF
--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -46,7 +46,7 @@ def parse_strings(filename: str) -> str:
 
     if inpath("strings"):
         # use "strings" on system if available (for performance)
-        data = subprocess.check_output(["strings", filename])
+        data = subprocess.check_output(["strings", "-n 3", filename])
         lines = data.decode("utf-8", errors="backslashreplace")
     else:
         # Otherwise, use python implementation


### PR DESCRIPTION
By default, strings command will only return strings which have at least 4 characters:

"Print sequences of displayable characters that are at least min-len characters long.  If not specified a default minimum length of 4 is used."

This is an issue to catch some package versions such as upcoming chrony. This issue can already be tested by replacing the version of dnsmasq from 2.80 to 2.8 in mapping_test_data of test/test_data/dnsmasq.py.

To fix this issue, give a minimum length of 1. An other option would be to always use the python Strings function.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>