### PR TITLE
fix: Set vendor to UNKNOWN if all else fails

### DIFF
--- a/cve_bin_tool/input_engine.py
+++ b/cve_bin_tool/input_engine.py
@@ -123,6 +123,8 @@ class InputEngine:
                                 vendor = vendor_package_pair[
                                     len(vendor_package_pair) - 1
                                 ]["vendor"]
+                            else:
+                                vendor = "UNKNOWN"
                         if version is not None and self.validate_product(product):
                             product_info = ProductInfo(
                                 vendor.strip(), product.strip(), version.strip()


### PR DESCRIPTION
Static analysis is complaining that there's a case where the vendor might not ever be found, and thus when we try to do vendor.strip() a few lines further down that it's going to fail.  I've marked the vendor as "UNKNOWN" the same way we mark versions so that this won't break.  Given that we're trying to actually report everything found in the future, I *think* this is probably the correct way to handle that fallthrough case, but I'm pinging @anthonyharrison to look at it and see if he knows of any way it's likely to cause weirdness.

We could equally set the vendor to "UNKNOWN" in the first case, not sure if that's better or more confusing.