### PR TITLE
fix: improve openssl checkers

### DIFF
--- a/cve_bin_tool/checkers/openssl.py
+++ b/cve_bin_tool/checkers/openssl.py
@@ -17,5 +17,5 @@ from cve_bin_tool.checkers import Checker
 class OpensslChecker(Checker):
     CONTAINS_PATTERNS = [r"part of OpenSSL", r"openssl.cnf", r"-DOPENSSL_"]
     FILENAME_PATTERNS = [r"libssl.so.", r"libcrypto.so"]
-    VERSION_PATTERNS = [r"OpenSSL ([0-9]+\.[0-9]+\.[0-9]+[a-z]*) "]
+    VERSION_PATTERNS = [r"(?:\n|of )OpenSSL ([0-9]+\.[0-9]+\.[0-9]+[a-z]*) "]
     VENDOR_PRODUCT = [("openssl", "openssl")]


### PR DESCRIPTION
Improve openssl checkers to avoid a false positive with curl binary raised because of this help text embedded in the binary:

```
       --tls13-ciphers <ciphersuite list>
              (TLS)  Specifies which cipher suites to use in the connection if
              it negotiates TLS 1.3. The list of ciphers suites  must  specify
              valid  ciphers.  Read up on TLS 1.3 cipher suite details on this
              URL:

               https://curl.se/docs/ssl-ciphers.html

              This option is currently used only when curl  is  built  to  use
              OpenSSL 1.1.1 or later. If you are using a different SSL backend
              you can try setting TLS 1.3 cipher suites by using the --ciphers
              option.
```

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>