### PR TITLE
docs: warn users that nvd may block them if they are not using an api_key

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,14 @@ The following data sources are used to get CVE data to find CVEs for a package:
 ### [National Vulnerability Database](https://nvd.nist.gov/) (NVD)
 This data source consists of majority of the CVE entries and is essential to provide vendor data for other data sources such as OSV, therefore downloading CVE data from it cannot be disabled, `--disable-data-source "NVD"` only disables CVEs from displaying in output.
 
+>**Note** : If you have problems downloading the initial data , it may be due to the NVD's current rate limiting scheme which block users entirely if they aren't using an API key.  
+>
+>NVD requires users to create and use an NVD_API_KEY to use their API. To setup an API_KEY ,please visit [Request an API Key](https://nvd.nist.gov/developers/request-an-api-key) .
+>
+>If you don't want to use the NVD API, you can also download their json files without setting up a key. Please note that this method is slower for getting updates but is more ideal if you just want to try out the `cve-bin-tool` for the first time. 
+> 
+>To use the json method, use the flag [`-n json`](https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-n-jsonapi---nvd-jsonapi) .
+
 ### [Open Source Vulnerability Database](https://osv.dev/) (OSV)
 This data source is based on the OSV schema from google, and consists of CVEs from different ecosystems that might not be covered by NVD.
 NVD is given priority if there are duplicate CVEs as some CVEs from OSV may not contain CVSS scores.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -328,6 +328,8 @@ CVE Binary tool by default queries the NVD database once per day and caches the 
 
 To get an API key, users should visit the [NVD API key request page](https://nvd.nist.gov/developers/request-an-api-key).
 
+>Note : It is recommended to use this method as  NVD's current rate limiting scheme may block the users entirely if they aren't using an API key.
+
 Related: [NVD API key announcement](https://nvd.nist.gov/general/news/API-Key-Announcement)
 
 ### -d {NVD,OSV,GAD} [{NVD,OSV,GAD} ...], --disable-data-source {NVD,OSV,GAD} [{NVD,OSV,GAD} ...]


### PR DESCRIPTION
Closes issue #2190 

Added sections in README.md and MANUAL.md regarding how NVD's current rate limiting scheme can block them and to setup an api_key to avoid it.