### PR TITLE
refactor: extractor is now inherited in test_extractor.py

### DIFF
--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -40,6 +40,7 @@ class TestExtractorBase:
     """Test methods for extraction of various file types"""
 
     tempdir = Path(tempfile.mkdtemp())  # type: Path
+    extractor = Extractor()
 
     @classmethod
     def setup_class(cls):
@@ -80,8 +81,6 @@ class TestExtractorBase:
 
 class TestExtractFileTar(TestExtractorBase):
     """Tests for tar file extraction"""
-
-    extractor = Extractor()
 
     def setup_method(self):
         for filename, tarmode in [
@@ -125,8 +124,6 @@ class TestExtractFileTar(TestExtractorBase):
 class TestExtractFileRpm(TestExtractorBase):
     """Tests for the rpm file extractor"""
 
-    extractor = Extractor()
-
     @classmethod
     def setup_class(cls):
         super().setup_class()
@@ -162,8 +159,6 @@ class TestExtractFileRpm(TestExtractorBase):
 class TestExtractFileZst(TestExtractorBase):
     """Tests for the zst file extractor"""
 
-    extractor = Extractor()
-
     def setup_method(self):
         shutil.copyfile(ZST_FILE_PATH, self.tempdir / "test.zst")
 
@@ -185,8 +180,6 @@ class TestExtractFileZst(TestExtractorBase):
 
 class TestExtractFilePkg(TestExtractorBase):
     """Tests for pkg file extractor"""
-
-    extractor = Extractor()
 
     def setup_method(self):
         assert inpath("tar") or inpath("7z"), "Required tools 'tar' or '7z' not found"
@@ -233,8 +226,6 @@ class TestExtractFilePkg(TestExtractorBase):
 class TestExtractFileRpmWithZstd(TestExtractorBase):
     """Tests for the rpm file extractor (zstd/windows)"""
 
-    extractor = Extractor()
-
     @classmethod
     def setup_class(cls):
         super().setup_class()
@@ -256,8 +247,6 @@ class TestExtractFileRpmWithZstd(TestExtractorBase):
 
 class TestExtractFileDeb(TestExtractorBase):
     """Tests for deb file extractor"""
-
-    extractor = Extractor()
 
     def setup_method(self):
         assert inpath("ar"), "Required tool 'ar' not found"
@@ -303,8 +292,6 @@ class TestExtractFileDeb(TestExtractorBase):
 class TestExtractFileIpk(TestExtractorBase):
     """Tests for ipk file extractor"""
 
-    extractor = Extractor()
-
     def setup_method(self):
         assert inpath("ar"), "Required tool 'ar' not found"
         shutil.copyfile(DEB_FILE_PATH, self.tempdir / "test.deb")
@@ -328,8 +315,6 @@ class TestExtractFileIpk(TestExtractorBase):
 
 class TestExtractFileCab(TestExtractorBase):
     """Tests for the cab file extractor"""
-
-    extractor = Extractor()
 
     def setup_method(self):
         shutil.copyfile(CAB_TEST_FILE_PATH, self.tempdir / "test.cab")
@@ -372,9 +357,6 @@ class TestExtractFileZip(TestExtractorBase):
     """Tests for the zip file extractor
     This extractor also handles jar, apk, and sometimes exe files
     when the exe is a self-extracting zipfile"""
-
-    tempdir = Path(tempfile.mkdtemp())
-    extractor = Extractor()
 
     @pytest.fixture
     def extension_list(self) -> List[str]:


### PR DESCRIPTION
Resolves #2168

Wasn't sure of any other methods to do it, but the tests run just fine