### PR TITLE
fix: fix dirname/filename typo in util.py

### DIFF
--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -190,7 +190,7 @@ class DirWalk:
                         yield str((Path(dirpath) / filename).resolve())
                 if self.yield_folders:
                     for dirname in dirnames:
-                        yield str((Path(dirname) / filename).resolve())
+                        yield str((Path(dirpath) / dirname).resolve())
 
     @staticmethod
     def pattern_match(text: str, patterns: str) -> bool:


### PR DESCRIPTION
I missed a typo in #2134 but it was caught by static analysis.  Yay for automation!