### PR TITLE
fix: remove LegacyVersion

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -8,9 +8,9 @@ from collections import defaultdict
 from logging import Logger
 from pathlib import Path
 from string import ascii_lowercase
-from typing import DefaultDict, Dict, List, Tuple, Union
+from typing import DefaultDict, Dict, List, Tuple
 
-from packaging.version import LegacyVersion, Version
+from packaging.version import Version
 from packaging.version import parse as parse_version
 from rich.console import Console
 
@@ -307,7 +307,7 @@ class CVEScanner:
             version = f"{version[:-1]}.{self.ALPHA_TO_NUM[last_char]}"
         return version
 
-    VersionType = Union[Version, LegacyVersion]
+    VersionType = Version
 
     def canonical_convert(
         self, product_info: ProductInfo

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -172,13 +172,13 @@ class CVEDB:
         # getting schema from command
         lines = table_schema.split("(")[1].split(",")
 
-        severity_schema = [x.split("\n")[1].strip().split(" ")[0] for x in lines]
-        severity_schema.pop()
+        table_schema = [x.split("\n")[1].strip().split(" ")[0] for x in lines]
+        table_schema.pop()
 
         # getting current schema from cve_severity
         current_schema = [x[0] for x in result.description]
 
-        if severity_schema == current_schema:
+        if table_schema == current_schema:
             schema_latest = True
 
         # check for cve_

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -149,25 +149,28 @@ class CVEDB:
             self.LOGGER.info(
                 "Using cached CVE data (<24h old). Use -u now to update immediately."
             )
-            if not self.latest_schema():
+            severity_schema, range_schema = self.table_schemas()
+            if not self.latest_schema(
+                "cve_severity", severity_schema
+            ) or not self.latest_schema("cve_range", range_schema):
                 self.refresh_cache_and_update_db()
                 self.time_of_last_update = datetime.datetime.today()
 
-    def latest_schema(self, cursor: sqlite3.Cursor | None = None) -> bool:
+    def latest_schema(
+        self, table_name: str, table_schema: str, cursor: sqlite3.Cursor | None = None
+    ) -> bool:
         """Check database is using latest schema"""
         self.LOGGER.debug("Check database is using latest schema")
         cursor = self.db_open_and_get_cursor()
-        schema_check = "SELECT * FROM cve_severity WHERE 1=0"
+        schema_check = f"SELECT * FROM {table_name} WHERE 1=0"
         result = cursor.execute(schema_check)
         schema_latest = False
 
         if not cursor:
             self.db_close()
 
-        severity, _ = self.table_schemas()
-
         # getting schema from command
-        lines = severity.split("(")[1].split(",")
+        lines = table_schema.split("(")[1].split(",")
 
         severity_schema = [x.split("\n")[1].strip().split(" ")[0] for x in lines]
         severity_schema.pop()
@@ -177,6 +180,8 @@ class CVEDB:
 
         if severity_schema == current_schema:
             schema_latest = True
+
+        # check for cve_
 
         return schema_latest
 
@@ -256,11 +261,20 @@ class CVEDB:
         cursor.execute(version_range_create)
         cursor.execute(index_range)
 
-        if not self.latest_schema(cursor):
+        severity_schema, range_schema = self.table_schemas()
+        # Check schema on cve_severity
+        if not self.latest_schema("cve_severity", severity_schema, cursor):
             # Recreate table using latest schema
-            self.LOGGER.info("Upgrading database to latest schema")
+            self.LOGGER.info("Upgrading database cve_severity to latest schema")
             cursor.execute("DROP TABLE cve_severity")
             cursor.execute(cve_data_create)
+
+        # Check schema on cve_range
+        if not self.latest_schema("cve_range", range_schema, cursor):
+            self.LOGGER.info("Upgrading database cve_range to latest schema")
+            cursor.execute("DROP TABLE cve_range")
+            cursor.execute(version_range_create)
+
         if self.connection is not None:
             self.connection.commit()
 


### PR DESCRIPTION
* fixes #2428 (on main; a new release would likely be needed to address the 3.1.1 release)

Turns out we weren't really using LegacyVersion for anything so this PR just tries removing the places it existed.  It's possible this will break some type checking, but the type checking for this file was still a work in progress anyhow.