### PR TITLE
refactor(html-test): rename `setup` & `teardown`

### DIFF
--- a/test/test_html.py
+++ b/test/test_html.py
@@ -11,11 +11,11 @@ from .pages.html_report import HTMLReport
 
 class TestOutputHTML:
     @pytest.fixture(autouse=True)
-    def setup(self, page: Page) -> None:
+    def setup_method(self, page: Page) -> None:
         self.html_report_page = HTMLReport(page)
         self.html_report_page.load()
 
-    def teardown(self) -> None:
+    def teardown_method(self) -> None:
         self.html_report_page.cleanup()
 
     def check_products_visible_hidden(


### PR DESCRIPTION
Rename `setup` & `teardown` to `setup_method` & `teardown_method`, as the latter is supported by pytest natively.
See https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose