### PR TITLE
fix: address potential None in db cursor

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -19,7 +19,7 @@ from rich.progress import track
 
 from cve_bin_tool.async_utils import run_coroutine
 from cve_bin_tool.data_sources import curl_source, gad_source, nvd_source, osv_source
-from cve_bin_tool.error_handler import ErrorMode
+from cve_bin_tool.error_handler import CVEDBError, ErrorMode
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.version import check_latest_version
 
@@ -160,6 +160,10 @@ class CVEDB:
             self.db_open()
         if self.connection is not None:
             cur = self.connection.cursor()
+        if cur is None:
+            LOGGER.error("Database cursor does not exist")
+            raise CVEDBError
+
         schema_check = "SELECT * FROM cve_severity WHERE 1=0"
         result = cur.execute(schema_check)
         schema_latest = False
@@ -189,6 +193,10 @@ class CVEDB:
         if self.connection is not None:
             cursor = self.connection.cursor()
         cve_entries_check = "SELECT data_source, COUNT(*) as number FROM cve_severity GROUP BY data_source ORDER BY number DESC"
+        if cursor is None:
+            # Something is up with the database, log and fail
+            LOGGER.error("Database cursor does not exist")
+            raise CVEDBError
         cursor.execute(cve_entries_check)
         # Find number of entries
         cve_entries = 0
@@ -255,6 +263,9 @@ class CVEDB:
         self.db_open()
         if self.connection is not None:
             cursor = self.connection.cursor()
+        if cursor is None:
+            LOGGER.error("Database cursor does not exist")
+            raise CVEDBError
 
         cve_data_create, version_range_create = self.table_schemas()
 
@@ -418,6 +429,9 @@ class CVEDB:
         self.db_open()
         if self.connection is not None:
             cursor = self.connection.cursor()
+        if cursor is None:
+            LOGGER.error("Database cursor does not exist")
+            raise CVEDBError
         vendor_package_pairs = []
         query = """
         SELECT DISTINCT vendor FROM cve_range

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -156,16 +156,9 @@ class CVEDB:
     def latest_schema(self, cursor: sqlite3.Cursor | None = None) -> bool:
         """Check database is using latest schema"""
         self.LOGGER.debug("Check database is using latest schema")
-        if not cursor:
-            self.db_open()
-        if self.connection is not None:
-            cur = self.connection.cursor()
-        if cur is None:
-            LOGGER.error("Database cursor does not exist")
-            raise CVEDBError
-
+        cursor = self.db_open_and_get_cursor()
         schema_check = "SELECT * FROM cve_severity WHERE 1=0"
-        result = cur.execute(schema_check)
+        result = cursor.execute(schema_check)
         schema_latest = False
 
         if not cursor:
@@ -189,14 +182,8 @@ class CVEDB:
 
     def check_cve_entries(self) -> bool:
         """Report if database has some CVE entries"""
-        self.db_open()
-        if self.connection is not None:
-            cursor = self.connection.cursor()
+        cursor = self.db_open_and_get_cursor()
         cve_entries_check = "SELECT data_source, COUNT(*) as number FROM cve_severity GROUP BY data_source ORDER BY number DESC"
-        if cursor is None:
-            # Something is up with the database, log and fail
-            LOGGER.error("Database cursor does not exist")
-            raise CVEDBError
         cursor.execute(cve_entries_check)
         # Find number of entries
         cve_entries = 0
@@ -260,15 +247,9 @@ class CVEDB:
 
     def init_database(self) -> None:
         """Initialize db tables used for storing cve/version data"""
-        self.db_open()
-        if self.connection is not None:
-            cursor = self.connection.cursor()
-        if cursor is None:
-            LOGGER.error("Database cursor does not exist")
-            raise CVEDBError
 
+        cursor = self.db_open_and_get_cursor()
         cve_data_create, version_range_create = self.table_schemas()
-
         index_range = "CREATE INDEX IF NOT EXISTS product_index ON cve_range (cve_number, vendor, product)"
         cursor.execute(cve_data_create)
         cursor.execute(version_range_create)
@@ -308,9 +289,7 @@ class CVEDB:
 
             severity_data, affected_data = cve_data
 
-            self.db_open()
-            if self.connection is not None:
-                cursor = self.connection.cursor()
+            cursor = self.db_open_and_get_cursor()
 
             if severity_data is not None and len(severity_data) > 0:
                 self.populate_severity(severity_data, cursor, data_source=source_name)
@@ -426,12 +405,7 @@ class CVEDB:
         """
         Fetches vendor from the database for packages that doesn't have vendor info for Package List Parser Utility and Universal Python package checker.
         """
-        self.db_open()
-        if self.connection is not None:
-            cursor = self.connection.cursor()
-        if cursor is None:
-            LOGGER.error("Database cursor does not exist")
-            raise CVEDBError
+        cursor = self.db_open_and_get_cursor()
         vendor_package_pairs = []
         query = """
         SELECT DISTINCT vendor FROM cve_range
