### PR TITLE
refactor: fix mypy errors in checkers q-t

### DIFF
--- a/cve_bin_tool/checkers/qt.py
+++ b/cve_bin_tool/checkers/qt.py
@@ -9,11 +9,13 @@ https://www.cvedetails.com/product/10758/QT-QT.html?vendor_id=6363
 https://www.cvedetails.com/product/24410/Digia-QT.html?vendor_id=12593
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class QtChecker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS = [
         r"libqt-mt.so",
         r"libQtTest.so",

--- a/cve_bin_tool/checkers/quagga.py
+++ b/cve_bin_tool/checkers/quagga.py
@@ -8,11 +8,13 @@ CVE checker for quagga
 https://www.cvedetails.com/product/20622/Quagga-Quagga.html?vendor_id=1853
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class QuaggaChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"Quagga \(version ([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("quagga", "quagga")]

--- a/cve_bin_tool/checkers/rdesktop.py
+++ b/cve_bin_tool/checkers/rdesktop.py
@@ -8,12 +8,14 @@ CVE checker for rdesktop
 https://www.cvedetails.com/product/13976/Rdesktop-Rdesktop.html?vendor_id=8065
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class RdesktopChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
         r"rdesktop: A Remote Desktop Protocol client.\r?\nVersion ([0-9]+\.[0-9]+\.[0-9]+)"
     ]

