### PR TITLE
refactor: type hints helper script

### DIFF
--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -4,6 +4,7 @@
 """ CVE Checkers """
 import collections
 import re
+from typing import Optional
 
 from cve_bin_tool.error_handler import InvalidCheckerError
 from cve_bin_tool.util import regex_find
@@ -284,10 +285,10 @@ class CheckerMetaClass(type):
 
 
 class Checker(metaclass=CheckerMetaClass):
-    CONTAINS_PATTERNS: list = []
-    VERSION_PATTERNS: list = []
-    FILENAME_PATTERNS: list = []
-    VENDOR_PRODUCT: list = []
+    CONTAINS_PATTERNS: list[str] = []
+    VERSION_PATTERNS: list[str] = []
+    FILENAME_PATTERNS: list[str] = []
+    VENDOR_PRODUCT: Optional[list[tuple[str, str]]] = []
 
     def guess_contains(self, lines):
         if any(pattern.search(lines) for pattern in self.CONTAINS_PATTERNS):

--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """ CVE Checkers """
+from __future__ import annotations
+
 import collections
 import re
-from typing import Optional
 
 from cve_bin_tool.error_handler import InvalidCheckerError
 from cve_bin_tool.util import regex_find
@@ -288,7 +289,7 @@ class Checker(metaclass=CheckerMetaClass):
     CONTAINS_PATTERNS: list[str] = []
     VERSION_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
-    VENDOR_PRODUCT: Optional[list[tuple[str, str]]] = []
+    VENDOR_PRODUCT: list[tuple[str, str]] = []
 
     def guess_contains(self, lines):
         if any(pattern.search(lines) for pattern in self.CONTAINS_PATTERNS):

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -346,7 +346,7 @@ class HelperScript:
         )
 
         # output: long human readable strings
-        print("\tCONTAINS_PATTERNS = [")
+        print("\tCONTAINS_PATTERNS: list[str] = [")
         for common_strings in sorted(self.contains_patterns):
             if ".debug" in common_strings:
                 rprint(
@@ -368,7 +368,7 @@ class HelperScript:
         """
 
         # output: filenames, that we search for binary strings
-        print("\tFILENAME_PATTERNS = [")
+        print("\tFILENAME_PATTERNS: list[str] = [")
         for filename in self.filename_pattern:
             if self.product_name == filename:
                 rprint(
@@ -386,13 +386,13 @@ class HelperScript:
         print("\t]")
 
         # output: version-strings
-        print("\tVERSION_PATTERNS = [")
+        print("\tVERSION_PATTERNS: list[str] = [")
         for version_string in self.version_pattern:
             rprint(f'\t\t[green]r"{version_string}"[/],')
         print("\t]")
 
         # output: vendor-product pair
-        print("\tVENDOR_PRODUCT = ", end="")
+        print("\tVENDOR_PRODUCT: list[tuple[str, str]] | None = ", end="")
         rprint(self.vendor_product)
 
         self.CONSOLE.rule()

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -53,7 +53,7 @@ class HelperScript:
         self.contains_patterns: list[str] = []
         self.filename_pattern: list[str] = []
         self.version_pattern: list[str] = []
-        self.vendor_product: list[tuple[str, str]] | None = []
+        self.vendor_product: list[tuple[str, str]] = []
 
         self.multiline_pattern: bool = True
 
@@ -251,7 +251,7 @@ class HelperScript:
             with ErrorHandler(mode=ErrorMode.NoTrace, logger=LOGGER):
                 raise UnknownArchiveType(filename)
 
-    def find_vendor_product(self) -> list[tuple[str, str]] | None:
+    def find_vendor_product(self) -> list[tuple[str, str]]:
         """find vendor-product pairs from database"""
 
         LOGGER.debug(
@@ -260,7 +260,7 @@ class HelperScript:
 
         CVEDB.db_open(self)  # type: ignore
         if self.connection is None:
-            return None
+            return []
         cursor = self.connection.cursor()
 
         # finding out all distinct (vendor, product) pairs with the help of product_name
@@ -269,7 +269,7 @@ class HelperScript:
             WHERE product=(:product);
         """
         if cursor is None:
-            return None
+            return []
 
         cursor.execute(query, {"product": self.product_name})
         data = cursor.fetchall()
@@ -338,7 +338,7 @@ class HelperScript:
 
                 <provide reference links here>
                 \"\"\"[/]
-                [magenta]from[/] typing [magenta]import[/] Optional
+                [magenta]from[/] __future__ [magenta]import[/] annotations
 
                 [magenta]from[/] cve_bin_tool.checkers [magenta]import[/] Checker
 
@@ -394,7 +394,7 @@ class HelperScript:
         print("\t]")
 
         # output: vendor-product pair
-        print("\tVENDOR_PRODUCT: Optional[list[tuple[str, str]]] = ", end="")
+        print("\tVENDOR_PRODUCT: list[tuple[str, str] = ", end="")
         rprint(self.vendor_product)
 
         self.CONSOLE.rule()

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -338,6 +338,8 @@ class HelperScript:
 
                 <provide reference links here>
                 \"\"\"[/]
+                [magenta]from[/] typing [magenta]import[/] Optional
+
                 [magenta]from[/] cve_bin_tool.checkers [magenta]import[/] Checker
 
 
@@ -392,7 +394,7 @@ class HelperScript:
         print("\t]")
 
         # output: vendor-product pair
-        print("\tVENDOR_PRODUCT: list[tuple[str, str]] | None = ", end="")
+        print("\tVENDOR_PRODUCT: Optional[list[tuple[str, str]]] = ", end="")
         rprint(self.vendor_product)
 
         self.CONSOLE.rule()


### PR DESCRIPTION
Closes #2127

I commented on this in the issue but to add the typing to `helper_script.py` I had to change the typing of the base `Checker` class.  I realize this may have a larger impact so look forward to any feedback.  Tests all passed so I think it's okay. 

Also, I used `Optional` in the typing instead of `|` so there's an extra import in the output of `helper_script.py`.

Note that I still get two exceptions in my pytest run (python 3.9):

```
FAILED test/test_extractor.py::TestExtractFileRpm::test_bad_files - struct.error: unpack requires a buffer of 96 bytes
FAILED test/test_extractor.py::TestExtractFileRpmWithZstd::test_bad_files - struct.error: unpack requires a buffer of 96 bytes
```

I was getting those exceptions prior to working on the issue though.