@@ -479,11 +453,7 @@ class CVEDB:
         updated_affected = []
 
         severity_data, affected_data = cve_data
-
-        self.db_open()
-
-        cursor = self.connection.cursor()
-
+        cursor = self.db_open_and_get_cursor()
         create_index = "CREATE INDEX IF NOT EXISTS product_vendor_index ON cve_range (product, vendor)"
         drop_index = "DROP INDEX product_vendor_index"
 
@@ -529,9 +499,7 @@ class CVEDB:
 
         severity_data, affected_data = cve_data
 
-        self.db_open()
-
-        cursor = self.connection.cursor()
+        cursor = self.db_open_and_get_cursor()
 
         query = """
         SELECT cve_number, data_source FROM cve_severity
@@ -557,10 +525,18 @@ class CVEDB:
 
         return updated_severity, updated_affected
 
-    def db_open(self) -> None:
-        """Opens connection to sqlite database."""
+    def db_open_and_get_cursor(self) -> sqlite3.Cursor:
+        """Opens connection to sqlite database, returns cursor object."""
+
         if not self.connection:
             self.connection = sqlite3.connect(self.dbpath)
+        if self.connection is not None:
+            cursor = self.connection.cursor()
+        if cursor is None:
+            # if this happens somsething has gone horribly wrong
+            LOGGER.error("Database cursor does not exist")
+            raise CVEDBError
+        return cursor
 
     def db_close(self) -> None:
         """Closes connection to sqlite database."""
@@ -617,8 +593,7 @@ class CVEDB:
         get_exploits = """
         SELECT cve_number FROM cve_exploited
         """
-        self.db_open()
-        cursor = self.connection.cursor()
+        cursor = self.db_open_and_get_cursor()
         cursor.row_factory = lambda cursor, row: row[0]
         self.exploits_list = cursor.execute(get_exploits).fetchall()
         self.db_close()
@@ -639,8 +614,7 @@ class CVEDB:
             PRIMARY KEY(cve_number)
         )
         """
-        self.db_open()
-        cursor = self.connection.cursor()
+        cursor = self.db_open_and_get_cursor()
         cursor.execute(create_exploit_table)
         self.connection.commit()
         self.db_close()
@@ -654,8 +628,7 @@ class CVEDB:
         )
         VALUES (?,?,?)
         """
-        self.db_open()
-        cursor = self.connection.cursor()
+        cursor = self.db_open_and_get_cursor()
         cursor.executemany(insert_exploit, exploits)
         self.connection.commit()
         self.db_close()

--- a/cve_bin_tool/error_handler.py
+++ b/cve_bin_tool/error_handler.py
@@ -116,6 +116,10 @@ class UnknownConfigType(Exception):
     """Unknown configuration file type"""
 
 
+class CVEDBError(Exception):
+    """Something unrecoverable went wrong with our database connection"""
+
+
 class ErrorMode(Enum):
     Ignore = 0
     NoTrace = 1
@@ -204,4 +208,5 @@ ERROR_CODES = {
     NVDRateLimit: 35,
     InvalidIntermediateJsonError: 36,
     NVDServiceError: 37,
+    CVEDBError: 38,
 }

--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -258,10 +258,7 @@ class HelperScript:
             f"checking for product_name='{self.product_name}' and version_name='{self.version_number}' in the database"
         )
 
-        CVEDB.db_open(self)  # type: ignore
-        if self.connection is None:
-            return []
-        cursor = self.connection.cursor()
+        cursor = CVEDB.db_open_and_get_cursor(self)
 
         # finding out all distinct (vendor, product) pairs with the help of product_name
         query = """


### PR DESCRIPTION
Coverity scan raised a few issues about the case where the database cursor could be None.  I'm not convinced this happens in practice short of a catastrophic database failure, but I don't see any reason not to put checks in anyhow.  I feel like there's maybe more than just these few places where it could happen and I'm not sure why only these are flagged.