### PR TITLE
fix: downgrade packaging temporarily

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,5 @@ requests
 urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
 gsutil
 cvss
-packaging
+packaging<22.0
 importlib_resources; python_version < "3.9"


### PR DESCRIPTION
The fix I attempted where we removed the LegacyVersion uncovered some other changes in packaging that may be causing us problems.  This uses the same "temporarily avoid version 22.0" solution that I used for the 3.1.2 release to see if that resolves the problem short-term while I see if we can work out a better long-term fix (see #2435 )

Note: I'm using 22.0 locally and not seeing any of these errors, so I'm not 100% sure what's going on in CI.