### PR TITLE
fix: pyupgrade fix for output_engine/console.py

### DIFF
--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -29,7 +29,7 @@ def output_console(*args: Any):
     ls_args.pop()
 
     if output_file:
-        with open(output_file, "wt", encoding="utf-8") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             console = Console(theme=cve_theme, file=f)
             ls_args.append(console)
             _output_console_nowrap(*ls_args)


### PR DESCRIPTION
The new version of pyupgrade merged in #2019 seems to have found one issue it wants resolved.