### PR TITLE
fix: treat rating in VEX triage files as optional

### DIFF
--- a/cve_bin_tool/input_engine.py
+++ b/cve_bin_tool/input_engine.py
@@ -99,8 +99,10 @@ class InputEngine:
                     if analysis_status in analysis_state:
                         state = analysis_state[analysis_status]
                     comments = vulnerability["analysis"]["detail"]
-                    for rating in vulnerability["ratings"]:
-                        severity = rating["severity"]
+                    severity = None
+                    if "ratings" in vulnerability:
+                        for rating in vulnerability["ratings"]:
+                            severity = rating["severity"]
                     for affect in vulnerability["affects"]:
                         ref = affect["ref"]
                         version = None
@@ -128,8 +130,11 @@ class InputEngine:
                             self.parsed_data[product_info][id.strip() or "default"] = {
                                 "remarks": state,
                                 "comments": comments.strip(),
-                                "severity": severity.strip(),
                             }
+                            if severity:
+                                self.parsed_data[product_info][id.strip() or "default"][
+                                    "severity"
+                                ] = severity.strip()
                             self.parsed_data[product_info]["paths"] = {""}
 
     def parse_data(self, fields: Set[str], data: Iterable) -> None:

--- a/test/vex/test_triage_triage_input.vex
+++ b/test/vex/test_triage_triage_input.vex
@@ -9,18 +9,6 @@
             "name": "NVD",
             "url": "https://nvd.nist.gov/vuln/detail/GMS-2016-69"
          },
-         "ratings": [
-            {
-               "source": {
-                  "name": "NVD",
-                  "url": "https://nvd.nist.gov/vuln-metrics/cvss/v2-calculator?name=GMS-2016-69&vector=unknown&version=2.0"
-               },
-               "score": "unknown",
-               "severity": "unknown",
-               "method": "CVSSvunknown",
-               "vector": "unknown"
-            }
-         ],
          "cwes": [],
          "description": "If an attacker can trick an unsuspecting user into viewing a specially crafted plot on a site that uses plotly.js, then the attacker could potentially retrieve authentication tokens and perform actions on behalf of the user.",
          "recommendation": "",


### PR DESCRIPTION
consistent with the schema at https://github.com/CycloneDX/specification/blob/master/schema/bom-1.4.xsd#L1810

When the rating is provided, the severity is still taken into account.