### PR TITLE
fix: improve sqlite checker patterns

### DIFF
--- a/cve_bin_tool/checkers/sqlite.py
+++ b/cve_bin_tool/checkers/sqlite.py
@@ -75,7 +75,11 @@ class SqliteChecker(Checker):
         # at the same time
 
         for mapping in self.VERSION_MAP:
-            if mapping[1] in lines:
+            # Truncate last four characters as "If the source code has been edited
+            # in any way since it was last checked in, then the last four
+            # hexadecimal digits of the hash may be modified."
+            # https://www.sqlite.org/c3ref/c_source_id.html
+            if mapping[1][:-4] in lines:
                 return True
 
         # If that fails, find a signature that might indicate presence of sqlite
@@ -92,7 +96,11 @@ class SqliteChecker(Checker):
         version_info = super().get_version(lines, filename)
 
         for mapping in self.VERSION_MAP:
-            if mapping[1] in lines:
+            # Truncate last four characters as "If the source code has been edited
+            # in any way since it was last checked in, then the last four
+            # hexadecimal digits of the hash may be modified."
+            # https://www.sqlite.org/c3ref/c_source_id.html
+            if mapping[1][:-4] in lines:
                 # overwrite version with the version found by sha mapping
                 version_info["version"] = mapping[0]
 

--- a/test/test_data/sqlite.py
+++ b/test/test_data/sqlite.py
@@ -26,6 +26,14 @@ mapping_test_data = [
             "ESCAPE expression must be a single character",
         ],
     },
+    {
+        "product": "sqlite",
+        "version": "3.12.2",
+        "version_strings": [
+            "2016-04-18 17:30:31 92dc59fd5ad66f646666042eb04195e3a61aalt2",
+            "ESCAPE expression must be a single character",
+        ],
+    },
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Current sqlite checker doesn't work with some exotic sqlite library because sha256 is slighty different of what is returned by https://www.sqlite.org/changes.html

Expected value:

`2018-04-10 17:39:29 4bb2294022060e61de7da5c227a69ccd846ba330e31626ebcd59a94efd148b3b`

Value in library:

`2018-04-10 17:39:29 4bb2294022060e61de7da5c227a69ccd846ba330e31626ebcd59a94efd14alt2`

To fix this issue, truncate last four characters which are not guaranteed to be constant as specified in
https://www.sqlite.org/c3ref/c_source_id.html:

> If the source code has been edited in any way since it was last checked in, then the last four hexadecimal digits of the hash may be modified.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>