### PR TITLE
fix: improve samba checker patterns

### DIFF
--- a/cve_bin_tool/checkers/samba.py
+++ b/cve_bin_tool/checkers/samba.py
@@ -32,5 +32,8 @@ class SambaChecker(Checker):
         r"smbcacls",
         r"sharesec",
     ]
-    VERSION_PATTERNS = [r"SAMBA_([0-9]+\.[0-9]+\.[0-9]+)"]
+    VERSION_PATTERNS = [
+        r"SAMBA_([0-9]+\.[0-9]+\.[0-9]+)",
+        r"samba/([0-9]+\.[0-9]+\.[0-9]+)",
+    ]
     VENDOR_PRODUCT = [("samba", "samba")]

--- a/test/test_data/samba.py
+++ b/test/test_data/samba.py
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 mapping_test_data = [
-    {"product": "samba", "version": "4.10.2", "version_strings": ["SAMBA_4.10.2"]}
+    {"product": "samba", "version": "4.10.2", "version_strings": ["SAMBA_4.10.2"]},
+    {"product": "samba", "version": "3.6.22", "version_strings": ["samba/3.6.22"]},
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Current samba checker doesn't work with samba3 binaries

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>