### PR TITLE
ci: increase cache timeout on windows

### DIFF
--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -45,7 +45,7 @@ jobs:
     if: github.repository == 'intel/cve-bin-tool'
     name: Update windows cached database
     runs-on: windows-latest
-    timeout-minutes: 20
+    timeout-minutes: 60
     env:
       PYTHONIOENCODING: 'utf8'
     steps:


### PR DESCRIPTION
Windows cache update timed out.  It didn't look like it hung so it may need more time.