### PR TITLE
fix: improve libjpeg checker patterns

### DIFF
--- a/cve_bin_tool/checkers/libjpeg.py
+++ b/cve_bin_tool/checkers/libjpeg.py
@@ -14,5 +14,5 @@ from cve_bin_tool.checkers import Checker
 class LibjpegChecker(Checker):
     CONTAINS_PATTERNS = []
     FILENAME_PATTERNS = []
-    VERSION_PATTERNS = [r"([0-9][a-z])  [a-zA-Z0-9-]+"]
+    VERSION_PATTERNS = [r"\n([0-9][a-z])  [a-zA-Z0-9-]+"]
     VENDOR_PRODUCT = [("ijg", "libjpeg")]


### PR DESCRIPTION
Current libjpeg checker will result in false positives, for example with the following line in `iwconfig`:

`%-8.16s  no wireless extensions.`

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>