### PR TITLE
fix: strings -n 3 args passing

### DIFF
--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -29,7 +29,7 @@ def output_console(*args: Any):
     ls_args.pop()
 
     if output_file:
-        with open(output_file, "wt", encoding="utf-8") as f:
+        with open(output_file, "w", encoding="utf-8") as f:
             console = Console(theme=cve_theme, file=f)
             ls_args.append(console)
             _output_console_nowrap(*ls_args)

--- a/cve_bin_tool/strings.py
+++ b/cve_bin_tool/strings.py
@@ -47,7 +47,7 @@ def parse_strings(filename: str) -> str:
 
     if inpath("strings"):
         # use "strings" on system if available (for performance)
-        data = subprocess.check_output(["strings", "-n 3", filename])
+        data = subprocess.check_output(["strings", "-n", "3", filename])
         lines = data.decode("utf-8", errors="backslashreplace")
     else:
         # Otherwise, use python implementation


### PR DESCRIPTION
It was passed as `"-n 3"` instead of `"-n", "3"`.

Yielded the error:
```
CalledProcessError: Command '['strings', '-n 3', 'lib.so']' returned
non-zero exit status 1.

error: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strings: unknown flag: -n 3
Usage: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/strings [-] [-a] [-o] [-t format] [-number] [-n number] [[-arch <arch_flag>] ...] [--] [file ...]
```