### PR TITLE
docs: Add short new contributor tips for copying into pull requests

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -223,6 +223,7 @@ iperf
 ipsec
 iptables
 irssi
+ISSUENUMBER
 itertools
 iucode
 jack

--- a/doc/new-contributor-tips.md
+++ b/doc/new-contributor-tips.md
@@ -1,0 +1,9 @@
+This file contains the tips/links I put into bugs marked "good first issue" so
+that new contributors have the guidance they need right in the bug.
+
+**Short tips for new contributors:**
+* [cve-bin-tool's contributor docs](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md)
+* If you've contributed to open source but not this project, you might just want our [checklist for a great pull request](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md#checklist-for-a-great-pull-request)
+* cve-bin-tool uses https://www.conventionalcommits.org/ style for commit messages, and we have a test that checks the title of your PR.  A good potential title for this one is in the title of this issue.
+* You can make an issue auto close by including a comment "fixes #ISSUENUMBER" in your PR comments where ISSUENUMBER is the actual number of the issue.
+


### PR DESCRIPTION
I usually cut and paste a set of tips into issues that I mark as "good first issue" so I figured I'd put them into the docs directory so it was faster to find them when I needed them.