### PR TITLE
refactor: fix mypy errors in cve_bin_tool/extractor.py

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -49,6 +49,7 @@ class BaseExtractor:
         # Sets up logger and if we should extract files or just report
         self.logger = logger or LOGGER.getChild(self.__class__.__name__)
         self.error_mode = error_mode
+        self.tempdir = None
         self.file_extractors = {
             self.extract_file_tar: {".tgz", ".tar.gz", ".tar", ".tar.xz", ".tar.bz2"},
             self.extract_file_rpm: {".rpm"},
@@ -309,7 +310,6 @@ class TempDirExtractorContext(BaseExtractor):
 
     def __init__(self, raise_failure=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.tempdir = None
         self.raise_failure = raise_failure
 
     async def aio_extract(self, filename):

--- a/test/test_data/grub2.py
+++ b/test/test_data/grub2.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2022 Orange
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-mapping_test_data = []
+from typing import Dict, List
+
+mapping_test_data: List[Dict] = []
 package_test_data = [
     {
         "url": "http://rpmfind.net/linux/opensuse/distribution/leap/15.5/repo/oss/aarch64/",

--- a/test/test_data/kerberos.py
+++ b/test/test_data/kerberos.py
@@ -1,6 +1,8 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from typing import Dict, List
+
 mapping_test_data = [
     {
         "product": "kerberos",
@@ -21,4 +23,4 @@ mapping_test_data = [
         ],
     },
 ]
-package_test_data = {}
+package_test_data: List[Dict] = []

--- a/test/test_data/kerberos_5.py
+++ b/test/test_data/kerberos_5.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2021 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-mapping_test_data = {}
+from typing import Dict, List
+
+mapping_test_data: List[Dict] = []
 package_test_data = [
     {
         "url": "http://mirror.centos.org/centos/7/os/x86_64/Packages/",

--- a/test/test_data/unbound.py
+++ b/test/test_data/unbound.py
@@ -1,7 +1,9 @@
 # Copyright (C) 2022 Orange
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-mapping_test_data = []
+from typing import Dict, List
+
+mapping_test_data: List[Dict] = []
 package_test_data = [
     {
         "url": "http://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/aarch64/os/Packages/u/",


### PR DESCRIPTION
Moved self.tempdir up to the BaseExtractor class to clean up the mypy errors. fixes #2191

Added typing to test_data fixes #2131 
