### PR TITLE
chore: bump version to 3.2.1dev0

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -8,7 +8,7 @@ from packaging import version
 
 from cve_bin_tool.log import LOGGER
 
-VERSION: str = "3.2"
+VERSION: str = "3.2.1dev0"
 
 
 def check_latest_version():


### PR DESCRIPTION
This changes our working version number to be 3.2.1dev0 so you can easily tell if you're running the release version or working on the development tree.  (The next release will either be 3.2.1 or possibly 4.0 depending on whether NVD removes access to NVD API 1.0.)