### PR TITLE
fix: Change extraction exceptions to logged warnings

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -102,10 +102,8 @@ class BaseExtractor:
             if not await aio_inpath("7z"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
                     # ExtractionToolNotFound
-                    self.logger.warning(f"No extraction tool found for {filename}")
-                    self.logger.warning(
-                        "rpm2cpio or 7z can be used to extract rpm files"
-                    )
+                    self.logger.error(f"No extraction tool found for {filename}")
+                    self.logger.error("rpm2cpio or 7z can be used to extract rpm files")
             else:
                 stdout, stderr, _ = await aio_run_command(["7z", "x", filename])
                 if stderr or not stdout:
@@ -151,8 +149,8 @@ class BaseExtractor:
                         return 1
                 else:
                     # ExtractionToolNotFound
-                    self.logger.warning(f"No extraction tool found for {filename}")
-                    self.logger.warning(
+                    self.logger.error(f"No extraction tool found for {filename}")
+                    self.logger.error(
                         "tar or 7zip-zstd is required to extract tar.zstd files"
                     )
         return e.exit_code
@@ -206,8 +204,8 @@ class BaseExtractor:
             if not await aio_inpath("ar"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
                     # ExtractionToolNotFound
-                    self.logger.warning(f"No extraction tool found for {filename}")
-                    self.logger.warning("'ar' is required to extract deb files")
+                    self.logger.error(f"No extraction tool found for {filename}")
+                    self.logger.error("'ar' is required to extract deb files")
             else:
                 stdout, stderr, _ = await aio_run_command(["ar", "x", filename])
                 if stderr:
@@ -265,8 +263,8 @@ class BaseExtractor:
             if not await aio_inpath("cabextract"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
                     # ExtractionToolNotFound
-                    self.logger.warning(f"No extraction tool found for {filename}")
-                    self.logger.warning("'cabextract' is required to extract cab files")
+                    self.logger.error(f"No extraction tool found for {filename}")
+                    self.logger.error("'cabextract' is required to extract cab files")
             else:
                 stdout, stderr, _ = await aio_run_command(
                     ["cabextract", "-d", extraction_path, filename]
@@ -277,8 +275,8 @@ class BaseExtractor:
             if not await aio_inpath("Expand"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
                     # ExtractionToolNotFound
-                    self.logger.warning(f"No extraction tool found for {filename}")
-                    self.logger.warning("'Expand' is required to extract cab files")
+                    self.logger.error(f"No extraction tool found for {filename}")
+                    self.logger.error("'Expand' is required to extract cab files")
             else:
                 stdout, stderr, _ = await aio_run_command(
                     ["Expand", filename, "-R -F:*", extraction_path]

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -28,13 +28,7 @@ from cve_bin_tool.async_utils import (
     run_coroutine,
 )
 
-from .error_handler import (
-    ErrorHandler,
-    ErrorMode,
-    ExtractionFailed,
-    ExtractionToolNotFound,
-    UnknownArchiveType,
-)
+from .error_handler import ErrorHandler, ErrorMode, ExtractionFailed, UnknownArchiveType
 from .log import LOGGER
 
 # Run rpmfile in a thread
@@ -107,7 +101,11 @@ class BaseExtractor:
         else:
             if not await aio_inpath("7z"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
-                    raise ExtractionToolNotFound("7z is required to extract rpm files")
+                    # ExtractionToolNotFound
+                    self.logger.warning(f"No extraction tool found for {filename}")
+                    self.logger.warning(
+                        "rpm2cpio or 7z can be used to extract rpm files"
+                    )
             else:
                 stdout, stderr, _ = await aio_run_command(["7z", "x", filename])
                 if stderr or not stdout:
@@ -152,7 +150,9 @@ class BaseExtractor:
                     if stderr:
                         return 1
                 else:
-                    raise ExtractionToolNotFound(
+                    # ExtractionToolNotFound
+                    self.logger.warning(f"No extraction tool found for {filename}")
+                    self.logger.warning(
                         "tar or 7zip-zstd is required to extract tar.zstd files"
                     )
         return e.exit_code
@@ -205,9 +205,9 @@ class BaseExtractor:
         if is_ar:
             if not await aio_inpath("ar"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
-                    raise ExtractionToolNotFound(
-                        "'ar' is required to extract deb files"
-                    )
+                    # ExtractionToolNotFound
+                    self.logger.warning(f"No extraction tool found for {filename}")
+                    self.logger.warning("'ar' is required to extract deb files")
             else:
                 stdout, stderr, _ = await aio_run_command(["ar", "x", filename])
                 if stderr:
@@ -264,9 +264,9 @@ class BaseExtractor:
         if sys.platform.startswith("linux"):
             if not await aio_inpath("cabextract"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
-                    raise ExtractionToolNotFound(
-                        "'cabextract' is required to extract cab files"
-                    )
+                    # ExtractionToolNotFound
+                    self.logger.warning(f"No extraction tool found for {filename}")
+                    self.logger.warning("'cabextract' is required to extract cab files")
             else:
                 stdout, stderr, _ = await aio_run_command(
                     ["cabextract", "-d", extraction_path, filename]
@@ -276,9 +276,9 @@ class BaseExtractor:
         else:
             if not await aio_inpath("Expand"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
-                    raise ExtractionToolNotFound(
-                        "'Expand' is required to extract cab files"
-                    )
+                    # ExtractionToolNotFound
+                    self.logger.warning(f"No extraction tool found for {filename}")
+                    self.logger.warning("'Expand' is required to extract cab files")
             else:
                 stdout, stderr, _ = await aio_run_command(
                     ["Expand", filename, "-R -F:*", extraction_path]

--- a/test/test_extractor.py
+++ b/test/test_extractor.py
@@ -27,7 +27,6 @@ from zipfile import ZipFile, ZipInfo
 import pytest
 from pytest_mock import MockerFixture
 
-from cve_bin_tool.error_handler import ERROR_CODES, ExtractionToolNotFound
 from cve_bin_tool.extractor import Extractor
 from cve_bin_tool.util import inpath
 
@@ -285,11 +284,14 @@ class TestExtractFileDeb(TestExtractorBase):
                 coroutine(mocker.Mock(return_value=False)),
             )
 
-        with pytest.raises(SystemExit) as e:
-            async for _ in self.extract_files(
-                [f"test{extension}" for extension in extension_list]
-            ):
-                assert e.value.args[0] == ERROR_CODES[ExtractionToolNotFound]
+        # will not extract file, but also won't raise an exception
+        # we could also check log messages?
+        async for extracted_path in self.extract_files(
+            [f"test{extension}" for extension in extension_list]
+        ):
+            assert not (
+                Path(extracted_path) / "usr" / "bin" / "cve_bin_tool_deb_test"
+            ).is_file()
 
 
 class TestExtractFileIpk(TestExtractorBase):
@@ -349,11 +351,12 @@ class TestExtractFileCab(TestExtractorBase):
                 coroutine(mocker.Mock(return_value=False)),
             )
 
-        with pytest.raises(SystemExit) as e:
-            async for _ in self.extract_files(
-                [f"test{extension}" for extension in extension_list]
-            ):
-                assert e.value.args[0] == ERROR_CODES[ExtractionToolNotFound]
+        # will not raise exception but also will not extract file
+        # could also check log messages here?
+        async for extracted_path in self.extract_files(
+            [f"test{extension}" for extension in extension_list]
+        ):
+            assert not (Path(extracted_path) / "usr" / "bin" / "python3.8").is_file()
 
 
 class TestExtractFileZip(TestExtractorBase):


### PR DESCRIPTION
* fixes #1748

Currently, when files can't be extracted because a tool is not installed, we throw an exception and halt the scan.  This is great for getting attention but terrible if you're scanning a large system and maybe just don't care about scanning those files.  It also causes a problem in the issue linked above when attempting to run cve-bin-tool on a system outside of the ones we actually support.

This PR switches us to logging a message and allowing the scan to proceed.  I think that's mostly what users want, but there's still a couple of questions here:

- Should these be `logger.warning` or `logger.error` ?  I started with warning because that's what we have elsewhere but I worried that people might not realize some things weren't being scanned that maybe could be, so I switched it to errors.
- do we need to put these warnings into the reports somehow so people will again realize if some files weren't scanned and maybe could have been?