### PR TITLE
ci: fix windows date variable for caching

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -261,12 +261,12 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "date=$(get-date -format "yyyyMMdd")" >> $GITHUB_OUTPUT
+          echo "DATE=$(powershell get-date -format "yyyyMMdd")" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Get cached database
         uses: actions/cache@v3
         with:
           path: ~/.cache/cve-bin-tool
-          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
+          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
       - name: Install cve-bin-tool
         run: |
           python -m pip install --upgrade pip
@@ -337,12 +337,12 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "date=$(get-date -format "yyyyMMdd")" >> $GITHUB_OUTPUT
+          echo "DATE=$(powershell get-date -format "yyyyMMdd")" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - name: Get cached database
         uses: actions/cache@v3
         with:
           path: ~/.cache/cve-bin-tool
-          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
+          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
       - name: Install cve-bin-tool
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -57,11 +57,11 @@ jobs:
       - name: Get date
         id: get-date
         run: |
-          echo "date=$(get-date -format "yyyyMMdd")" >> $GITHUB_OUTPUT
+          echo "DATE=$(powershell get-date -format "yyyyMMdd")" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
       - uses: actions/cache@v3
         with:
           path: ~/.cache/cve-bin-tool
-          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
+          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
       - name: Install cve-bin-tool
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
* fixes #2441 

Turns out the environment variable used for the date wasn't getting set and exported correctly on windows because windows uses a very different environment variable setup.  The key part of how to fix it was found here https://github.com/actions/runner-images/issues/5251 