--- a/cve_bin_tool/checkers/rsync.py
+++ b/cve_bin_tool/checkers/rsync.py
@@ -12,12 +12,14 @@ https://www.cvedetails.com/product/11903/Rsync-Rsync.html?vendor_id=7059
 https://www.cvedetails.com/product/13782/Samba-Rsync.html?vendor_id=102
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class RsyncChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"([0-9]+\.[0-9]+\.[0-9]+)\r?\nrsync"]
     VENDOR_PRODUCT = [
         ("andrew_tridgell", "rsync"),

--- a/cve_bin_tool/checkers/rsyslog.py
+++ b/cve_bin_tool/checkers/rsyslog.py
@@ -6,11 +6,13 @@
 CVE checker for rsyslog
 https://www.cvedetails.com/product/15708/Rsyslog-Rsyslog.html?vendor_id=3361
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class RsyslogChecker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS = [r"rsyslogd"]
     VERSION_PATTERNS = [r"rsyslogd? ([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("rsyslog", "rsyslog")]

--- a/cve_bin_tool/checkers/rtl_433.py
+++ b/cve_bin_tool/checkers/rtl_433.py
@@ -8,11 +8,13 @@ CVE checker for rtl_433
 https://www.cvedetails.com/product/110856/Rtl-433-Project-Rtl-433.html?vendor_id=26553
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class Rtl433Checker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"rtl[-_]433-([0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("rtl_433_project", "rtl_433")]

--- a/cve_bin_tool/checkers/samba.py
+++ b/cve_bin_tool/checkers/samba.py
@@ -12,11 +12,13 @@ lists "winbindd" and "nmbd" as necessary to configure in startup along with smbd
 But these files do not have the strings which match the signatures in regex.
 That is why they have not been added in FILENAME_PATTERNS.
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SambaChecker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS = [
         r"smbd",
         r"smbtree",

--- a/cve_bin_tool/checkers/sane_backends.py
+++ b/cve_bin_tool/checkers/sane_backends.py
@@ -8,11 +8,13 @@ CVE checker for sane-backends
 https://www.cvedetails.com/vendor/16236/?q=Sane-backends+Project
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SaneBackendsChecker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS = [r"sane-find-scanner"]
     VERSION_PATTERNS = [r"sane-backends ([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("sane-backends_project", "sane-backends")]

--- a/cve_bin_tool/checkers/shadowsocks_libev.py
+++ b/cve_bin_tool/checkers/shadowsocks_libev.py
@@ -8,12 +8,14 @@ CVE checker for shadowsocks-libev
 https://www.cvedetails.com/product/41244/Shadowsocks-Shadowsocks-libev.html?vendor_id=17167
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class ShadowsocksLibevChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
         r"([0-9]+\.[0-9]+\.[0-9]+)\r?\nshadowsocks-libev",
         r"([0-9]+\.[0-9]+\.[0-9]+)\r?\n  usage\:\r?\n    ss-",

--- a/cve_bin_tool/checkers/snort.py
+++ b/cve_bin_tool/checkers/snort.py
@@ -11,12 +11,14 @@ https://www.cvedetails.com/product/2893/Sourcefire-Snort.html?vendor_id=1674
 
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SnortChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
         r"snort-([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)",
         r"Snort Version ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)",

--- a/cve_bin_tool/checkers/sofia_sip.py
+++ b/cve_bin_tool/checkers/sofia_sip.py
@@ -8,11 +8,13 @@ CVE checker for sofia-sip
 https://www.cvedetails.com/product/116029/Signalwire-Sofia-sip.html?vendor_id=25697
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SofiaSipChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"sofia-sip-([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("signalwire", "sofia-sip")]

--- a/cve_bin_tool/checkers/spice.py
+++ b/cve_bin_tool/checkers/spice.py
@@ -8,11 +8,13 @@ CVE checker for spice
 https://www.cvedetails.com/product/25789/Spice-Project-Spice.html?vendor_id=12813
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SpiceChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"SPICE_SERVER_([0-9]+\.[0-9]+\.[0-9]+)\r?\nGLIBC"]
     VENDOR_PRODUCT = [("spice_project", "spice")]

--- a/cve_bin_tool/checkers/squashfs.py
+++ b/cve_bin_tool/checkers/squashfs.py
@@ -9,12 +9,14 @@ https://www.cvedetails.com/product/37102/Squashfs-Project-Squashfs.html?vendor_i
 https://www.cvedetails.com/product/99849/Squashfs-tools-Project-Squashfs-tools.html?vendor_id=25307
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SquashfsChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"squashfs version ([0-9]+\.[0-9]+\.?[0-9]*)"]
     VENDOR_PRODUCT = [
         ("squashfs_project", "squashfs"),

--- a/cve_bin_tool/checkers/squid.py
+++ b/cve_bin_tool/checkers/squid.py
@@ -9,11 +9,13 @@ https://www.cvedetails.com/product/1814/Squid-Squid.html?vendor_id=823
 https://www.cvedetails.com/product/17766/Squid-cache-Squid.html?vendor_id=9950
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SquidChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"squid/([0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("squid", "squid"), ("squid-cache", "squid")]

--- a/cve_bin_tool/checkers/strongswan.py
+++ b/cve_bin_tool/checkers/strongswan.py
@@ -8,11 +8,13 @@ CVE checker for strongswan
 https://www.cvedetails.com/product/3992/Strongswan-Strongswan.html?vendor_id=2278
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class StrongswanChecker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS = [r"libcharon.so"]
     VERSION_PATTERNS = [r"strongSwan ([0-9]+\.[0-9]+\.[0-9])"]
     VENDOR_PRODUCT = [("strongswan", "strongswan")]

--- a/cve_bin_tool/checkers/stunnel.py
+++ b/cve_bin_tool/checkers/stunnel.py
@@ -8,11 +8,13 @@ CVE checker for stunnel
 https://www.cvedetails.com/product/1122/Stunnel-Stunnel.html?vendor_id=659
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class StunnelChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"stunnel ([0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("stunnel", "stunnel")]

--- a/cve_bin_tool/checkers/suricata.py
+++ b/cve_bin_tool/checkers/suricata.py
@@ -10,12 +10,14 @@ https://www.cvedetails.com/product/45965/Suricata-ids-Suricata.html?vendor_id=17
 https://www.cvedetails.com/product/57121/Oisf-Suricata.html?vendor_id=17892
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SuricataChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
         r"suricata\-([0-9]+\.[0-9]+\.[0-9]+)",
         r"([0-9]+\.[0-9]+\.[0-9]+) RELEASE\r?\nClosing Suricata",

--- a/cve_bin_tool/checkers/sylpheed.py
+++ b/cve_bin_tool/checkers/sylpheed.py
@@ -9,11 +9,13 @@ https://www.cvedetails.com/product/3149/Sylpheed-Sylpheed.html?vendor_id=1716
 https://www.cvedetails.com/product/42176/Sylpheed-Project-Sylpheed.html?vendor_id=17369
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class SylpheedChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"Sylpheed ([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("sylpheed", "sylpheed"), ("sylpheed_project", "sylpheed")]

--- a/cve_bin_tool/checkers/tcpdump.py
+++ b/cve_bin_tool/checkers/tcpdump.py
@@ -8,11 +8,13 @@ CVE checker for tcpdump
 https://www.cvedetails.com/product/10494/Tcpdump-Tcpdump.html?vendor_id=6197
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class TcpdumpChecker(Checker):
-    CONTAINS_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS = [r"tcpdump"]
     # lookup_{emem,protoid} are static functions provided by tcpdump in addrtoname.c
     VERSION_PATTERNS = [

--- a/cve_bin_tool/checkers/thrift.py
+++ b/cve_bin_tool/checkers/thrift.py
@@ -8,12 +8,14 @@ CVE checker for thrift
 https://www.cvedetails.com/product/38295/Apache-Thrift.html?vendor_id=45
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class ThriftChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
         r"Thrift Compiler \(\r?\n([0-9]+\.[0-9]+\.[0-9]+)",
         r"thrift-([0-9]+\.[0-9]+\.[0-9]+)",

--- a/cve_bin_tool/checkers/thttpd.py
+++ b/cve_bin_tool/checkers/thttpd.py
@@ -11,11 +11,13 @@ https://www.cvedetails.com/product/18644/Acme-Thttpd.html?vendor_id=10442
 Note: thttpd is not provided by debian or openWRT. Tests provided are fedora-only.
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class ThttpdChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"thttpd/([0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("acme_labs", "thttpd"), ("acme", "thttpd")]

--- a/cve_bin_tool/checkers/timescaledb.py
+++ b/cve_bin_tool/checkers/timescaledb.py
@@ -10,11 +10,13 @@ https://www.cvedetails.com/product/111330/Timescale-Timescaledb.html?vendor_id=2
 Note: timescaledb is not provided by debian or openWRT. Tests provided are fedora-only.
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class TimescaledbChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"timescaledb-([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("timescale", "timescaledb")]

--- a/cve_bin_tool/checkers/tinyproxy.py
+++ b/cve_bin_tool/checkers/tinyproxy.py
@@ -10,12 +10,14 @@ https://www.cvedetails.com/product/20722/Banu-Tinyproxy.html?vendor_id=11393
 https://www.cvedetails.com/product/39089/Tinyproxy-Project-Tinyproxy.html?vendor_id=16766
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class TinyproxyChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = ["tinyproxy\\/([0-9]+\\.[0-9]+\\.[0-9]+)"]
     VENDOR_PRODUCT = [
         ("banu", "tinyproxy"),

--- a/cve_bin_tool/checkers/tor.py
+++ b/cve_bin_tool/checkers/tor.py
@@ -10,12 +10,14 @@ https://www.cvedetails.com/product/39020/Debian-TOR.html?vendor_id=23
 https://www.cvedetails.com/product/67243/Tor-Project-TOR.html?vendor_id=21651
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class TorChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"Tor ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [
         ("debian", "tor"),

--- a/cve_bin_tool/checkers/tpm2_tss.py
+++ b/cve_bin_tool/checkers/tpm2_tss.py
@@ -7,11 +7,13 @@ CVE checker for tpm2_software_stack
 https://www.cvedetails.com/product/89648/Tpm2-Software-Stack-Project-Tpm2-Software-Stack.html?vendor_id=23886
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class Tpm2TssChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"tpm2-tss ([0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("tpm2_software_stack_project", "tpm2_software_stack")]

--- a/cve_bin_tool/checkers/transmission.py
+++ b/cve_bin_tool/checkers/transmission.py
@@ -8,11 +8,13 @@ CVE checker for transmission
 https://www.cvedetails.com/product/17422/Transmissionbt-Transmission.html?vendor_id=9749
 
 """
+from __future__ import annotations
+
 from cve_bin_tool.checkers import Checker
 
 
 class TransmissionChecker(Checker):
-    CONTAINS_PATTERNS = []
-    FILENAME_PATTERNS = []
+    CONTAINS_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"Transmission ([0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [("transmissionbt", "transmission")]


### PR DESCRIPTION
Fixes #2282

I've done `from __future__ import annotations` and used `list` instead of doing `from typing import List` and using it. This way when we drop Python 3.8 we can just drop the import and leave type hints untouched. But I can switch it to `typing` if you prefer.