### PR TITLE
fix: address 'SelectableGroups dict interface deprecated' warning

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -32,6 +32,8 @@ from collections import ChainMap
 from pathlib import Path
 from typing import Dict
 
+from backports.entry_points_selectable import entry_points
+
 from cve_bin_tool.available_fix import (
     AvailableFixReport,
     get_available_fix_supported_distros,
@@ -65,7 +67,6 @@ from cve_bin_tool.sbom_manager import SBOMManager
 from cve_bin_tool.util import ProductInfo
 from cve_bin_tool.version import VERSION
 from cve_bin_tool.version_scanner import VersionScanner
-from backports.entry_points_selectable import entry_points
 
 sys.excepthook = excepthook  # Always install excepthook for entrypoint module.
 

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -65,11 +65,7 @@ from cve_bin_tool.sbom_manager import SBOMManager
 from cve_bin_tool.util import ProductInfo
 from cve_bin_tool.version import VERSION
 from cve_bin_tool.version_scanner import VersionScanner
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata as importlib_metadata
-else:
-    import importlib_metadata
+from backports.entry_points_selectable import entry_points
 
 sys.excepthook = excepthook  # Always install excepthook for entrypoint module.
 
@@ -678,7 +674,7 @@ def main(argv=None):
                 lambda checker: checker.name,
                 filter(
                     lambda checker: checker.name not in runs,
-                    importlib_metadata.entry_points()["cve_bin_tool.checker"],
+                    entry_points().select(group="cve_bin_tool.checker"),
                 ),
             )
         )

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -18,11 +18,9 @@ from cve_bin_tool.log import LOGGER
 from cve_bin_tool.parsers.parse import parse, valid_files
 from cve_bin_tool.strings import parse_strings
 from cve_bin_tool.util import DirWalk, ProductInfo, ScanInfo, inpath
+from backports.entry_points_selectable import entry_points
 
-if sys.version_info >= (3, 8):
-    from importlib import metadata as importlib_metadata
-else:
-    import importlib_metadata
+
 if sys.version_info >= (3, 9):
     import importlib.resources as resources
 else:
@@ -80,14 +78,14 @@ class VersionScanner:
         checkers = dict(
             map(
                 lambda checker: (checker.name, checker.load()),
-                importlib_metadata.entry_points()[cls.CHECKER_ENTRYPOINT],
+                entry_points().select(group=cls.CHECKER_ENTRYPOINT),
             )
         )
         return checkers
 
     @classmethod
     def available_checkers(cls) -> list[str]:
-        checkers = importlib_metadata.entry_points()[cls.CHECKER_ENTRYPOINT]
+        checkers = entry_points().select(group=cls.CHECKER_ENTRYPOINT)
         checker_list = [item.name for item in checkers]
         return checker_list
 

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -8,6 +8,8 @@ from logging import Logger
 from pathlib import Path, PurePath
 from typing import Iterator
 
+from backports.entry_points_selectable import entry_points
+
 from cve_bin_tool.checkers import Checker
 from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.egg_updater import IS_DEVELOP, update_egg
@@ -18,8 +20,6 @@ from cve_bin_tool.log import LOGGER
 from cve_bin_tool.parsers.parse import parse, valid_files
 from cve_bin_tool.strings import parse_strings
 from cve_bin_tool.util import DirWalk, ProductInfo, ScanInfo, inpath
-from backports.entry_points_selectable import entry_points
-
 
 if sys.version_info >= (3, 9):
     import importlib.resources as resources

--- a/requirements.csv
+++ b/requirements.csv
@@ -19,3 +19,4 @@ google,gsutil
 skontar,cvss
 python_not_in_db,packaging
 python_not_in_db,importlib_resources
+backports.entry_points_selectable

--- a/requirements.csv
+++ b/requirements.csv
@@ -19,4 +19,4 @@ google,gsutil
 skontar,cvss
 python_not_in_db,packaging
 python_not_in_db,importlib_resources
-backports.entry_points_selectable
+python_not_in_db,backports.entry_points_selectable

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ distro
 defusedxml
 xmlschema
 importlib_metadata; python_version < "3.8"
+backports.entry_points_selectable
 requests
 urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
 gsutil

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -2,18 +2,13 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
-import sys
 
 import pytest
 
 from cve_bin_tool.checkers import Checker, VendorProductPair
 from cve_bin_tool.egg_updater import IS_DEVELOP, update_egg
 from cve_bin_tool.log import LOGGER
-
-if sys.version_info >= (3, 8):
-    from importlib import metadata as importlib_metadata
-else:
-    import importlib_metadata
+from backports.entry_points_selectable import entry_points
 
 Pattern = type(re.compile("", 0))
 
@@ -119,7 +114,7 @@ class TestCheckerVersionParser:
     )
     def test_filename_is(self, checker_name, file_name, expected_results):
         """Test a checker's filename detection"""
-        checkers = importlib_metadata.entry_points()["cve_bin_tool.checker"]
+        checkers = entry_points().select(group="cve_bin_tool.checker")
         for checker in checkers:
             if checker.name == checker_name:
                 Checker = checker.load()
@@ -168,7 +163,7 @@ class TestCheckerVersionParser:
             "2.30",
         ]
         file_name = "libc.so.6"
-        checkers = importlib_metadata.entry_points()["cve_bin_tool.checker"]
+        checkers = entry_points().select(group="cve_bin_tool.checker")
         result = None
         for checker in checkers:
             if checker.name == "glibc":

--- a/test/test_checkers.py
+++ b/test/test_checkers.py
@@ -4,11 +4,11 @@
 import re
 
 import pytest
+from backports.entry_points_selectable import entry_points
 
 from cve_bin_tool.checkers import Checker, VendorProductPair
 from cve_bin_tool.egg_updater import IS_DEVELOP, update_egg
 from cve_bin_tool.log import LOGGER
-from backports.entry_points_selectable import entry_points
 
 Pattern = type(re.compile("", 0))
 


### PR DESCRIPTION
This pr fixes #2437 .

Currently, we get warning ` DeprecationWarning: SelectableGroups dict interface is deprecated. Use select.`  as this method is currently deprecated as mentioned [here](https://importlib-metadata.readthedocs.io/en/latest/history.html#:~:text=Use%20of%20Mapping%20(dict)%20interfaces%20on%20SelectableGroups%20is%20now%20flagged%20as%20deprecated.%20Instead%2C%20users%20are%20advised%20to%20use%20the%20select%20interface%20for%20future%20compatibility.).

I have tried to fix this warning by replacing ` importlib_metadata.entry_points("checker_name")` with `entry_points().select(group="checker_name")` as described [here](https://pypi.org/project/backports.entry-points-selectable/)
