### PR TITLE
fix: improve json-c checker patterns

### DIFF
--- a/cve_bin_tool/checkers/json_c.py
+++ b/cve_bin_tool/checkers/json_c.py
@@ -15,7 +15,8 @@ class JsonCChecker(Checker):
     CONTAINS_PATTERNS = []
     FILENAME_PATTERNS = []
     VERSION_PATTERNS = [
+        r"json-c-([0-9]+\.[0-9]+\.?[0-9]*)",
         r"JSONC_([0-9]+\.[0-9]+\.?[0-9]*)\r?\nGLIBC_",
-        r"([0-9]+\.[0-9]+\.?[0-9]*)[a-zA-Z0-9,% +\.\-\\\r\n]*json_tokener_error",
+        r"([0-9]+\.[0-9]+\.?[0-9]*)[a-zA-Z0-9,% +:\"\.\-\\\r\n]*json_tokener_error",
     ]
     VENDOR_PRODUCT = [("json-c_project", "json-c")]

--- a/test/test_data/json_c.py
+++ b/test/test_data/json_c.py
@@ -14,6 +14,7 @@ mapping_test_data = [
             "0.12.1\n\\u00%c00%c\n-Infinity\n%.17g\n.+-eE\n, json_tokener_error"
         ],
     },
+    {"product": "json-c", "version": "0.13.1", "version_strings": ["json-c-0.13.1"]},
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Current json-c checker doesn't work with some exotic json-c library

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>