### PR TITLE
ci: test if tests work without initial run on windows

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -277,9 +277,9 @@ jobs:
       - name: Install playwright dependencies for HTML tests
         run: |
           python -m playwright install chromium --with-deps
-      - name: Try single CLI run of tool
-        run: |
-          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
+      #- name: Try single CLI run of tool
+      #  run: |
+      #    python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out
       - name: Run async tests
         run: >
           pytest -n 4 -v

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -248,7 +248,7 @@ jobs:
   windows_tests:
     name: Windows tests
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'
@@ -353,9 +353,9 @@ jobs:
       - name: Install playwright dependencies for HTML tests
         run: |
           python -m playwright install chromium --with-deps
-      - name: Try single CLI run of tool
-        run: |
-          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
+      #- name: Try single CLI run of tool
+      #  run: |
+      #    python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
       - name: Run async tests
         run: >
           pytest --cov --cov-append -n 4 -v


### PR DESCRIPTION
An experiment in CI to see if the tests run without the cli test on windows (they should, but it depends on what's going on with the database)