### PR TITLE
fix: change python strings to return only strings of length 3+

### DIFF
--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -33,7 +33,8 @@ class Strings:
                     if char in Strings.PRINTABLE:
                         tmp.append(chr(char))
                     elif tmp:
-                        self.output += "".join(tmp) + "\n"
+                        if len(tmp) >= 3:
+                            self.output += "".join(tmp) + "\n"
                         tmp = []
         return self.output
 


### PR DESCRIPTION
Closes #2140

