### PR TITLE
ci(js): update workflow for updating JS

### DIFF
--- a/.github/workflows/update-js-dependencies.yml
+++ b/.github/workflows/update-js-dependencies.yml
@@ -22,8 +22,7 @@ jobs:
           python-version: '3.x'
 
       - name: Update JS dependencies
-        run: |
-          python .github/workflows/update_js_dependencies.py
+        run: python .github/workflows/update_js_dependencies.py
 
       - name: Get cached Python packages
         uses: actions/cache@v3
@@ -35,15 +34,13 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python3-dev
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools wheel
-          python -m pip install --upgrade -r requirements.txt pytest pdftotext
+          python -m pip install --upgrade . pytest-xdist pytest-playwright
+          python -m playwright install chromium --with-deps
 
-      - name: Test HTML report generation
-        run: |
-          pytest test/test_output_engine.py -k test_output_html
+      - name: Run HTML tests
+        run: python -m pytest -v -n auto test/test_html.py
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v4
@@ -62,11 +59,10 @@ jobs:
         run: |
           python -c 'from test.test_output_engine import TestOutputEngine; \
           from cve_bin_tool.output_engine.html import output_html; \
-          output_html(TestOutputEngine.MOCK_OUTPUT, "", "", "", 3, 3, 0, None, None, open("test.html", "w"))'
+          output_html(TestOutputEngine.MOCK_OUTPUT, None, "", "", "", 3, 3, 0, None, None, open("test.html", "w"))'
 
       - name: Upload mock report
         uses: actions/upload-artifact@v3
         with:
           name: HTML report
-          path: |
-            test.html
+          path: test.html


### PR DESCRIPTION
I have noticed that the workflow for updating JS dependencies [has failed](https://github.com/intel/cve-bin-tool/actions/runs/3819307107) so I've updated it with changes from #1667 and #1925.