### PR TITLE
fix: remove extraneous exit() calls

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -86,7 +86,6 @@ def main(argv=None):
         raise OSError(
             "Python no longer provides security updates for version 3.6 as of December 2021. Please upgrade to python 3.7+ to use CVE Binary Tool."
         )
-        exit()
     argv = argv or sys.argv
 
     # Reset logger level to info


### PR DESCRIPTION
Fixes #2414 

Removed bogus exit call

Signed off by metabiswadeep