### PR TITLE
ci: skip analyzing things we can't fix in coverity

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -16,4 +16,4 @@ jobs:
         email: ${{ secrets.COVERITY_SCAN_EMAIL }}
         token: ${{ secrets.COVERITY_SCAN_TOKEN }}
         build_language: 'other'
-        command: '--no-command --fs-capture-search ./'
+        command: '--no-command --fs-capture-search ./ --fs-capture-search-exclude-regex /cov-analysis/.* --fs-capture-search-exclude-regex /cve_bin_tool/schemas.*'


### PR DESCRIPTION
Currently our Coverity scans do a file system capture on everything in the cve-bin-tool directory.  Unfortunately, that means coverity scans its own analysis (stored in cov-analysis) and also our 3rd party schemas, and it finds a lot of things in both of those.  I'm currently ignoring those in the web interface so we don't miss real, fixable issues, but this change would (hopefully, assuming I didn't make a typo) mean they don't get captured in the first place so they'll stop showing in our "defect density" going forwards.