### PR TITLE
fix: improve curl checker patterns

### DIFF
--- a/cve_bin_tool/checkers/curl.py
+++ b/cve_bin_tool/checkers/curl.py
@@ -27,7 +27,5 @@ class CurlChecker(Checker):
         # r"ignoring --proxy-capath, not supported by libcurl",
     ]
     FILENAME_PATTERNS = [r"curl"]
-    VERSION_PATTERNS = [
-        r"curl ([678]+\.[0-9]+\.[0-9]+)",
-    ]
+    VERSION_PATTERNS = [r"curl[ -]([678]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("haxx", "curl"), ("haxx", "libcurl")]

--- a/test/test_data/curl.py
+++ b/test/test_data/curl.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 mapping_test_data = [
-    {"product": "curl", "version": "7.34.0", "version_strings": ["curl 7.34.0"]}
+    {"product": "curl", "version": "7.34.0", "version_strings": ["curl 7.34.0"]},
+    {"product": "curl", "version": "7.34.0", "version_strings": ["curl-7.34.0"]},
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Current curl checker doesn't work with some exotic libcurl library

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>