### PR TITLE
feat: explicit option to load triage file

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ Usage:
       directory             directory to scan
       -i INPUT_FILE, --input-file INPUT_FILE
                             provide input filename
+      --triage-input-file TRIAGE_INPUT_FILE
+                            provide input filename for triage data
       -C CONFIG, --config CONFIG
                             provide config file
       -L PACKAGE_LIST, --package-list PACKAGE_LIST

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -147,17 +147,17 @@ def main(argv=None):
         "directory", help="directory to scan", nargs="?", default=""
     )
     input_group.add_argument(
-        "--triage-input-file",
-        action="store",
-        default="",
-        help="provide input filename for triage data",
-    )
-    input_group.add_argument(
         "-i",
         "--input-file",
         action="store",
         default="",
         help="provide input filename",
+    )
+    input_group.add_argument(
+        "--triage-input-file",
+        action="store",
+        default="",
+        help="provide input filename for triage data",
     )
     input_group.add_argument(
         "-C", "--config", action="store", default="", help="provide config file"

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -147,6 +147,12 @@ def main(argv=None):
         "directory", help="directory to scan", nargs="?", default=""
     )
     input_group.add_argument(
+        "--triage-input-file",
+        action="store",
+        default="",
+        help="provide input filename for triage data",
+    )
+    input_group.add_argument(
         "-i",
         "--input-file",
         action="store",
@@ -701,6 +707,18 @@ def main(argv=None):
                 args["package_list"], error_mode=error_mode
             )
             parsed_data = package_list.parse_list()
+            for product_info, triage_data in parsed_data.items():
+                LOGGER.debug(f"{product_info}, {triage_data}")
+                cve_scanner.get_cves(product_info, triage_data)
+
+        if args["triage_input_file"]:
+            input_engine = InputEngine(
+                args["triage_input_file"],
+                logger=LOGGER,
+                error_mode=error_mode,
+                filetype="vex",
+            )
+            parsed_data = input_engine.parse_input()
             for product_info, triage_data in parsed_data.items():
                 LOGGER.debug(f"{product_info}, {triage_data}")
                 cve_scanner.get_cves(product_info, triage_data)

--- a/cve_bin_tool/input_engine.py
+++ b/cve_bin_tool/input_engine.py
@@ -117,7 +117,10 @@ class InputEngine:
                                 product
                             )
                             if vendor_package_pair != []:
