### PR TITLE
fix: improve console notes

### DIFF
--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -177,20 +177,20 @@ def _output_console_nowrap(
                 break
 
         # Show table of vulnerable products mapped to filename paths
-        # As path names can be long, these maybe replaced with a note which
+        # As names can be long, these maybe replaced with a note which
         # is printed at end of table
 
-        def validate_path_length(path_name, path_type):
-            # If long pathname replace with a note
-            if len(path_name) > 45:
-                if [path_name, path_type] not in note_data:
-                    note_data.append([path_name, path_type])
+        def validate_cell_length(cell_name, cell_type):
+            # If long name replace with a note
+            if len(cell_name) > 30:
+                if [cell_name, cell_type] not in note_data:
+                    note_data.append([cell_name, cell_type])
                 return (
-                    path_type
-                    + str(note_data.index([path_name, path_type]))
+                    cell_type
+                    + str(note_data.index([cell_name, cell_type]))
                     + " (see below)"
                 )
-            return path_name
+            return cell_name
 
         i = 0
         note_data = []
@@ -207,11 +207,13 @@ def _output_console_nowrap(
         for cve_data in cve_by_paths[remarks]:
             path_root = format_path(cve_data["paths"])
             cells = [
-                Text.styled(cve_data["vendor"], color),
-                Text.styled(cve_data["product"], color),
+                Text.styled(validate_cell_length(cve_data["vendor"], "Vendor "), color),
+                Text.styled(
+                    validate_cell_length(cve_data["product"], "Product "), color
+                ),
                 Text.styled(cve_data["version"], color),
-                Text.styled(validate_path_length(path_root[0], "Root "), color),
-                Text.styled(validate_path_length(path_root[1], "Path "), color),
+                Text.styled(validate_cell_length(path_root[0], "Root "), color),
+                Text.styled(validate_cell_length(path_root[1], "Path "), color),
             ]
             table.add_row(*cells)
         # Print the table to the console


### PR DESCRIPTION
Reduce path length from 45 to 30 as 45 is too much and results in truncated path since the addition of radvd and pppd which have very long vendor and product names (i.e. `point-to-point_protocol_project:point-to-point_protocol` and `litech:router_advertisement_daemon`)

While at it, also add a note for vendor and product if they are too long

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>