### PR TITLE
ci: requirements do not need to be tested during windows longtests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -361,6 +361,7 @@ jobs:
           pytest --cov --cov-append -n 4 -v
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
+          --ignore=test/test_requirements.py
           --ignore=test/test_html.py
       - name: Run synchronous tests
         run: >


### PR DESCRIPTION
* Noticed thanks to #2368 

For some reason, windows long tests were still running test_requirements.py. We had intentionally moved that into a separate test runner so that it was easier to spot new CVEs that might affect us and it looks like we just  forgot to exclude it on windows.