### PR TITLE
fix: improve libjpeg checker patterns

### DIFF
--- a/cve_bin_tool/checkers/libjpeg.py
+++ b/cve_bin_tool/checkers/libjpeg.py
@@ -14,5 +14,5 @@ from cve_bin_tool.checkers import Checker
 class LibjpegChecker(Checker):
     CONTAINS_PATTERNS = []
     FILENAME_PATTERNS = []
-    VERSION_PATTERNS = [r"\n([0-9][a-z])  [a-zA-Z0-9-]+"]
+    VERSION_PATTERNS = [r"\n([0-9][a-z])  [0-9]+-[a-zA-Z]+-[0-9]+"]
     VENDOR_PRODUCT = [("ijg", "libjpeg")]


### PR DESCRIPTION
Current libjpeg checker raises the following false positive with the following extract of some proprietary binary:

`0c  c`

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>