### PR TITLE
fix: ensure all pacman packages are accounted for

### DIFF
--- a/cve_bin_tool/package_list_parser.py
+++ b/cve_bin_tool/package_list_parser.py
@@ -93,7 +93,7 @@ class PackageListParser:
                 installed_packages = []
 
                 installed_packages_output = run(
-                    ["pacman", "--query", "--explicit"],
+                    ["pacman", "--query"],
                     stdout=PIPE,
                 )
 


### PR DESCRIPTION
The `--explicit` flag is used to get a list of all packages installed explicity on a system. This omits all packages installed as dependencies in the same transaction.

    $ pacman --query | wc -l
    1114
    $ pacman --query --explicit | wc -l
    74

Fixes: f57e7100c2ca3676bfba71f516307bfaddc8a1de

Signed-off-by: Morten Linderud <morten@linderud.pw>