-                                vendor = vendor_package_pair[0]["vendor"]
+                                # FIXME https://github.com/intel/cve-bin-tool/issues/2320
+                                vendor = vendor_package_pair[
+                                    len(vendor_package_pair) - 1
+                                ]["vendor"]
                         if version is not None and self.validate_product(product):
                             product_info = ProductInfo(
                                 vendor.strip(), product.strip(), version.strip()

--- a/cve_bin_tool/input_engine.py
+++ b/cve_bin_tool/input_engine.py
@@ -29,11 +29,16 @@ class InputEngine:
     parsed_data: DefaultDict[ProductInfo, TriageData]
 
     def __init__(
-        self, filename: str, logger: Logger = None, error_mode=ErrorMode.TruncTrace
+        self,
+        filename: str,
+        logger: Logger = None,
+        error_mode=ErrorMode.TruncTrace,
+        filetype="autodetect",
     ):
         self.filename = str(Path(filename).resolve())
         self.logger = logger or LOGGER.getChild(self.__class__.__name__)
         self.error_mode = error_mode
+        self.filetype = filetype
         self.parsed_data = defaultdict(dict)
         # Connect to the database
         self.cvedb = CVEDB(version_check=False)
@@ -44,10 +49,10 @@ class InputEngine:
                 raise FileNotFoundError(self.filename)
         if self.filename.endswith(".csv"):
             self.input_csv()
+        elif self.filename.endswith(".vex") or self.filetype == "vex":
+            self.input_vex()
         elif self.filename.endswith(".json"):
             self.input_json()
-        elif self.filename.endswith(".vex"):
-            self.input_vex()
         return self.parsed_data
 
     def input_csv(self) -> None:

--- a/test/csv/test_triage_input.csv
+++ b/test/csv/test_triage_input.csv
@@ -1,0 +1,10 @@
+vendor,product,version
+plot,plotly,5.10.0
+pocoo,jinja2,3.1.2
+aiohttp_project,aiohttp,3.8.1
+pyyaml,pyyaml,6.0
+python,requests,2.28.1
+python,urllib3,1.26.12
+skontar,cvss,2.5
+getbootstrap,bootstrap,5.2.0
+plotly,plotly.js,2.13.2

--- a/test/test_input_engine.py
+++ b/test/test_input_engine.py
@@ -64,7 +64,7 @@ class TestInputEngine:
         },
     }
     VEX_TRIAGE_DATA = {
-        ProductInfo("d.r.commander", "libjpeg-turbo", "2.0.1"): {
+        ProductInfo("libjpeg-turbo", "libjpeg-turbo", "2.0.1"): {
             "CVE-2018-19664": {
                 "comments": "High priority need to resolve fast",
                 "remarks": Remarks.Confirmed,
@@ -72,7 +72,7 @@ class TestInputEngine:
             },
             "paths": {""},
         },
-        ProductInfo("gnu", "glibc", "2.33"): {
+        ProductInfo("gentoo", "glibc", "2.33"): {
             "CVE-2021-1234": {
                 "comments": "",
                 "remarks": Remarks.Unexplored,

--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -136,7 +136,7 @@ def test_requirements():
             "cve_bin_tool.cli",
             "--input-file",
             SCAN_CSV,
-            "--merge",
+            "--triage-input-file",
             TRIAGE_JSON,
             "--format",
             "json",

--- a/test/test_triage.py
+++ b/test/test_triage.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2022 Arnout Engelen
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+import subprocess
+import tempfile
+from pathlib import Path
+
+TEMP_DIR = Path(tempfile.mkdtemp(prefix="requirements_scan-"))
+TEST_DIR = Path(__file__).parent.resolve()
+VEX_PATH = TEST_DIR / "vex"
+CSV_PATH = TEST_DIR / "csv"
+OUTPUT_JSON = str(TEMP_DIR / "test_triage_output.json")  # the output is a temp file
+
+
+def test_triage():
+    INPUT_CSV = str(CSV_PATH / "test_triage_input.csv")
+    TRIAGE_VEX = str(VEX_PATH / "test_triage_triage_input.vex")
+    subprocess.run(
+        [
+            "python",
+            "-m",
+            "cve_bin_tool.cli",
+            "--input-file",
+            INPUT_CSV,
+            "--triage-input-file",
+            TRIAGE_VEX,
+            "--format",
+            "json",
+            "--output-file",
+            OUTPUT_JSON,
+        ]
+    )
+
+    with open(OUTPUT_JSON) as f:
+        output_json = json.load(f)
+        assert len(output_json) == 2
+
+        # the triage file specifies the plotly error is mitigated:
+        assert output_json[0]["product"] == "plotly.js"
+        assert output_json[0]["remarks"] == "Mitigated"
+
+        # the triage file does not mention anything about aiohttp,
+        # so that problem still needs to be reported as Unexplored:
+        assert output_json[1]["product"] == "aiohttp"
+        assert output_json[1]["remarks"] == "Unexplored"

--- a/test/vex/test_triage_triage_input.vex
+++ b/test/vex/test_triage_triage_input.vex
@@ -1,0 +1,44 @@
+{
+   "bomFormat": "CycloneDX",
+   "specVersion": "1.4",
+   "version": 1,
+   "vulnerabilities": [
+      {
+         "id": "GMS-2016-69",
+         "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/GMS-2016-69"
+         },
+         "ratings": [
+            {
+               "source": {
+                  "name": "NVD",
+                  "url": "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?name=GMS-2016-69&vector=unknown&version=2.0"
+               },
+               "score": "unknown",
+               "severity": "unknown",
+               "method": "CVSSvunknown",
+               "vector": "unknown"
+            }
+         ],
+         "cwes": [],
+         "description": "If an attacker can trick an unsuspecting user into viewing a specially crafted plot on a site that uses plotly.js, then the attacker could potentially retrieve authentication tokens and perform actions on behalf of the user.",
+         "recommendation": "",
+         "advisories": [],
+         "created": "NOT_KNOWN",
+         "published": "NOT_KNOWN",
+         "updated": "NOT_KNOWN",
+         "analysis": {
+            "state": "not_affected",
+            "response": [ "code_not_reachable" ],
+            "justification": "",
+            "detail": ""
+         },
+         "affects": [
+            {
+               "ref": "urn:cdx:NOTKNOWN/1#plotly.js-2.13.2"
+            }
+         ]
+      }
+   ]
+}

--- a/triage.json
+++ b/triage.json
@@ -1,25 +1,81 @@
 {
-    "metadata": {
-        "timestamp": "2022-07-05.16-08-33",
-        "tag": "",
-        "scanned_dir": "",
-        "products_with_cve": 1,
-        "products_without_cve": 9,
-        "total_files": 0
-    },
-    "report": [
-        {
-            "vendor": "aiohttp_project",
-            "product": "aiohttp",
-            "version": "3.8.1",
-            "cve_number": "CVE-2022-33124",
-            "severity": "MEDIUM",
-            "score": "5.5",
-            "cvss_version": "3",
-            "cvss_vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
-            "paths": "",
-            "remarks": "Ignored",
-            "comments": "See https://github.com/intel/cve-bin-tool/issues/1741"
-        }
-    ]
+   "bomFormat": "CycloneDX",
+   "specVersion": "1.4",
+   "version": 1,
+   "vulnerabilities": [
+      {
+         "id": "CVE-2022-33124",
+         "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/CVE-2022-33124"
+         },
+         "ratings": [
+            {
+               "source": {
+                  "name": "NVD",
+                  "url": "https://nvd.nist.gov/vuln-metrics/cvss/v3-calculator?name=CVE-2022-33124&vector=CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H&version=3.1"
+               },
+               "score": "5.5",
+               "severity": "MEDIUM",
+               "method": "CVSSv3",
+               "vector": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+            }
+         ],
+         "cwes": [],
+         "description": "** DISPUTED ** AIOHTTP 3.8.1 can report a \"ValueError: Invalid IPv6 URL\" outcome, which can lead to a Denial of Service (DoS). NOTE: multiple third parties dispute this issue because there is no example of a context in which denial of service would occur, and many common contexts have exception handing in the calling application.",
+         "recommendation": "",
+         "advisories": [],
+         "created": "NOT_KNOWN",
+         "published": "NOT_KNOWN",
+         "updated": "NOT_KNOWN",
+         "analysis": {
+            "state": "not_affected",
+            "response": [ ],
+            "justification": "",
+            "detail": "See https://github.com/intel/cve-bin-tool/issues/1741"
+         },
+         "affects": [
+            {
+               "ref": "urn:cdx:NOTKNOWN/1#aiohttp-3.8.1"
+            }
+         ]
+      },
+      {
+         "id": "GMS-2016-69",
+         "source": {
+            "name": "NVD",
+            "url": "https://nvd.nist.gov/vuln/detail/GMS-2016-69"
+         },
+         "ratings": [
+            {
+               "source": {
+                  "name": "NVD",
+                  "url": "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?name=GMS-2016-69&vector=unknown&version=2.0"
+               },
+               "score": "unknown",
+               "severity": "unknown",
+               "method": "CVSSvunknown",
+               "vector": "unknown"
+            }
+         ],
+         "cwes": [],
+         "description": "If an attacker can trick an unsuspecting user into viewing a specially crafted plot on a site that uses plotly.js, then the attacker could potentially retrieve authentication tokens and perform actions on behalf of the user.",
+         "recommendation": "",
+         "advisories": [],
+         "created": "NOT_KNOWN",
+         "published": "NOT_KNOWN",
+         "updated": "NOT_KNOWN",
+         "analysis": {
+            "state": "not_affected",
+            "response": [ "code_not_reachable" ],
+            "justification": "",
+            "detail": ""
+         },
+         "affects": [
+            {
+               "ref": "urn:cdx:NOTKNOWN/1#plotly.js-2.13.2"
+            }
+         ]
+      }
+   ]
 }


### PR DESCRIPTION
As discussed in #2316, provide a way to load the (scanned) dependency data and the (manually enriched) triage data from separate files.

Another way to implement this might have been to allow multiple `--input-file` parameters, but  making an explicit separation between dependency input and triage input seems like a good idea, as we might want to handle those differently (and not rely on detecting them by looking at file extensions) in the future.

This implementation also assumes the triage data is in `vex` format and not in the internal `json` format. I think this makes sense since you might want to exchange triage data between different parties/tools, so having the `vex` format as a 'first-class citizen' rather than supporting `vex` and the internal format side-by-side seems more attractive.