### PR TITLE
ci: use `$GITHUB_OUTPUT` instead of `set-output`

### DIFF
--- a/.github/workflows/cve_scan.yml
+++ b/.github/workflows/cve_scan.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       - name: Get cached database
         uses: actions/cache@v3
         with:

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       - name: Get cached database
         uses: actions/cache@v3
         with:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       - name: Get cached database
         uses: actions/cache@v3
         with:
@@ -108,7 +108,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       - name: Get cached database
         uses: actions/cache@v3
         with:
@@ -191,7 +191,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(get-date -format "yyyyMMdd")"
+          echo "date=$(get-date -format "yyyyMMdd")" >> $GITHUB_OUTPUT
       - name: Get cached database
         uses: actions/cache@v3
         with:
@@ -267,7 +267,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(get-date -format "yyyyMMdd")"
+          echo "date=$(get-date -format "yyyyMMdd")" >> $GITHUB_OUTPUT
       - name: Get cached database
         uses: actions/cache@v3
         with:

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ~/.cache/cve-bin-tool
@@ -57,7 +57,7 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "::set-output name=date::$(get-date -format "yyyyMMdd")"
+          echo "date=$(get-date -format "yyyyMMdd")" >> $GITHUB_OUTPUT
       - uses: actions/cache@v3
         with:
           path: ~/.cache/cve-bin-tool

--- a/doc/how_to_guides/cve_scanner_gh_action.md
+++ b/doc/how_to_guides/cve_scanner_gh_action.md
@@ -25,7 +25,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
     #  Let's first download dependencies for this action.
       - uses: actions/checkout@v2

--- a/doc/how_to_guides/cve_scanner_gh_action.yml
+++ b/doc/how_to_guides/cve_scanner_gh_action.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
         shell: bash
     #  Let's first download dependencies for this action.
       - uses: actions/checkout@v2


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.