### PR TITLE
ci: Switching version of python used for long tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -99,7 +99,7 @@ jobs:
         run: pytest -v -n auto test/test_html.py
 
   long_tests:
-    name: Long tests on Python 3.8
+    name: Long tests on Python 3.10
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -108,7 +108,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           cache: 'pip'
       - name: Get date
         id: get-date
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           cache: 'pip'
       - name: Get date
         id: get-date

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.7', '3.9', '3.10']
+        python: ['3.7', '3.8', '3.9']
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes #2431 

Upgrade long tests and external connectivity tests to python 3.10