### PR TITLE
ci(SBOM): better SBOM maintenance

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,12 +10,14 @@ jobs:
   sbom_gen:
     name: Generate SBOM
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    strategy:
+      matrix:
+        python: ['3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: ${{ matrix.python }}
           cache: 'pip'
           cache-dependency-path: '**/requirements.txt'
       - name: Install dependencies and cve-bin-tool
@@ -27,31 +29,32 @@ jobs:
           pip install . --upgrade --upgrade-strategy=eager
       - name: Generate SBOM for cve-bin-tool
         run: |
-          sbom4python --module cve-bin-tool --output cve-bin-tool.spdx
-          sbom4python --module cve-bin-tool --sbom cyclonedx --format json --output cve-bin-tool.json
+          sbom4python --module cve-bin-tool --output cve-bin-tool-py${{ matrix.python }}.spdx
+          sbom4python --module cve-bin-tool --sbom cyclonedx --format json --output cve-bin-tool-py${{ matrix.python }}.json
       - name: Compare SBOM for cve-bin-tool
         id: diff-sbom
         # This would fail due to time/date of SBOM generation in SBOM header
         # Therefore ignore first 10 lines of file in comparison which is SBOM header
         run: |
-          /bin/tail -n +10 sbom/cve-bin-tool.spdx > orig
-          /bin/tail -n +10 cve-bin-tool.spdx > new
+          /bin/tail -n +10 sbom/cve-bin-tool-py${{ matrix.python }}.spdx > orig
+          /bin/tail -n +10 cve-bin-tool-py${{ matrix.python }}.spdx > new
           echo "changed=$(/bin/diff -q orig new)" >> $GITHUB_OUTPUT
       - name: Display generated SBOM if difference detected
         if: ${{ steps.diff-sbom.outputs.changed }}
         run: |
-          /bin/cat cve-bin-tool.spdx
+          /bin/cat cve-bin-tool-py${{ matrix.python }}.spdx
       - name: Update existing SBOM if difference detected
         if: ${{ steps.diff-sbom.outputs.changed }}
         run: |
-          cp cve-bin-tool.spdx sbom/cve-bin-tool.spdx
-          cp cve-bin-tool.json sbom/cve-bin-tool.json
+          cp cve-bin-tool-py${{ matrix.python }}.spdx sbom/cve-bin-tool-py${{ matrix.python }}.spdx
+          cp cve-bin-tool-py${{ matrix.python }}.json sbom/cve-bin-tool-py${{ matrix.python }}.json
       - name: Create Pull Request
+        if: ${{ steps.diff-sbom.outputs.changed }}
         uses: peter-evans/create-pull-request@v4
         with:
-          commit-message: "chore: update SBOM"
-          title: "chore: update SBOM"
-          branch: chore-sbom
+          commit-message: "chore: update SBOM for Python ${{ matrix.python }}"
+          title: "chore: update SBOM for Python ${{ matrix.python }}"
+          branch: chore-sbom-py${{ matrix.python }}
           delete-branch: true
           author: GitHub <noreply@github.com>
           add-paths: sbom

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -33,9 +33,8 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
           python -m pip install --upgrade wheel
-          python -m pip install --upgrade pytest
           python -m pip install --upgrade sbom4python
-          pip install . -r doc/requirements.txt
+          pip install . --upgrade --upgrade-strategy=eager
       - name: Generate SBOM for cve-bin-tool
         run: |
           sbom4python --module cve-bin-tool --output sbom/cve-bin-tool.spdx

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -11,7 +11,6 @@ jobs:
     name: Generate SBOM
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -19,15 +18,6 @@ jobs:
           python-version: '3.x'
           cache: 'pip'
           cache-dependency-path: '**/requirements.txt'
-      - name: Get date
-        id: get-date
-        run: |
-          echo "date=$(/bin/date -u "+%Y%m%d")" >> $GITHUB_OUTPUT
-      - name: Get cached database
-        uses: actions/cache@v3
-        with:
-          path: ~/.cache/cve-bin-tool
-          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.date }}
       - name: Install dependencies and cve-bin-tool
         run: |
           python -m pip install --upgrade pip
@@ -37,17 +27,31 @@ jobs:
           pip install . --upgrade --upgrade-strategy=eager
       - name: Generate SBOM for cve-bin-tool
         run: |
-          sbom4python --module cve-bin-tool --output sbom/cve-bin-tool.spdx
-          sbom4python --module cve-bin-tool --sbom cyclonedx --format json --output sbom/cve-bin-tool.json
-#      - name: Compare SBOM for cve-bin-tool
-#        # This would fail due to time/date of SBOM generation in SBOM header
-#        # Therefore ignore first 10 lines of file in comparison which is SBOM header
-#        run: |
-#          /bin/tail -n +10 sbom/cve-bin-tool.spdx > orig
-#          /bin/tail -n +10 cve-bin-tool.spdx > new
-#          /bin/diff -b orig new
-#      - name: Display generated SBOM if difference detected
-#        if: ${{ failure() }}
-#        run: |
-#          /bin/cat cve-bin-tool.spdx
-
+          sbom4python --module cve-bin-tool --output cve-bin-tool.spdx
+          sbom4python --module cve-bin-tool --sbom cyclonedx --format json --output cve-bin-tool.json
+      - name: Compare SBOM for cve-bin-tool
+        id: diff-sbom
+        # This would fail due to time/date of SBOM generation in SBOM header
+        # Therefore ignore first 10 lines of file in comparison which is SBOM header
+        run: |
+          /bin/tail -n +10 sbom/cve-bin-tool.spdx > orig
+          /bin/tail -n +10 cve-bin-tool.spdx > new
+          echo "changed=$(/bin/diff -q orig new)" >> $GITHUB_OUTPUT
+      - name: Display generated SBOM if difference detected
+        if: ${{ steps.diff-sbom.outputs.changed }}
+        run: |
+          /bin/cat cve-bin-tool.spdx
+      - name: Update existing SBOM if difference detected
+        if: ${{ steps.diff-sbom.outputs.changed }}
+        run: |
+          cp cve-bin-tool.spdx sbom/cve-bin-tool.spdx
+          cp cve-bin-tool.json sbom/cve-bin-tool.json
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore: update SBOM"
+          title: "chore: update SBOM"
+          branch: chore-sbom
+          delete-branch: true
+          author: GitHub <noreply@github.com>
+          add-paths: sbom

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,6 +1,7 @@
 name: SBOM generation
 
 on:
+  workflow_dispatch:
   schedule:
     # Runs at 02:00 UTC every Monday
     - cron: '2 0 * * 1'

--- a/sbom/cve-bin-tool-py3.10.json
+++ b/sbom/cve-bin-tool-py3.10.json
@@ -1,0 +1,1097 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid44df97ba-2a0d-4fbb-b836-d3a16e801a41",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-01-02T23:37:09Z",
+    "tools": [
+      {
+        "name": "sbom4python",
+        "version": "0.4.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "application",
+      "bom-ref": "1-cve-bin-tool",
+      "name": "cve-bin-tool",
+      "version": "3.2.1.dev0",
+      "author": "Terri Oda",
+      "cpe": "cpe:/a:terri_oda:cve-bin-tool:3.2.1.dev0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0-or-later",
+            "url": "https://www.gnu.org/licenses/gpl-3.0-standalone.html"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cve-bin-tool@3.2.1.dev0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "2-aiohttp",
+      "name": "aiohttp",
+      "version": "3.8.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp@3.8.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "3-aiosignal",
+      "name": "aiosignal",
+      "version": "1.3.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiosignal@1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "4-frozenlist",
+      "name": "frozenlist",
+      "version": "1.3.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/frozenlist@1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "5-async-timeout",
+      "name": "async-timeout",
+      "version": "4.0.2",
+      "author": "Andrew Svetlov <andrew.svetlov@gmail.com>",
+      "cpe": "cpe:/a:andrew_svetlov_<andrew.svetlov@gmail.com>:async-timeout:4.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/async-timeout@4.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "6-attrs",
+      "name": "attrs",
+      "version": "22.2.0",
+      "author": "Hynek Schlawack",
+      "cpe": "cpe:/a:hynek_schlawack:attrs:22.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/attrs@22.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "7-charset-normalizer",
+      "name": "charset-normalizer",
+      "version": "2.1.1",
+      "author": "Ahmed TAHRI @Ousret",
+      "cpe": "cpe:/a:ahmed_tahri_@ousret:charset-normalizer:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "8-multidict",
+      "name": "multidict",
+      "version": "6.0.4",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:multidict:6.0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/multidict@6.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "9-yarl",
+      "name": "yarl",
+      "version": "1.8.2",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:yarl:1.8.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/yarl@1.8.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "10-idna",
+      "name": "idna",
+      "version": "3.4",
+      "purl": "pkg:pypi/idna@3.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "11-beautifulsoup4",
+      "name": "beautifulsoup4",
+      "version": "4.11.1",
+      "author": "Leonard Richardson",
+      "cpe": "cpe:/a:leonard_richardson:beautifulsoup4:4.11.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/beautifulsoup4@4.11.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "12-soupsieve",
+      "name": "soupsieve",
+      "version": "2.3.2.post1",
+      "purl": "pkg:pypi/soupsieve@2.3.2.post1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "13-cvss",
+      "name": "cvss",
+      "version": "2.5",
+      "author": "Stanislav Kontar, Red Hat Product Security",
+      "cpe": "cpe:/a:stanislav_kontar,_red_hat_product_security:cvss:2.5",
+      "purl": "pkg:pypi/cvss@2.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "14-defusedxml",
+      "name": "defusedxml",
+      "version": "0.7.1",
+      "author": "Christian Heimes",
+      "cpe": "cpe:/a:christian_heimes:defusedxml:0.7.1",
+      "purl": "pkg:pypi/defusedxml@0.7.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "15-distro",
+      "name": "distro",
+      "version": "1.8.0",
+      "author": "Nir Cohen",
+      "cpe": "cpe:/a:nir_cohen:distro:1.8.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/distro@1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "16-gsutil",
+      "name": "gsutil",
+      "version": "5.17",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gsutil:5.17",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gsutil@5.17"
+    },
+    {
+      "type": "library",
+      "bom-ref": "17-argcomplete",
+      "name": "argcomplete",
+      "version": "2.0.0",
+      "author": "Andrey Kislyuk",
+      "cpe": "cpe:/a:andrey_kislyuk:argcomplete:2.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/argcomplete@2.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "18-crcmod",
+      "name": "crcmod",
+      "version": "1.7",
+      "author": "Ray Buvel",
+      "cpe": "cpe:/a:ray_buvel:crcmod:1.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/crcmod@1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "19-fasteners",
+      "name": "fasteners",
+      "version": "0.18",
+      "author": "Joshua Harlow",
+      "cpe": "cpe:/a:joshua_harlow:fasteners:0.18",
+      "purl": "pkg:pypi/fasteners@0.18"
+    },
+    {
+      "type": "library",
+      "bom-ref": "20-gcs-oauth2-boto-plugin",
+      "name": "gcs-oauth2-boto-plugin",
+      "version": "3.0",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gcs-oauth2-boto-plugin:3.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gcs-oauth2-boto-plugin@3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "21-boto",
+      "name": "boto",
+      "version": "2.49.0",
+      "author": "Mitch Garnaat",
+      "cpe": "cpe:/a:mitch_garnaat:boto:2.49.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/boto@2.49.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "22-google-reauth",
+      "name": "google-reauth",
+      "version": "0.1.1",
+      "author": "Google",
+      "cpe": "cpe:/a:google:google-reauth:0.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-reauth@0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "23-pyu2f",
+      "name": "pyu2f",
+      "version": "0.1.5",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:pyu2f:0.1.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyu2f@0.1.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "24-six",
+      "name": "six",
+      "version": "1.16.0",
+      "author": "Benjamin Peterson",
+      "cpe": "cpe:/a:benjamin_peterson:six:1.16.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "25-httplib2",
+      "name": "httplib2",
+      "version": "0.20.4",
+      "author": "Joe Gregorio",
+      "cpe": "cpe:/a:joe_gregorio:httplib2:0.20.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/httplib2@0.20.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "26-pyparsing",
+      "name": "pyparsing",
+      "version": "3.0.9",
+      "purl": "pkg:pypi/pyparsing@3.0.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "27-oauth2client",
+      "name": "oauth2client",
+      "version": "4.1.3",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:oauth2client:4.1.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/oauth2client@4.1.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "28-pyasn1",
+      "name": "pyasn1",
+      "version": "0.4.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1:0.4.8",
+      "purl": "pkg:pypi/pyasn1@0.4.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "29-pyasn1-modules",
+      "name": "pyasn1-modules",
+      "version": "0.2.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1-modules:0.2.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1-modules@0.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "30-rsa",
+      "name": "rsa",
+      "version": "4.7.2",
+      "author": "Sybren A. Stuvel",
+      "cpe": "cpe:/a:sybren_a._stuvel:rsa:4.7.2",
+      "purl": "pkg:pypi/rsa@4.7.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "31-pyopenssl",
+      "name": "pyopenssl",
+      "version": "23.0.0",
+      "author": "The pyOpenSSL developers",
+      "cpe": "cpe:/a:the_pyopenssl_developers:pyopenssl:23.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyopenssl@23.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "32-cryptography",
+      "name": "cryptography",
+      "version": "39.0.0",
+      "author": "The Python Cryptographic Authority and individual contributors",
+      "cpe": "cpe:/a:the_python_cryptographic_authority_and_individual_contributors:cryptography:39.0.0",
+      "purl": "pkg:pypi/cryptography@39.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "33-cffi",
+      "name": "cffi",
+      "version": "1.15.1",
+      "author": "Armin Rigo, Maciej Fijalkowski",
+      "cpe": "cpe:/a:armin_rigo,_maciej_fijalkowski:cffi:1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cffi@1.15.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "34-pycparser",
+      "name": "pycparser",
+      "version": "2.21",
+      "author": "Eli Bendersky",
+      "cpe": "cpe:/a:eli_bendersky:pycparser:2.21",
+      "purl": "pkg:pypi/pycparser@2.21"
+    },
+    {
+      "type": "library",
+      "bom-ref": "35-retry-decorator",
+      "name": "retry-decorator",
+      "version": "1.1.1",
+      "author": "Patrick Ng",
+      "cpe": "cpe:/a:patrick_ng:retry-decorator:1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/retry-decorator@1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "36-google-apitools",
+      "name": "google-apitools",
+      "version": "0.5.32",
+      "author": "Craig Citro",
+      "cpe": "cpe:/a:craig_citro:google-apitools:0.5.32",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-apitools@0.5.32"
+    },
+    {
+      "type": "library",
+      "bom-ref": "37-google-auth",
+      "name": "google-auth",
+      "version": "2.15.0",
+      "author": "Google Cloud Platform",
+      "cpe": "cpe:/a:google_cloud_platform:google-auth:2.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-auth@2.15.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "38-cachetools",
+      "name": "cachetools",
+      "version": "5.2.0",
+      "author": "Thomas Kemmer",
+      "cpe": "cpe:/a:thomas_kemmer:cachetools:5.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cachetools@5.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "39-monotonic",
+      "name": "monotonic",
+      "version": "1.6",
+      "author": "Ori Livneh",
+      "cpe": "cpe:/a:ori_livneh:monotonic:1.6",
+      "purl": "pkg:pypi/monotonic@1.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "40-jinja2",
+      "name": "jinja2",
+      "version": "3.1.2",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:jinja2:3.1.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jinja2@3.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "41-markupsafe",
+      "name": "markupsafe",
+      "version": "2.1.1",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:markupsafe:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/markupsafe@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "42-jsonschema",
+      "name": "jsonschema",
+      "version": "4.17.3",
+      "author": "Julian Berman",
+      "cpe": "cpe:/a:julian_berman:jsonschema:4.17.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.17.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "43-pyrsistent",
+      "name": "pyrsistent",
+      "version": "0.19.3",
+      "author": "Tobias Gustafsson",
+      "cpe": "cpe:/a:tobias_gustafsson:pyrsistent:0.19.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyrsistent@0.19.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "44-packaging",
+      "name": "packaging",
+      "version": "21.3",
+      "author": "Donald Stufft and individual contributors",
+      "cpe": "cpe:/a:donald_stufft_and_individual_contributors:packaging:21.3",
+      "purl": "pkg:pypi/packaging@21.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "45-plotly",
+      "name": "plotly",
+      "version": "5.11.0",
+      "author": "Chris P",
+      "cpe": "cpe:/a:chris_p:plotly:5.11.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/plotly@5.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "46-tenacity",
+      "name": "tenacity",
+      "version": "8.1.0",
+      "author": "Julien Danjou",
+      "cpe": "cpe:/a:julien_danjou:tenacity:8.1.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/tenacity@8.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "47-pyyaml",
+      "name": "pyyaml",
+      "version": "6.0",
+      "author": "Kirill Simonov",
+      "cpe": "cpe:/a:kirill_simonov:pyyaml:6.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyyaml@6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "48-requests",
+      "name": "requests",
+      "version": "2.28.1",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:requests:2.28.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.28.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "49-certifi",
+      "name": "certifi",
+      "version": "2022.12.7",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:certifi:2022.12.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "url": "https://www.mozilla.org/MPL/2.0/"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2022.12.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "50-urllib3",
+      "name": "urllib3",
+      "version": "1.26.13",
+      "author": "Andrey Petrov",
+      "cpe": "cpe:/a:andrey_petrov:urllib3:1.26.13",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@1.26.13"
+    },
+    {
+      "type": "library",
+      "bom-ref": "51-rich",
+      "name": "rich",
+      "version": "13.0.0",
+      "author": "Will McGugan",
+      "cpe": "cpe:/a:will_mcgugan:rich:13.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rich@13.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "52-commonmark",
+      "name": "commonmark",
+      "version": "0.9.1",
+      "author": "Bibek Kafle <bkafle662@gmail.com>, Roland Shoemaker <rolandshoemaker@gmail.com>",
+      "cpe": "cpe:/a:bibek_kafle_<bkafle662@gmail.com>,_roland_shoemaker_<rolandshoemaker@gmail.com>:commonmark:0.9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/commonmark@0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "53-pygments",
+      "name": "pygments",
+      "version": "2.14.0",
+      "author": "Georg Brandl",
+      "cpe": "cpe:/a:georg_brandl:pygments:2.14.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pygments@2.14.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "54-rpmfile",
+      "name": "rpmfile",
+      "version": "1.0.8",
+      "author": "Sean Ross-Ross",
+      "cpe": "cpe:/a:sean_ross-ross:rpmfile:1.0.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rpmfile@1.0.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "55-toml",
+      "name": "toml",
+      "version": "0.10.2",
+      "author": "William Pearson",
+      "cpe": "cpe:/a:william_pearson:toml:0.10.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "56-xmlschema",
+      "name": "xmlschema",
+      "version": "2.1.1",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:xmlschema:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/xmlschema@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "57-elementpath",
+      "name": "elementpath",
+      "version": "3.0.2",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:elementpath:3.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/elementpath@3.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "58-zstandard",
+      "name": "zstandard",
+      "version": "0.19.0",
+      "author": "Gregory Szorc",
+      "cpe": "cpe:/a:gregory_szorc:zstandard:0.19.0",
+      "purl": "pkg:pypi/zstandard@0.19.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "1-cve-bin-tool",
+      "dependsOn": [
+        "2-aiohttp",
+        "11-beautifulsoup4",
+        "13-cvss",
+        "14-defusedxml",
+        "15-distro",
+        "16-gsutil",
+        "40-jinja2",
+        "42-jsonschema",
+        "44-packaging",
+        "45-plotly",
+        "47-pyyaml",
+        "48-requests",
+        "51-rich",
+        "54-rpmfile",
+        "55-toml",
+        "50-urllib3",
+        "56-xmlschema",
+        "58-zstandard"
+      ]
+    },
+    {
+      "ref": "2-aiohttp",
+      "dependsOn": [
+        "3-aiosignal",
+        "5-async-timeout",
+        "6-attrs",
+        "7-charset-normalizer",
+        "4-frozenlist",
+        "8-multidict",
+        "9-yarl"
+      ]
+    },
+    {
+      "ref": "3-aiosignal",
+      "dependsOn": [
+        "4-frozenlist"
+      ]
+    },
+    {
+      "ref": "9-yarl",
+      "dependsOn": [
+        "10-idna",
+        "8-multidict"
+      ]
+    },
+    {
+      "ref": "11-beautifulsoup4",
+      "dependsOn": [
+        "12-soupsieve"
+      ]
+    },
+    {
+      "ref": "16-gsutil",
+      "dependsOn": [
+        "17-argcomplete",
+        "18-crcmod",
+        "19-fasteners",
+        "20-gcs-oauth2-boto-plugin",
+        "36-google-apitools",
+        "37-google-auth",
+        "22-google-reauth",
+        "25-httplib2",
+        "39-monotonic",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "20-gcs-oauth2-boto-plugin",
+      "dependsOn": [
+        "21-boto",
+        "22-google-reauth",
+        "25-httplib2",
+        "27-oauth2client",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "22-google-reauth",
+      "dependsOn": [
+        "23-pyu2f"
+      ]
+    },
+    {
+      "ref": "23-pyu2f",
+      "dependsOn": [
+        "24-six"
+      ]
+    },
+    {
+      "ref": "25-httplib2",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "27-oauth2client",
+      "dependsOn": [
+        "25-httplib2",
+        "28-pyasn1",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "29-pyasn1-modules",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "30-rsa",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "31-pyopenssl",
+      "dependsOn": [
+        "32-cryptography"
+      ]
+    },
+    {
+      "ref": "32-cryptography",
+      "dependsOn": [
+        "33-cffi"
+      ]
+    },
+    {
+      "ref": "33-cffi",
+      "dependsOn": [
+        "34-pycparser"
+      ]
+    },
+    {
+      "ref": "36-google-apitools",
+      "dependsOn": [
+        "19-fasteners",
+        "25-httplib2",
+        "27-oauth2client",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "37-google-auth",
+      "dependsOn": [
+        "38-cachetools",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "40-jinja2",
+      "dependsOn": [
+        "41-markupsafe"
+      ]
+    },
+    {
+      "ref": "42-jsonschema",
+      "dependsOn": [
+        "6-attrs",
+        "43-pyrsistent"
+      ]
+    },
+    {
+      "ref": "44-packaging",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "45-plotly",
+      "dependsOn": [
+        "46-tenacity"
+      ]
+    },
+    {
+      "ref": "48-requests",
+      "dependsOn": [
+        "49-certifi",
+        "7-charset-normalizer",
+        "10-idna",
+        "50-urllib3"
+      ]
+    },
+    {
+      "ref": "51-rich",
+      "dependsOn": [
+        "52-commonmark",
+        "53-pygments"
+      ]
+    },
+    {
+      "ref": "56-xmlschema",
+      "dependsOn": [
+        "57-elementpath"
+      ]
+    }
+  ]
+}

--- a/sbom/cve-bin-tool-py3.10.spdx
+++ b/sbom/cve-bin-tool-py3.10.spdx
@@ -2,64 +2,68 @@ SPDXVersion: SPDX-2.2
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: cve-bin-tool
-DocumentNamespace: http://spdx.org/spdxdocs/cve-bin-tool-1ad092fe-a322-4a6d-a19f-cc3aa3d6b241
-LicenseListVersion: 3.9
-Creator: Tool: SBOM4PYTHON_Generator-0.2.0
-Created: 2022-08-25T07:02:32Z
+DocumentNamespace: http://spdx.org/spdxdocs/cve-bin-tool-9e355190-e497-42b0-ae2a-f2bb05d8796e
+LicenseListVersion: 3.18
+Creator: Tool: sbom4python-0.4.0
+Created: 2023-01-02T23:36:08Z
 CreatorComment: <text>This document has been automatically generated.</text>
-#####
+##### 
 
 PackageName: cve-bin-tool
 SPDXID: SPDXRef-Package-1-cve-bin-tool
-PackageSupplier: Person: Terri Oda
-PackageVersion: 3.1.1
+PackageSupplier: Person: Terri_Oda
+PackageVersion: 3.2.1.dev0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license GPL-3.0-or-later
 PackageLicenseConcluded: GPL-3.0-or-later
 PackageLicenseDeclared: GPL-3.0-or-later
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cve-bin-tool@3.2.1.dev0
+##### 
 
 PackageName: aiohttp
 SPDXID: SPDXRef-Package-2-aiohttp
-PackageSupplier: Person:
-PackageVersion: 3.8.1
+PackageSupplier: NOASSERTION
+PackageVersion: 3.8.3
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache 2
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.3
+##### 
 
 PackageName: aiosignal
 SPDXID: SPDXRef-Package-3-aiosignal
-PackageSupplier: Person: Nikolay Kim
-PackageVersion: 1.2.0
-PackageDownloadLocation: NOASSERTION
-FilesAnalyzed: false
-##### Reported license Apache 2
-PackageLicenseConcluded: Apache-2.0
-PackageLicenseDeclared: Apache-2.0
-PackageCopyrightText: NOASSERTION
-#####
-
-PackageName: frozenlist
-SPDXID: SPDXRef-Package-4-frozenlist
-PackageSupplier: Person:
+PackageSupplier: NOASSERTION
 PackageVersion: 1.3.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
+##### 
+
+PackageName: frozenlist
+SPDXID: SPDXRef-Package-4-frozenlist
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
 ##### Reported license Apache 2
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+##### 
 
 PackageName: async-timeout
 SPDXID: SPDXRef-Package-5-async-timeout
-PackageSupplier: Organization: Andrew Svetlov <andrew.svetlov@gmail.com>
+PackageSupplier: Organization: Andrew_Svetlov_<andrew.svetlov@gmail.com>
 PackageVersion: 4.0.2
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -67,23 +71,25 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/async-timeout@4.0.2
+##### 
 
 PackageName: attrs
 SPDXID: SPDXRef-Package-6-attrs
-PackageSupplier: Person: Hynek Schlawack
-PackageVersion: 22.1.0
+PackageSupplier: Person: Hynek_Schlawack
+PackageVersion: 22.2.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MIT
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/attrs@22.2.0
+##### 
 
 PackageName: charset-normalizer
 SPDXID: SPDXRef-Package-7-charset-normalizer
-PackageSupplier: Organization: Ahmed TAHRI @Ousret
+PackageSupplier: Organization: Ahmed_TAHRI_@Ousret
 PackageVersion: 2.1.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -91,47 +97,51 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/charset-normalizer@2.1.1
+##### 
 
 PackageName: multidict
 SPDXID: SPDXRef-Package-8-multidict
-PackageSupplier: Person: Andrew Svetlov
-PackageVersion: 6.0.2
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 6.0.4
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache 2
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/multidict@6.0.4
+##### 
 
 PackageName: yarl
 SPDXID: SPDXRef-Package-9-yarl
-PackageSupplier: Person: Andrew Svetlov
-PackageVersion: 1.8.1
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 1.8.2
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache 2
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/yarl@1.8.2
+##### 
 
 PackageName: idna
 SPDXID: SPDXRef-Package-10-idna
-PackageSupplier: Person: Kim Davies
-PackageVersion: 3.3
+PackageSupplier: NOASSERTION
+PackageVersion: 3.4
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
-##### Reported license BSD-3-Clause
-PackageLicenseConcluded: BSD-3-Clause
-PackageLicenseDeclared: BSD-3-Clause
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/idna@3.4
+##### 
 
 PackageName: beautifulsoup4
 SPDXID: SPDXRef-Package-11-beautifulsoup4
-PackageSupplier: Person: Leonard Richardson
+PackageSupplier: Person: Leonard_Richardson
 PackageVersion: 4.11.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -139,23 +149,25 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/beautifulsoup4@4.11.1
+##### 
 
 PackageName: soupsieve
 SPDXID: SPDXRef-Package-12-soupsieve
-PackageSupplier: Person:
+PackageSupplier: NOASSERTION
 PackageVersion: 2.3.2.post1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
-##### Reported license
+##### Reported license 
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/soupsieve@2.3.2.post1
+##### 
 
 PackageName: cvss
 SPDXID: SPDXRef-Package-13-cvss
-PackageSupplier: Organization: Stanislav Kontar, Red Hat Product Security
+PackageSupplier: Organization: Stanislav_Kontar,_Red_Hat_Product_Security
 PackageVersion: 2.5
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -163,11 +175,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cvss@2.5
+##### 
 
 PackageName: defusedxml
 SPDXID: SPDXRef-Package-14-defusedxml
-PackageSupplier: Person: Christian Heimes
+PackageSupplier: Person: Christian_Heimes
 PackageVersion: 0.7.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -175,35 +188,38 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/defusedxml@0.7.1
+##### 
 
 PackageName: distro
 SPDXID: SPDXRef-Package-15-distro
-PackageSupplier: Person: Nir Cohen
-PackageVersion: 1.7.0
+PackageSupplier: Person: Nir_Cohen
+PackageVersion: 1.8.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache License, Version 2.0
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/distro@1.8.0
+##### 
 
 PackageName: gsutil
 SPDXID: SPDXRef-Package-16-gsutil
-PackageSupplier: Person: Google Inc.
-PackageVersion: 5.12
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 5.17
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache 2.0
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gsutil@5.17
+##### 
 
 PackageName: argcomplete
 SPDXID: SPDXRef-Package-17-argcomplete
-PackageSupplier: Person: Andrey Kislyuk
+PackageSupplier: Person: Andrey_Kislyuk
 PackageVersion: 2.0.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -211,11 +227,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/argcomplete@2.0.0
+##### 
 
 PackageName: crcmod
 SPDXID: SPDXRef-Package-18-crcmod
-PackageSupplier: Person: Ray Buvel
+PackageSupplier: Person: Ray_Buvel
 PackageVersion: 1.7
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -223,23 +240,25 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/crcmod@1.7
+##### 
 
 PackageName: fasteners
 SPDXID: SPDXRef-Package-19-fasteners
-PackageSupplier: Person: Joshua Harlow
-PackageVersion: 0.17.3
+PackageSupplier: Person: Joshua_Harlow
+PackageVersion: 0.18
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license ASL 2.0
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/fasteners@0.18
+##### 
 
 PackageName: gcs-oauth2-boto-plugin
 SPDXID: SPDXRef-Package-20-gcs-oauth2-boto-plugin
-PackageSupplier: Person: Google Inc.
+PackageSupplier: Person: Google_Inc.
 PackageVersion: 3.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -247,11 +266,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gcs-oauth2-boto-plugin@3.0
+##### 
 
 PackageName: boto
 SPDXID: SPDXRef-Package-21-boto
-PackageSupplier: Person: Mitch Garnaat
+PackageSupplier: Person: Mitch_Garnaat
 PackageVersion: 2.49.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -259,7 +279,8 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/boto@2.49.0
+##### 
 
 PackageName: google-reauth
 SPDXID: SPDXRef-Package-22-google-reauth
@@ -271,11 +292,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-reauth@0.1.1
+##### 
 
 PackageName: pyu2f
 SPDXID: SPDXRef-Package-23-pyu2f
-PackageSupplier: Person: Google Inc.
+PackageSupplier: Person: Google_Inc.
 PackageVersion: 0.1.5
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -283,11 +305,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyu2f@0.1.5
+##### 
 
 PackageName: six
 SPDXID: SPDXRef-Package-24-six
-PackageSupplier: Person: Benjamin Peterson
+PackageSupplier: Person: Benjamin_Peterson
 PackageVersion: 1.16.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -295,11 +318,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/six@1.16.0
+##### 
 
 PackageName: httplib2
 SPDXID: SPDXRef-Package-25-httplib2
-PackageSupplier: Person: Joe Gregorio
+PackageSupplier: Person: Joe_Gregorio
 PackageVersion: 0.20.4
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -307,23 +331,25 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/httplib2@0.20.4
+##### 
 
 PackageName: pyparsing
 SPDXID: SPDXRef-Package-26-pyparsing
-PackageSupplier: Person:
+PackageSupplier: NOASSERTION
 PackageVersion: 3.0.9
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
-##### Reported license
+##### Reported license 
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyparsing@3.0.9
+##### 
 
 PackageName: oauth2client
 SPDXID: SPDXRef-Package-27-oauth2client
-PackageSupplier: Person: Google Inc.
+PackageSupplier: Person: Google_Inc.
 PackageVersion: 4.1.3
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -331,11 +357,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/oauth2client@4.1.3
+##### 
 
 PackageName: pyasn1
 SPDXID: SPDXRef-Package-28-pyasn1
-PackageSupplier: Person: Ilya Etingof
+PackageSupplier: Person: Ilya_Etingof
 PackageVersion: 0.4.8
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -343,11 +370,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1@0.4.8
+##### 
 
 PackageName: pyasn1-modules
 SPDXID: SPDXRef-Package-29-pyasn1-modules
-PackageSupplier: Person: Ilya Etingof
+PackageSupplier: Person: Ilya_Etingof
 PackageVersion: 0.2.8
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -355,11 +383,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: BSD-2-Clause
 PackageLicenseDeclared: BSD-2-Clause
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1-modules@0.2.8
+##### 
 
 PackageName: rsa
 SPDXID: SPDXRef-Package-30-rsa
-PackageSupplier: Organization: Sybren A. Stuvel
+PackageSupplier: Organization: Sybren_A._Stuvel
 PackageVersion: 4.7.2
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -367,35 +396,38 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rsa@4.7.2
+##### 
 
 PackageName: pyopenssl
 SPDXID: SPDXRef-Package-31-pyopenssl
-PackageSupplier: Organization: The pyOpenSSL developers
-PackageVersion: 22.0.0
+PackageSupplier: Organization: The_pyOpenSSL_developers
+PackageVersion: 23.0.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache License, Version 2.0
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyopenssl@23.0.0
+##### 
 
 PackageName: cryptography
 SPDXID: SPDXRef-Package-32-cryptography
-PackageSupplier: Organization: The Python Cryptographic Authority and individual contributors
-PackageVersion: 37.0.4
+PackageSupplier: Organization: The_Python_Cryptographic_Authority_and_individual_contributors
+PackageVersion: 39.0.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
-##### Reported license BSD-3-Clause OR Apache-2.0
+##### Reported license (Apache-2.0 OR BSD-3-Clause) AND PSF-2.0
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@39.0.0
+##### 
 
 PackageName: cffi
 SPDXID: SPDXRef-Package-33-cffi
-PackageSupplier: Organization: Armin Rigo, Maciej Fijalkowski
+PackageSupplier: Organization: Armin_Rigo,_Maciej_Fijalkowski
 PackageVersion: 1.15.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -403,11 +435,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cffi@1.15.1
+##### 
 
 PackageName: pycparser
 SPDXID: SPDXRef-Package-34-pycparser
-PackageSupplier: Person: Eli Bendersky
+PackageSupplier: Person: Eli_Bendersky
 PackageVersion: 2.21
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -415,11 +448,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pycparser@2.21
+##### 
 
 PackageName: retry-decorator
 SPDXID: SPDXRef-Package-35-retry-decorator
-PackageSupplier: Person: Patrick Ng
+PackageSupplier: Person: Patrick_Ng
 PackageVersion: 1.1.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -427,11 +461,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/retry-decorator@1.1.1
+##### 
 
 PackageName: google-apitools
 SPDXID: SPDXRef-Package-36-google-apitools
-PackageSupplier: Person: Craig Citro
+PackageSupplier: Person: Craig_Citro
 PackageVersion: 0.5.32
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -439,23 +474,25 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-apitools@0.5.32
+##### 
 
 PackageName: google-auth
 SPDXID: SPDXRef-Package-37-google-auth
-PackageSupplier: Organization: Google Cloud Platform
-PackageVersion: 2.11.0
+PackageSupplier: Organization: Google_Cloud_Platform
+PackageVersion: 2.15.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache 2.0
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.15.0
+##### 
 
 PackageName: cachetools
 SPDXID: SPDXRef-Package-38-cachetools
-PackageSupplier: Person: Thomas Kemmer
+PackageSupplier: Person: Thomas_Kemmer
 PackageVersion: 5.2.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -463,11 +500,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cachetools@5.2.0
+##### 
 
 PackageName: monotonic
 SPDXID: SPDXRef-Package-39-monotonic
-PackageSupplier: Person: Ori Livneh
+PackageSupplier: Person: Ori_Livneh
 PackageVersion: 1.6
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -475,11 +513,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/monotonic@1.6
+##### 
 
 PackageName: jinja2
 SPDXID: SPDXRef-Package-40-jinja2
-PackageSupplier: Person: Armin Ronacher
+PackageSupplier: Person: Armin_Ronacher
 PackageVersion: 3.1.2
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -487,11 +526,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: BSD-3-Clause
 PackageLicenseDeclared: BSD-3-Clause
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jinja2@3.1.2
+##### 
 
 PackageName: markupsafe
 SPDXID: SPDXRef-Package-41-markupsafe
-PackageSupplier: Person: Armin Ronacher
+PackageSupplier: Person: Armin_Ronacher
 PackageVersion: 2.1.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -499,35 +539,38 @@ FilesAnalyzed: false
 PackageLicenseConcluded: BSD-3-Clause
 PackageLicenseDeclared: BSD-3-Clause
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.1
+##### 
 
 PackageName: jsonschema
 SPDXID: SPDXRef-Package-42-jsonschema
-PackageSupplier: Person: Julian Berman
-PackageVersion: 4.14.0
+PackageSupplier: Person: Julian_Berman
+PackageVersion: 4.17.3
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MIT
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.17.3
+##### 
 
 PackageName: pyrsistent
 SPDXID: SPDXRef-Package-43-pyrsistent
-PackageSupplier: Person: Tobias Gustafsson
-PackageVersion: 0.18.1
+PackageSupplier: Person: Tobias_Gustafsson
+PackageVersion: 0.19.3
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MIT
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyrsistent@0.19.3
+##### 
 
 PackageName: packaging
 SPDXID: SPDXRef-Package-44-packaging
-PackageSupplier: Organization: Donald Stufft and individual contributors
+PackageSupplier: Organization: Donald_Stufft_and_individual_contributors
 PackageVersion: 21.3
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -535,35 +578,38 @@ FilesAnalyzed: false
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/packaging@21.3
+##### 
 
 PackageName: plotly
 SPDXID: SPDXRef-Package-45-plotly
-PackageSupplier: Person: Chris P
-PackageVersion: 5.10.0
+PackageSupplier: Person: Chris_P
+PackageVersion: 5.11.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MIT
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/plotly@5.11.0
+##### 
 
 PackageName: tenacity
 SPDXID: SPDXRef-Package-46-tenacity
-PackageSupplier: Person: Julien Danjou
-PackageVersion: 8.0.1
+PackageSupplier: Person: Julien_Danjou
+PackageVersion: 8.1.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license Apache 2.0
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/tenacity@8.1.0
+##### 
 
 PackageName: pyyaml
 SPDXID: SPDXRef-Package-47-pyyaml
-PackageSupplier: Person: Kirill Simonov
+PackageSupplier: Person: Kirill_Simonov
 PackageVersion: 6.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -571,11 +617,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
+##### 
 
 PackageName: requests
 SPDXID: SPDXRef-Package-48-requests
-PackageSupplier: Person: Kenneth Reitz
+PackageSupplier: Person: Kenneth_Reitz
 PackageVersion: 2.28.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -583,47 +630,51 @@ FilesAnalyzed: false
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseDeclared: Apache-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/requests@2.28.1
+##### 
 
 PackageName: certifi
 SPDXID: SPDXRef-Package-49-certifi
-PackageSupplier: Person: Kenneth Reitz
-PackageVersion: 2022.6.15
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2022.12.7
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MPL-2.0
 PackageLicenseConcluded: MPL-2.0
 PackageLicenseDeclared: MPL-2.0
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2022.12.7
+##### 
 
 PackageName: urllib3
 SPDXID: SPDXRef-Package-50-urllib3
-PackageSupplier: Person: Andrey Petrov
-PackageVersion: 1.26.12
+PackageSupplier: Person: Andrey_Petrov
+PackageVersion: 1.26.13
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MIT
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/urllib3@1.26.13
+##### 
 
 PackageName: rich
 SPDXID: SPDXRef-Package-51-rich
-PackageSupplier: Person: Will McGugan
-PackageVersion: 12.5.1
+PackageSupplier: Person: Will_McGugan
+PackageVersion: 13.0.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MIT
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rich@13.0.0
+##### 
 
 PackageName: commonmark
 SPDXID: SPDXRef-Package-52-commonmark
-PackageSupplier: Organization: Bibek Kafle <bkafle662@gmail.com>, Roland Shoemaker <rolandshoemaker@gmail.com>
+PackageSupplier: Organization: Bibek_Kafle_<bkafle662@gmail.com>,_Roland_Shoemaker_<rolandshoemaker@gmail.com>
 PackageVersion: 0.9.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -631,23 +682,25 @@ FilesAnalyzed: false
 PackageLicenseConcluded: BSD-3-Clause
 PackageLicenseDeclared: BSD-3-Clause
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/commonmark@0.9.1
+##### 
 
 PackageName: pygments
 SPDXID: SPDXRef-Package-53-pygments
-PackageSupplier: Person: Georg Brandl
-PackageVersion: 2.13.0
+PackageSupplier: Person: Georg_Brandl
+PackageVersion: 2.14.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
-##### Reported license BSD License
-PackageLicenseConcluded: NOASSERTION
-PackageLicenseDeclared: NOASSERTION
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pygments@2.14.0
+##### 
 
 PackageName: rpmfile
 SPDXID: SPDXRef-Package-54-rpmfile
-PackageSupplier: Person: Sean Ross-Ross
+PackageSupplier: Person: Sean_Ross-Ross
 PackageVersion: 1.0.8
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -655,11 +708,12 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpmfile@1.0.8
+##### 
 
 PackageName: toml
 SPDXID: SPDXRef-Package-55-toml
-PackageSupplier: Person: William Pearson
+PackageSupplier: Person: William_Pearson
 PackageVersion: 0.10.2
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -667,23 +721,25 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/toml@0.10.2
+##### 
 
 PackageName: xmlschema
 SPDXID: SPDXRef-Package-56-xmlschema
-PackageSupplier: Person: Davide Brunato
-PackageVersion: 2.0.2
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 2.1.1
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license MIT
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/xmlschema@2.1.1
+##### 
 
 PackageName: elementpath
 SPDXID: SPDXRef-Package-57-elementpath
-PackageSupplier: Person: Davide Brunato
+PackageSupplier: Person: Davide_Brunato
 PackageVersion: 3.0.2
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
@@ -691,18 +747,20 @@ FilesAnalyzed: false
 PackageLicenseConcluded: MIT
 PackageLicenseDeclared: MIT
 PackageCopyrightText: NOASSERTION
-#####
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/elementpath@3.0.2
+##### 
 
 PackageName: zstandard
 SPDXID: SPDXRef-Package-58-zstandard
-PackageSupplier: Person: Gregory Szorc
-PackageVersion: 0.18.0
+PackageSupplier: Person: Gregory_Szorc
+PackageVersion: 0.19.0
 PackageDownloadLocation: NOASSERTION
 FilesAnalyzed: false
 ##### Reported license BSD
 PackageLicenseConcluded: NOASSERTION
 PackageLicenseDeclared: NOASSERTION
 PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zstandard@0.19.0
 Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1-cve-bin-tool
 Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-11-beautifulsoup4
 Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-13-cvss

--- a/sbom/cve-bin-tool-py3.11.json
+++ b/sbom/cve-bin-tool-py3.11.json
@@ -1,0 +1,1097 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid44df97ba-2a0d-4fbb-b836-d3a16e801a41",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-01-02T23:37:09Z",
+    "tools": [
+      {
+        "name": "sbom4python",
+        "version": "0.4.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "application",
+      "bom-ref": "1-cve-bin-tool",
+      "name": "cve-bin-tool",
+      "version": "3.2.1.dev0",
+      "author": "Terri Oda",
+      "cpe": "cpe:/a:terri_oda:cve-bin-tool:3.2.1.dev0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0-or-later",
+            "url": "https://www.gnu.org/licenses/gpl-3.0-standalone.html"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cve-bin-tool@3.2.1.dev0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "2-aiohttp",
+      "name": "aiohttp",
+      "version": "3.8.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp@3.8.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "3-aiosignal",
+      "name": "aiosignal",
+      "version": "1.3.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiosignal@1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "4-frozenlist",
+      "name": "frozenlist",
+      "version": "1.3.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/frozenlist@1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "5-async-timeout",
+      "name": "async-timeout",
+      "version": "4.0.2",
+      "author": "Andrew Svetlov <andrew.svetlov@gmail.com>",
+      "cpe": "cpe:/a:andrew_svetlov_<andrew.svetlov@gmail.com>:async-timeout:4.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/async-timeout@4.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "6-attrs",
+      "name": "attrs",
+      "version": "22.2.0",
+      "author": "Hynek Schlawack",
+      "cpe": "cpe:/a:hynek_schlawack:attrs:22.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/attrs@22.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "7-charset-normalizer",
+      "name": "charset-normalizer",
+      "version": "2.1.1",
+      "author": "Ahmed TAHRI @Ousret",
+      "cpe": "cpe:/a:ahmed_tahri_@ousret:charset-normalizer:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "8-multidict",
+      "name": "multidict",
+      "version": "6.0.4",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:multidict:6.0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/multidict@6.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "9-yarl",
+      "name": "yarl",
+      "version": "1.8.2",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:yarl:1.8.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/yarl@1.8.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "10-idna",
+      "name": "idna",
+      "version": "3.4",
+      "purl": "pkg:pypi/idna@3.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "11-beautifulsoup4",
+      "name": "beautifulsoup4",
+      "version": "4.11.1",
+      "author": "Leonard Richardson",
+      "cpe": "cpe:/a:leonard_richardson:beautifulsoup4:4.11.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/beautifulsoup4@4.11.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "12-soupsieve",
+      "name": "soupsieve",
+      "version": "2.3.2.post1",
+      "purl": "pkg:pypi/soupsieve@2.3.2.post1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "13-cvss",
+      "name": "cvss",
+      "version": "2.5",
+      "author": "Stanislav Kontar, Red Hat Product Security",
+      "cpe": "cpe:/a:stanislav_kontar,_red_hat_product_security:cvss:2.5",
+      "purl": "pkg:pypi/cvss@2.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "14-defusedxml",
+      "name": "defusedxml",
+      "version": "0.7.1",
+      "author": "Christian Heimes",
+      "cpe": "cpe:/a:christian_heimes:defusedxml:0.7.1",
+      "purl": "pkg:pypi/defusedxml@0.7.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "15-distro",
+      "name": "distro",
+      "version": "1.8.0",
+      "author": "Nir Cohen",
+      "cpe": "cpe:/a:nir_cohen:distro:1.8.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/distro@1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "16-gsutil",
+      "name": "gsutil",
+      "version": "5.17",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gsutil:5.17",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gsutil@5.17"
+    },
+    {
+      "type": "library",
+      "bom-ref": "17-argcomplete",
+      "name": "argcomplete",
+      "version": "2.0.0",
+      "author": "Andrey Kislyuk",
+      "cpe": "cpe:/a:andrey_kislyuk:argcomplete:2.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/argcomplete@2.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "18-crcmod",
+      "name": "crcmod",
+      "version": "1.7",
+      "author": "Ray Buvel",
+      "cpe": "cpe:/a:ray_buvel:crcmod:1.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/crcmod@1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "19-fasteners",
+      "name": "fasteners",
+      "version": "0.18",
+      "author": "Joshua Harlow",
+      "cpe": "cpe:/a:joshua_harlow:fasteners:0.18",
+      "purl": "pkg:pypi/fasteners@0.18"
+    },
+    {
+      "type": "library",
+      "bom-ref": "20-gcs-oauth2-boto-plugin",
+      "name": "gcs-oauth2-boto-plugin",
+      "version": "3.0",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gcs-oauth2-boto-plugin:3.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gcs-oauth2-boto-plugin@3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "21-boto",
+      "name": "boto",
+      "version": "2.49.0",
+      "author": "Mitch Garnaat",
+      "cpe": "cpe:/a:mitch_garnaat:boto:2.49.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/boto@2.49.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "22-google-reauth",
+      "name": "google-reauth",
+      "version": "0.1.1",
+      "author": "Google",
+      "cpe": "cpe:/a:google:google-reauth:0.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-reauth@0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "23-pyu2f",
+      "name": "pyu2f",
+      "version": "0.1.5",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:pyu2f:0.1.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyu2f@0.1.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "24-six",
+      "name": "six",
+      "version": "1.16.0",
+      "author": "Benjamin Peterson",
+      "cpe": "cpe:/a:benjamin_peterson:six:1.16.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "25-httplib2",
+      "name": "httplib2",
+      "version": "0.20.4",
+      "author": "Joe Gregorio",
+      "cpe": "cpe:/a:joe_gregorio:httplib2:0.20.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/httplib2@0.20.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "26-pyparsing",
+      "name": "pyparsing",
+      "version": "3.0.9",
+      "purl": "pkg:pypi/pyparsing@3.0.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "27-oauth2client",
+      "name": "oauth2client",
+      "version": "4.1.3",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:oauth2client:4.1.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/oauth2client@4.1.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "28-pyasn1",
+      "name": "pyasn1",
+      "version": "0.4.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1:0.4.8",
+      "purl": "pkg:pypi/pyasn1@0.4.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "29-pyasn1-modules",
+      "name": "pyasn1-modules",
+      "version": "0.2.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1-modules:0.2.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1-modules@0.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "30-rsa",
+      "name": "rsa",
+      "version": "4.7.2",
+      "author": "Sybren A. Stuvel",
+      "cpe": "cpe:/a:sybren_a._stuvel:rsa:4.7.2",
+      "purl": "pkg:pypi/rsa@4.7.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "31-pyopenssl",
+      "name": "pyopenssl",
+      "version": "23.0.0",
+      "author": "The pyOpenSSL developers",
+      "cpe": "cpe:/a:the_pyopenssl_developers:pyopenssl:23.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyopenssl@23.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "32-cryptography",
+      "name": "cryptography",
+      "version": "39.0.0",
+      "author": "The Python Cryptographic Authority and individual contributors",
+      "cpe": "cpe:/a:the_python_cryptographic_authority_and_individual_contributors:cryptography:39.0.0",
+      "purl": "pkg:pypi/cryptography@39.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "33-cffi",
+      "name": "cffi",
+      "version": "1.15.1",
+      "author": "Armin Rigo, Maciej Fijalkowski",
+      "cpe": "cpe:/a:armin_rigo,_maciej_fijalkowski:cffi:1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cffi@1.15.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "34-pycparser",
+      "name": "pycparser",
+      "version": "2.21",
+      "author": "Eli Bendersky",
+      "cpe": "cpe:/a:eli_bendersky:pycparser:2.21",
+      "purl": "pkg:pypi/pycparser@2.21"
+    },
+    {
+      "type": "library",
+      "bom-ref": "35-retry-decorator",
+      "name": "retry-decorator",
+      "version": "1.1.1",
+      "author": "Patrick Ng",
+      "cpe": "cpe:/a:patrick_ng:retry-decorator:1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/retry-decorator@1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "36-google-apitools",
+      "name": "google-apitools",
+      "version": "0.5.32",
+      "author": "Craig Citro",
+      "cpe": "cpe:/a:craig_citro:google-apitools:0.5.32",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-apitools@0.5.32"
+    },
+    {
+      "type": "library",
+      "bom-ref": "37-google-auth",
+      "name": "google-auth",
+      "version": "2.15.0",
+      "author": "Google Cloud Platform",
+      "cpe": "cpe:/a:google_cloud_platform:google-auth:2.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-auth@2.15.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "38-cachetools",
+      "name": "cachetools",
+      "version": "5.2.0",
+      "author": "Thomas Kemmer",
+      "cpe": "cpe:/a:thomas_kemmer:cachetools:5.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cachetools@5.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "39-monotonic",
+      "name": "monotonic",
+      "version": "1.6",
+      "author": "Ori Livneh",
+      "cpe": "cpe:/a:ori_livneh:monotonic:1.6",
+      "purl": "pkg:pypi/monotonic@1.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "40-jinja2",
+      "name": "jinja2",
+      "version": "3.1.2",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:jinja2:3.1.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jinja2@3.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "41-markupsafe",
+      "name": "markupsafe",
+      "version": "2.1.1",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:markupsafe:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/markupsafe@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "42-jsonschema",
+      "name": "jsonschema",
+      "version": "4.17.3",
+      "author": "Julian Berman",
+      "cpe": "cpe:/a:julian_berman:jsonschema:4.17.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.17.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "43-pyrsistent",
+      "name": "pyrsistent",
+      "version": "0.19.3",
+      "author": "Tobias Gustafsson",
+      "cpe": "cpe:/a:tobias_gustafsson:pyrsistent:0.19.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyrsistent@0.19.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "44-packaging",
+      "name": "packaging",
+      "version": "21.3",
+      "author": "Donald Stufft and individual contributors",
+      "cpe": "cpe:/a:donald_stufft_and_individual_contributors:packaging:21.3",
+      "purl": "pkg:pypi/packaging@21.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "45-plotly",
+      "name": "plotly",
+      "version": "5.11.0",
+      "author": "Chris P",
+      "cpe": "cpe:/a:chris_p:plotly:5.11.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/plotly@5.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "46-tenacity",
+      "name": "tenacity",
+      "version": "8.1.0",
+      "author": "Julien Danjou",
+      "cpe": "cpe:/a:julien_danjou:tenacity:8.1.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/tenacity@8.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "47-pyyaml",
+      "name": "pyyaml",
+      "version": "6.0",
+      "author": "Kirill Simonov",
+      "cpe": "cpe:/a:kirill_simonov:pyyaml:6.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyyaml@6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "48-requests",
+      "name": "requests",
+      "version": "2.28.1",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:requests:2.28.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.28.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "49-certifi",
+      "name": "certifi",
+      "version": "2022.12.7",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:certifi:2022.12.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "url": "https://www.mozilla.org/MPL/2.0/"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2022.12.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "50-urllib3",
+      "name": "urllib3",
+      "version": "1.26.13",
+      "author": "Andrey Petrov",
+      "cpe": "cpe:/a:andrey_petrov:urllib3:1.26.13",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@1.26.13"
+    },
+    {
+      "type": "library",
+      "bom-ref": "51-rich",
+      "name": "rich",
+      "version": "13.0.0",
+      "author": "Will McGugan",
+      "cpe": "cpe:/a:will_mcgugan:rich:13.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rich@13.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "52-commonmark",
+      "name": "commonmark",
+      "version": "0.9.1",
+      "author": "Bibek Kafle <bkafle662@gmail.com>, Roland Shoemaker <rolandshoemaker@gmail.com>",
+      "cpe": "cpe:/a:bibek_kafle_<bkafle662@gmail.com>,_roland_shoemaker_<rolandshoemaker@gmail.com>:commonmark:0.9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/commonmark@0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "53-pygments",
+      "name": "pygments",
+      "version": "2.14.0",
+      "author": "Georg Brandl",
+      "cpe": "cpe:/a:georg_brandl:pygments:2.14.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pygments@2.14.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "54-rpmfile",
+      "name": "rpmfile",
+      "version": "1.0.8",
+      "author": "Sean Ross-Ross",
+      "cpe": "cpe:/a:sean_ross-ross:rpmfile:1.0.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rpmfile@1.0.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "55-toml",
+      "name": "toml",
+      "version": "0.10.2",
+      "author": "William Pearson",
+      "cpe": "cpe:/a:william_pearson:toml:0.10.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "56-xmlschema",
+      "name": "xmlschema",
+      "version": "2.1.1",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:xmlschema:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/xmlschema@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "57-elementpath",
+      "name": "elementpath",
+      "version": "3.0.2",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:elementpath:3.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/elementpath@3.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "58-zstandard",
+      "name": "zstandard",
+      "version": "0.19.0",
+      "author": "Gregory Szorc",
+      "cpe": "cpe:/a:gregory_szorc:zstandard:0.19.0",
+      "purl": "pkg:pypi/zstandard@0.19.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "1-cve-bin-tool",
+      "dependsOn": [
+        "2-aiohttp",
+        "11-beautifulsoup4",
+        "13-cvss",
+        "14-defusedxml",
+        "15-distro",
+        "16-gsutil",
+        "40-jinja2",
+        "42-jsonschema",
+        "44-packaging",
+        "45-plotly",
+        "47-pyyaml",
+        "48-requests",
+        "51-rich",
+        "54-rpmfile",
+        "55-toml",
+        "50-urllib3",
+        "56-xmlschema",
+        "58-zstandard"
+      ]
+    },
+    {
+      "ref": "2-aiohttp",
+      "dependsOn": [
+        "3-aiosignal",
+        "5-async-timeout",
+        "6-attrs",
+        "7-charset-normalizer",
+        "4-frozenlist",
+        "8-multidict",
+        "9-yarl"
+      ]
+    },
+    {
+      "ref": "3-aiosignal",
+      "dependsOn": [
+        "4-frozenlist"
+      ]
+    },
+    {
+      "ref": "9-yarl",
+      "dependsOn": [
+        "10-idna",
+        "8-multidict"
+      ]
+    },
+    {
+      "ref": "11-beautifulsoup4",
+      "dependsOn": [
+        "12-soupsieve"
+      ]
+    },
+    {
+      "ref": "16-gsutil",
+      "dependsOn": [
+        "17-argcomplete",
+        "18-crcmod",
+        "19-fasteners",
+        "20-gcs-oauth2-boto-plugin",
+        "36-google-apitools",
+        "37-google-auth",
+        "22-google-reauth",
+        "25-httplib2",
+        "39-monotonic",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "20-gcs-oauth2-boto-plugin",
+      "dependsOn": [
+        "21-boto",
+        "22-google-reauth",
+        "25-httplib2",
+        "27-oauth2client",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "22-google-reauth",
+      "dependsOn": [
+        "23-pyu2f"
+      ]
+    },
+    {
+      "ref": "23-pyu2f",
+      "dependsOn": [
+        "24-six"
+      ]
+    },
+    {
+      "ref": "25-httplib2",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "27-oauth2client",
+      "dependsOn": [
+        "25-httplib2",
+        "28-pyasn1",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "29-pyasn1-modules",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "30-rsa",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "31-pyopenssl",
+      "dependsOn": [
+        "32-cryptography"
+      ]
+    },
+    {
+      "ref": "32-cryptography",
+      "dependsOn": [
+        "33-cffi"
+      ]
+    },
+    {
+      "ref": "33-cffi",
+      "dependsOn": [
+        "34-pycparser"
+      ]
+    },
+    {
+      "ref": "36-google-apitools",
+      "dependsOn": [
+        "19-fasteners",
+        "25-httplib2",
+        "27-oauth2client",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "37-google-auth",
+      "dependsOn": [
+        "38-cachetools",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "40-jinja2",
+      "dependsOn": [
+        "41-markupsafe"
+      ]
+    },
+    {
+      "ref": "42-jsonschema",
+      "dependsOn": [
+        "6-attrs",
+        "43-pyrsistent"
+      ]
+    },
+    {
+      "ref": "44-packaging",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "45-plotly",
+      "dependsOn": [
+        "46-tenacity"
+      ]
+    },
+    {
+      "ref": "48-requests",
+      "dependsOn": [
+        "49-certifi",
+        "7-charset-normalizer",
+        "10-idna",
+        "50-urllib3"
+      ]
+    },
+    {
+      "ref": "51-rich",
+      "dependsOn": [
+        "52-commonmark",
+        "53-pygments"
+      ]
+    },
+    {
+      "ref": "56-xmlschema",
+      "dependsOn": [
+        "57-elementpath"
+      ]
+    }
+  ]
+}

--- a/sbom/cve-bin-tool-py3.11.spdx
+++ b/sbom/cve-bin-tool-py3.11.spdx
@@ -1,0 +1,846 @@
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: cve-bin-tool
+DocumentNamespace: http://spdx.org/spdxdocs/cve-bin-tool-9e355190-e497-42b0-ae2a-f2bb05d8796e
+LicenseListVersion: 3.18
+Creator: Tool: sbom4python-0.4.0
+Created: 2023-01-02T23:36:08Z
+CreatorComment: <text>This document has been automatically generated.</text>
+##### 
+
+PackageName: cve-bin-tool
+SPDXID: SPDXRef-Package-1-cve-bin-tool
+PackageSupplier: Person: Terri_Oda
+PackageVersion: 3.2.1.dev0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license GPL-3.0-or-later
+PackageLicenseConcluded: GPL-3.0-or-later
+PackageLicenseDeclared: GPL-3.0-or-later
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cve-bin-tool@3.2.1.dev0
+##### 
+
+PackageName: aiohttp
+SPDXID: SPDXRef-Package-2-aiohttp
+PackageSupplier: NOASSERTION
+PackageVersion: 3.8.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.3
+##### 
+
+PackageName: aiosignal
+SPDXID: SPDXRef-Package-3-aiosignal
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
+##### 
+
+PackageName: frozenlist
+SPDXID: SPDXRef-Package-4-frozenlist
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+##### 
+
+PackageName: async-timeout
+SPDXID: SPDXRef-Package-5-async-timeout
+PackageSupplier: Organization: Andrew_Svetlov_<andrew.svetlov@gmail.com>
+PackageVersion: 4.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/async-timeout@4.0.2
+##### 
+
+PackageName: attrs
+SPDXID: SPDXRef-Package-6-attrs
+PackageSupplier: Person: Hynek_Schlawack
+PackageVersion: 22.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/attrs@22.2.0
+##### 
+
+PackageName: charset-normalizer
+SPDXID: SPDXRef-Package-7-charset-normalizer
+PackageSupplier: Organization: Ahmed_TAHRI_@Ousret
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/charset-normalizer@2.1.1
+##### 
+
+PackageName: multidict
+SPDXID: SPDXRef-Package-8-multidict
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 6.0.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/multidict@6.0.4
+##### 
+
+PackageName: yarl
+SPDXID: SPDXRef-Package-9-yarl
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 1.8.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/yarl@1.8.2
+##### 
+
+PackageName: idna
+SPDXID: SPDXRef-Package-10-idna
+PackageSupplier: NOASSERTION
+PackageVersion: 3.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/idna@3.4
+##### 
+
+PackageName: beautifulsoup4
+SPDXID: SPDXRef-Package-11-beautifulsoup4
+PackageSupplier: Person: Leonard_Richardson
+PackageVersion: 4.11.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/beautifulsoup4@4.11.1
+##### 
+
+PackageName: soupsieve
+SPDXID: SPDXRef-Package-12-soupsieve
+PackageSupplier: NOASSERTION
+PackageVersion: 2.3.2.post1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/soupsieve@2.3.2.post1
+##### 
+
+PackageName: cvss
+SPDXID: SPDXRef-Package-13-cvss
+PackageSupplier: Organization: Stanislav_Kontar,_Red_Hat_Product_Security
+PackageVersion: 2.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license LGPLv3+
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cvss@2.5
+##### 
+
+PackageName: defusedxml
+SPDXID: SPDXRef-Package-14-defusedxml
+PackageSupplier: Person: Christian_Heimes
+PackageVersion: 0.7.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license PSFL
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/defusedxml@0.7.1
+##### 
+
+PackageName: distro
+SPDXID: SPDXRef-Package-15-distro
+PackageSupplier: Person: Nir_Cohen
+PackageVersion: 1.8.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/distro@1.8.0
+##### 
+
+PackageName: gsutil
+SPDXID: SPDXRef-Package-16-gsutil
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 5.17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gsutil@5.17
+##### 
+
+PackageName: argcomplete
+SPDXID: SPDXRef-Package-17-argcomplete
+PackageSupplier: Person: Andrey_Kislyuk
+PackageVersion: 2.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache Software License
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/argcomplete@2.0.0
+##### 
+
+PackageName: crcmod
+SPDXID: SPDXRef-Package-18-crcmod
+PackageSupplier: Person: Ray_Buvel
+PackageVersion: 1.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/crcmod@1.7
+##### 
+
+PackageName: fasteners
+SPDXID: SPDXRef-Package-19-fasteners
+PackageSupplier: Person: Joshua_Harlow
+PackageVersion: 0.18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/fasteners@0.18
+##### 
+
+PackageName: gcs-oauth2-boto-plugin
+SPDXID: SPDXRef-Package-20-gcs-oauth2-boto-plugin
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 3.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gcs-oauth2-boto-plugin@3.0
+##### 
+
+PackageName: boto
+SPDXID: SPDXRef-Package-21-boto
+PackageSupplier: Person: Mitch_Garnaat
+PackageVersion: 2.49.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/boto@2.49.0
+##### 
+
+PackageName: google-reauth
+SPDXID: SPDXRef-Package-22-google-reauth
+PackageSupplier: Person: Google
+PackageVersion: 0.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-reauth@0.1.1
+##### 
+
+PackageName: pyu2f
+SPDXID: SPDXRef-Package-23-pyu2f
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 0.1.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyu2f@0.1.5
+##### 
+
+PackageName: six
+SPDXID: SPDXRef-Package-24-six
+PackageSupplier: Person: Benjamin_Peterson
+PackageVersion: 1.16.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/six@1.16.0
+##### 
+
+PackageName: httplib2
+SPDXID: SPDXRef-Package-25-httplib2
+PackageSupplier: Person: Joe_Gregorio
+PackageVersion: 0.20.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/httplib2@0.20.4
+##### 
+
+PackageName: pyparsing
+SPDXID: SPDXRef-Package-26-pyparsing
+PackageSupplier: NOASSERTION
+PackageVersion: 3.0.9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyparsing@3.0.9
+##### 
+
+PackageName: oauth2client
+SPDXID: SPDXRef-Package-27-oauth2client
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 4.1.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/oauth2client@4.1.3
+##### 
+
+PackageName: pyasn1
+SPDXID: SPDXRef-Package-28-pyasn1
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.4.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1@0.4.8
+##### 
+
+PackageName: pyasn1-modules
+SPDXID: SPDXRef-Package-29-pyasn1-modules
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.2.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1-modules@0.2.8
+##### 
+
+PackageName: rsa
+SPDXID: SPDXRef-Package-30-rsa
+PackageSupplier: Organization: Sybren_A._Stuvel
+PackageVersion: 4.7.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rsa@4.7.2
+##### 
+
+PackageName: pyopenssl
+SPDXID: SPDXRef-Package-31-pyopenssl
+PackageSupplier: Organization: The_pyOpenSSL_developers
+PackageVersion: 23.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyopenssl@23.0.0
+##### 
+
+PackageName: cryptography
+SPDXID: SPDXRef-Package-32-cryptography
+PackageSupplier: Organization: The_Python_Cryptographic_Authority_and_individual_contributors
+PackageVersion: 39.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license (Apache-2.0 OR BSD-3-Clause) AND PSF-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@39.0.0
+##### 
+
+PackageName: cffi
+SPDXID: SPDXRef-Package-33-cffi
+PackageSupplier: Organization: Armin_Rigo,_Maciej_Fijalkowski
+PackageVersion: 1.15.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cffi@1.15.1
+##### 
+
+PackageName: pycparser
+SPDXID: SPDXRef-Package-34-pycparser
+PackageSupplier: Person: Eli_Bendersky
+PackageVersion: 2.21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pycparser@2.21
+##### 
+
+PackageName: retry-decorator
+SPDXID: SPDXRef-Package-35-retry-decorator
+PackageSupplier: Person: Patrick_Ng
+PackageVersion: 1.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/retry-decorator@1.1.1
+##### 
+
+PackageName: google-apitools
+SPDXID: SPDXRef-Package-36-google-apitools
+PackageSupplier: Person: Craig_Citro
+PackageVersion: 0.5.32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-apitools@0.5.32
+##### 
+
+PackageName: google-auth
+SPDXID: SPDXRef-Package-37-google-auth
+PackageSupplier: Organization: Google_Cloud_Platform
+PackageVersion: 2.15.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.15.0
+##### 
+
+PackageName: cachetools
+SPDXID: SPDXRef-Package-38-cachetools
+PackageSupplier: Person: Thomas_Kemmer
+PackageVersion: 5.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cachetools@5.2.0
+##### 
+
+PackageName: monotonic
+SPDXID: SPDXRef-Package-39-monotonic
+PackageSupplier: Person: Ori_Livneh
+PackageVersion: 1.6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/monotonic@1.6
+##### 
+
+PackageName: jinja2
+SPDXID: SPDXRef-Package-40-jinja2
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 3.1.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jinja2@3.1.2
+##### 
+
+PackageName: markupsafe
+SPDXID: SPDXRef-Package-41-markupsafe
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.1
+##### 
+
+PackageName: jsonschema
+SPDXID: SPDXRef-Package-42-jsonschema
+PackageSupplier: Person: Julian_Berman
+PackageVersion: 4.17.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.17.3
+##### 
+
+PackageName: pyrsistent
+SPDXID: SPDXRef-Package-43-pyrsistent
+PackageSupplier: Person: Tobias_Gustafsson
+PackageVersion: 0.19.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyrsistent@0.19.3
+##### 
+
+PackageName: packaging
+SPDXID: SPDXRef-Package-44-packaging
+PackageSupplier: Organization: Donald_Stufft_and_individual_contributors
+PackageVersion: 21.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause or Apache-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/packaging@21.3
+##### 
+
+PackageName: plotly
+SPDXID: SPDXRef-Package-45-plotly
+PackageSupplier: Person: Chris_P
+PackageVersion: 5.11.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/plotly@5.11.0
+##### 
+
+PackageName: tenacity
+SPDXID: SPDXRef-Package-46-tenacity
+PackageSupplier: Person: Julien_Danjou
+PackageVersion: 8.1.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/tenacity@8.1.0
+##### 
+
+PackageName: pyyaml
+SPDXID: SPDXRef-Package-47-pyyaml
+PackageSupplier: Person: Kirill_Simonov
+PackageVersion: 6.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
+##### 
+
+PackageName: requests
+SPDXID: SPDXRef-Package-48-requests
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2.28.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/requests@2.28.1
+##### 
+
+PackageName: certifi
+SPDXID: SPDXRef-Package-49-certifi
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2022.12.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MPL-2.0
+PackageLicenseConcluded: MPL-2.0
+PackageLicenseDeclared: MPL-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2022.12.7
+##### 
+
+PackageName: urllib3
+SPDXID: SPDXRef-Package-50-urllib3
+PackageSupplier: Person: Andrey_Petrov
+PackageVersion: 1.26.13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/urllib3@1.26.13
+##### 
+
+PackageName: rich
+SPDXID: SPDXRef-Package-51-rich
+PackageSupplier: Person: Will_McGugan
+PackageVersion: 13.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rich@13.0.0
+##### 
+
+PackageName: commonmark
+SPDXID: SPDXRef-Package-52-commonmark
+PackageSupplier: Organization: Bibek_Kafle_<bkafle662@gmail.com>,_Roland_Shoemaker_<rolandshoemaker@gmail.com>
+PackageVersion: 0.9.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/commonmark@0.9.1
+##### 
+
+PackageName: pygments
+SPDXID: SPDXRef-Package-53-pygments
+PackageSupplier: Person: Georg_Brandl
+PackageVersion: 2.14.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pygments@2.14.0
+##### 
+
+PackageName: rpmfile
+SPDXID: SPDXRef-Package-54-rpmfile
+PackageSupplier: Person: Sean_Ross-Ross
+PackageVersion: 1.0.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpmfile@1.0.8
+##### 
+
+PackageName: toml
+SPDXID: SPDXRef-Package-55-toml
+PackageSupplier: Person: William_Pearson
+PackageVersion: 0.10.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/toml@0.10.2
+##### 
+
+PackageName: xmlschema
+SPDXID: SPDXRef-Package-56-xmlschema
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/xmlschema@2.1.1
+##### 
+
+PackageName: elementpath
+SPDXID: SPDXRef-Package-57-elementpath
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 3.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/elementpath@3.0.2
+##### 
+
+PackageName: zstandard
+SPDXID: SPDXRef-Package-58-zstandard
+PackageSupplier: Person: Gregory_Szorc
+PackageVersion: 0.19.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zstandard@0.19.0
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1-cve-bin-tool
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-11-beautifulsoup4
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-13-cvss
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-14-defusedxml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-15-distro
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-16-gsutil
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-2-aiohttp
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-40-jinja2
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-42-jsonschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-44-packaging
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-45-plotly
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-47-pyyaml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-48-requests
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-50-urllib3
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-51-rich
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-54-rpmfile
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-55-toml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-56-xmlschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-58-zstandard
+Relationship: SPDXRef-Package-11-beautifulsoup4 CONTAINS SPDXRef-Package-12-soupsieve
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-17-argcomplete
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-18-crcmod
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-19-fasteners
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-20-gcs-oauth2-boto-plugin
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-22-google-reauth
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-31-pyopenssl
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-35-retry-decorator
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-36-google-apitools
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-37-google-auth
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-39-monotonic
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-3-aiosignal
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-5-async-timeout
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-6-attrs
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-7-charset-normalizer
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-8-multidict
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-9-yarl
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-21-boto
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-22-google-reauth
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-27-oauth2client
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-31-pyopenssl
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-35-retry-decorator
+Relationship: SPDXRef-Package-22-google-reauth CONTAINS SPDXRef-Package-23-pyu2f
+Relationship: SPDXRef-Package-23-pyu2f CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-25-httplib2 CONTAINS SPDXRef-Package-26-pyparsing
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-29-pyasn1-modules
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-29-pyasn1-modules CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-3-aiosignal CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-30-rsa CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-31-pyopenssl CONTAINS SPDXRef-Package-32-cryptography
+Relationship: SPDXRef-Package-32-cryptography CONTAINS SPDXRef-Package-33-cffi
+Relationship: SPDXRef-Package-33-cffi CONTAINS SPDXRef-Package-34-pycparser
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-19-fasteners
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-27-oauth2client
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-29-pyasn1-modules
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-38-cachetools
+Relationship: SPDXRef-Package-40-jinja2 CONTAINS SPDXRef-Package-41-markupsafe
+Relationship: SPDXRef-Package-42-jsonschema CONTAINS SPDXRef-Package-43-pyrsistent
+Relationship: SPDXRef-Package-42-jsonschema CONTAINS SPDXRef-Package-6-attrs
+Relationship: SPDXRef-Package-44-packaging CONTAINS SPDXRef-Package-26-pyparsing
+Relationship: SPDXRef-Package-45-plotly CONTAINS SPDXRef-Package-46-tenacity
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-10-idna
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-49-certifi
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-50-urllib3
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-7-charset-normalizer
+Relationship: SPDXRef-Package-51-rich CONTAINS SPDXRef-Package-52-commonmark
+Relationship: SPDXRef-Package-51-rich CONTAINS SPDXRef-Package-53-pygments
+Relationship: SPDXRef-Package-56-xmlschema CONTAINS SPDXRef-Package-57-elementpath
+Relationship: SPDXRef-Package-9-yarl CONTAINS SPDXRef-Package-10-idna
+Relationship: SPDXRef-Package-9-yarl CONTAINS SPDXRef-Package-8-multidict

--- a/sbom/cve-bin-tool-py3.7.json
+++ b/sbom/cve-bin-tool-py3.7.json
@@ -1,0 +1,1192 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuide599f266-53ee-4a59-8c3c-8488e39049d0",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-01-03T00:52:04Z",
+    "tools": [
+      {
+        "name": "sbom4python",
+        "version": "0.4.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "application",
+      "bom-ref": "1-cve-bin-tool",
+      "name": "cve-bin-tool",
+      "version": "3.2.1.dev0",
+      "author": "Terri Oda",
+      "cpe": "cpe:/a:terri_oda:cve-bin-tool:3.2.1.dev0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0-or-later",
+            "url": "https://www.gnu.org/licenses/gpl-3.0-standalone.html"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cve-bin-tool@3.2.1.dev0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "2-aiohttp",
+      "name": "aiohttp",
+      "version": "3.8.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp@3.8.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "3-aiosignal",
+      "name": "aiosignal",
+      "version": "1.3.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiosignal@1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "4-frozenlist",
+      "name": "frozenlist",
+      "version": "1.3.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/frozenlist@1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "5-async-timeout",
+      "name": "async-timeout",
+      "version": "4.0.2",
+      "author": "Andrew Svetlov <andrew.svetlov@gmail.com>",
+      "cpe": "cpe:/a:andrew_svetlov_<andrew.svetlov@gmail.com>:async-timeout:4.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/async-timeout@4.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "6-typing-extensions",
+      "name": "typing-extensions",
+      "version": "4.4.0",
+      "purl": "pkg:pypi/typing-extensions@4.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "7-asynctest",
+      "name": "asynctest",
+      "version": "0.13.0",
+      "author": "Martin Richard",
+      "cpe": "cpe:/a:martin_richard:asynctest:0.13.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/asynctest@0.13.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "8-attrs",
+      "name": "attrs",
+      "version": "22.2.0",
+      "author": "Hynek Schlawack",
+      "cpe": "cpe:/a:hynek_schlawack:attrs:22.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/attrs@22.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "9-charset-normalizer",
+      "name": "charset-normalizer",
+      "version": "2.1.1",
+      "author": "Ahmed TAHRI @Ousret",
+      "cpe": "cpe:/a:ahmed_tahri_@ousret:charset-normalizer:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "10-multidict",
+      "name": "multidict",
+      "version": "6.0.4",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:multidict:6.0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/multidict@6.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "11-yarl",
+      "name": "yarl",
+      "version": "1.8.2",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:yarl:1.8.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/yarl@1.8.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "12-idna",
+      "name": "idna",
+      "version": "3.4",
+      "purl": "pkg:pypi/idna@3.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "13-beautifulsoup4",
+      "name": "beautifulsoup4",
+      "version": "4.11.1",
+      "author": "Leonard Richardson",
+      "cpe": "cpe:/a:leonard_richardson:beautifulsoup4:4.11.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/beautifulsoup4@4.11.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "14-soupsieve",
+      "name": "soupsieve",
+      "version": "2.3.2.post1",
+      "purl": "pkg:pypi/soupsieve@2.3.2.post1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "15-cvss",
+      "name": "cvss",
+      "version": "2.5",
+      "author": "Stanislav Kontar, Red Hat Product Security",
+      "cpe": "cpe:/a:stanislav_kontar,_red_hat_product_security:cvss:2.5",
+      "purl": "pkg:pypi/cvss@2.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "16-defusedxml",
+      "name": "defusedxml",
+      "version": "0.7.1",
+      "author": "Christian Heimes",
+      "cpe": "cpe:/a:christian_heimes:defusedxml:0.7.1",
+      "purl": "pkg:pypi/defusedxml@0.7.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "17-distro",
+      "name": "distro",
+      "version": "1.8.0",
+      "author": "Nir Cohen",
+      "cpe": "cpe:/a:nir_cohen:distro:1.8.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/distro@1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "18-gsutil",
+      "name": "gsutil",
+      "version": "5.17",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gsutil:5.17",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gsutil@5.17"
+    },
+    {
+      "type": "library",
+      "bom-ref": "19-argcomplete",
+      "name": "argcomplete",
+      "version": "2.0.0",
+      "author": "Andrey Kislyuk",
+      "cpe": "cpe:/a:andrey_kislyuk:argcomplete:2.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/argcomplete@2.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "20-importlib-metadata",
+      "name": "importlib-metadata",
+      "version": "4.13.0",
+      "author": "Jason R. Coombs",
+      "cpe": "cpe:/a:jason_r._coombs:importlib-metadata:4.13.0",
+      "purl": "pkg:pypi/importlib-metadata@4.13.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "21-zipp",
+      "name": "zipp",
+      "version": "3.11.0",
+      "author": "Jason R. Coombs",
+      "cpe": "cpe:/a:jason_r._coombs:zipp:3.11.0",
+      "purl": "pkg:pypi/zipp@3.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "22-crcmod",
+      "name": "crcmod",
+      "version": "1.7",
+      "author": "Ray Buvel",
+      "cpe": "cpe:/a:ray_buvel:crcmod:1.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/crcmod@1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "23-fasteners",
+      "name": "fasteners",
+      "version": "0.18",
+      "author": "Joshua Harlow",
+      "cpe": "cpe:/a:joshua_harlow:fasteners:0.18",
+      "purl": "pkg:pypi/fasteners@0.18"
+    },
+    {
+      "type": "library",
+      "bom-ref": "24-gcs-oauth2-boto-plugin",
+      "name": "gcs-oauth2-boto-plugin",
+      "version": "3.0",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gcs-oauth2-boto-plugin:3.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gcs-oauth2-boto-plugin@3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "25-boto",
+      "name": "boto",
+      "version": "2.49.0",
+      "author": "Mitch Garnaat",
+      "cpe": "cpe:/a:mitch_garnaat:boto:2.49.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/boto@2.49.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "26-google-reauth",
+      "name": "google-reauth",
+      "version": "0.1.1",
+      "author": "Google",
+      "cpe": "cpe:/a:google:google-reauth:0.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-reauth@0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "27-pyu2f",
+      "name": "pyu2f",
+      "version": "0.1.5",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:pyu2f:0.1.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyu2f@0.1.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "28-six",
+      "name": "six",
+      "version": "1.16.0",
+      "author": "Benjamin Peterson",
+      "cpe": "cpe:/a:benjamin_peterson:six:1.16.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "29-httplib2",
+      "name": "httplib2",
+      "version": "0.20.4",
+      "author": "Joe Gregorio",
+      "cpe": "cpe:/a:joe_gregorio:httplib2:0.20.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/httplib2@0.20.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "30-pyparsing",
+      "name": "pyparsing",
+      "version": "3.0.9",
+      "purl": "pkg:pypi/pyparsing@3.0.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "31-oauth2client",
+      "name": "oauth2client",
+      "version": "4.1.3",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:oauth2client:4.1.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/oauth2client@4.1.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "32-pyasn1",
+      "name": "pyasn1",
+      "version": "0.4.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1:0.4.8",
+      "purl": "pkg:pypi/pyasn1@0.4.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "33-pyasn1-modules",
+      "name": "pyasn1-modules",
+      "version": "0.2.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1-modules:0.2.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1-modules@0.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "34-rsa",
+      "name": "rsa",
+      "version": "4.7.2",
+      "author": "Sybren A. Stuvel",
+      "cpe": "cpe:/a:sybren_a._stuvel:rsa:4.7.2",
+      "purl": "pkg:pypi/rsa@4.7.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "35-pyopenssl",
+      "name": "pyopenssl",
+      "version": "23.0.0",
+      "author": "The pyOpenSSL developers",
+      "cpe": "cpe:/a:the_pyopenssl_developers:pyopenssl:23.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyopenssl@23.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "36-cryptography",
+      "name": "cryptography",
+      "version": "39.0.0",
+      "author": "The Python Cryptographic Authority and individual contributors",
+      "cpe": "cpe:/a:the_python_cryptographic_authority_and_individual_contributors:cryptography:39.0.0",
+      "purl": "pkg:pypi/cryptography@39.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "37-cffi",
+      "name": "cffi",
+      "version": "1.15.1",
+      "author": "Armin Rigo, Maciej Fijalkowski",
+      "cpe": "cpe:/a:armin_rigo,_maciej_fijalkowski:cffi:1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cffi@1.15.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "38-pycparser",
+      "name": "pycparser",
+      "version": "2.21",
+      "author": "Eli Bendersky",
+      "cpe": "cpe:/a:eli_bendersky:pycparser:2.21",
+      "purl": "pkg:pypi/pycparser@2.21"
+    },
+    {
+      "type": "library",
+      "bom-ref": "39-retry-decorator",
+      "name": "retry-decorator",
+      "version": "1.1.1",
+      "author": "Patrick Ng",
+      "cpe": "cpe:/a:patrick_ng:retry-decorator:1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/retry-decorator@1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "40-google-apitools",
+      "name": "google-apitools",
+      "version": "0.5.32",
+      "author": "Craig Citro",
+      "cpe": "cpe:/a:craig_citro:google-apitools:0.5.32",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-apitools@0.5.32"
+    },
+    {
+      "type": "library",
+      "bom-ref": "41-google-auth",
+      "name": "google-auth",
+      "version": "2.15.0",
+      "author": "Google Cloud Platform",
+      "cpe": "cpe:/a:google_cloud_platform:google-auth:2.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-auth@2.15.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "42-cachetools",
+      "name": "cachetools",
+      "version": "5.2.0",
+      "author": "Thomas Kemmer",
+      "cpe": "cpe:/a:thomas_kemmer:cachetools:5.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cachetools@5.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "43-monotonic",
+      "name": "monotonic",
+      "version": "1.6",
+      "author": "Ori Livneh",
+      "cpe": "cpe:/a:ori_livneh:monotonic:1.6",
+      "purl": "pkg:pypi/monotonic@1.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "44-importlib-resources",
+      "name": "importlib-resources",
+      "version": "5.10.2",
+      "author": "Barry Warsaw",
+      "cpe": "cpe:/a:barry_warsaw:importlib-resources:5.10.2",
+      "purl": "pkg:pypi/importlib-resources@5.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "45-jinja2",
+      "name": "jinja2",
+      "version": "3.1.2",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:jinja2:3.1.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jinja2@3.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "46-markupsafe",
+      "name": "markupsafe",
+      "version": "2.1.1",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:markupsafe:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/markupsafe@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "47-jsonschema",
+      "name": "jsonschema",
+      "version": "4.17.3",
+      "author": "Julian Berman",
+      "cpe": "cpe:/a:julian_berman:jsonschema:4.17.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.17.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "48-pkgutil-resolve-name",
+      "name": "pkgutil-resolve-name",
+      "version": "1.3.10",
+      "author": "Vinay Sajip",
+      "cpe": "cpe:/a:vinay_sajip:pkgutil-resolve-name:1.3.10",
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "type": "library",
+      "bom-ref": "49-pyrsistent",
+      "name": "pyrsistent",
+      "version": "0.19.3",
+      "author": "Tobias Gustafsson",
+      "cpe": "cpe:/a:tobias_gustafsson:pyrsistent:0.19.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyrsistent@0.19.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "50-packaging",
+      "name": "packaging",
+      "version": "21.3",
+      "author": "Donald Stufft and individual contributors",
+      "cpe": "cpe:/a:donald_stufft_and_individual_contributors:packaging:21.3",
+      "purl": "pkg:pypi/packaging@21.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "51-plotly",
+      "name": "plotly",
+      "version": "5.11.0",
+      "author": "Chris P",
+      "cpe": "cpe:/a:chris_p:plotly:5.11.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/plotly@5.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "52-tenacity",
+      "name": "tenacity",
+      "version": "8.1.0",
+      "author": "Julien Danjou",
+      "cpe": "cpe:/a:julien_danjou:tenacity:8.1.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/tenacity@8.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "53-pyyaml",
+      "name": "pyyaml",
+      "version": "6.0",
+      "author": "Kirill Simonov",
+      "cpe": "cpe:/a:kirill_simonov:pyyaml:6.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyyaml@6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "54-requests",
+      "name": "requests",
+      "version": "2.28.1",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:requests:2.28.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.28.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "55-certifi",
+      "name": "certifi",
+      "version": "2022.12.7",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:certifi:2022.12.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "url": "https://www.mozilla.org/MPL/2.0/"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2022.12.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "56-urllib3",
+      "name": "urllib3",
+      "version": "1.26.13",
+      "author": "Andrey Petrov",
+      "cpe": "cpe:/a:andrey_petrov:urllib3:1.26.13",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@1.26.13"
+    },
+    {
+      "type": "library",
+      "bom-ref": "57-rich",
+      "name": "rich",
+      "version": "13.0.0",
+      "author": "Will McGugan",
+      "cpe": "cpe:/a:will_mcgugan:rich:13.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rich@13.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "58-commonmark",
+      "name": "commonmark",
+      "version": "0.9.1",
+      "author": "Bibek Kafle <bkafle662@gmail.com>, Roland Shoemaker <rolandshoemaker@gmail.com>",
+      "cpe": "cpe:/a:bibek_kafle_<bkafle662@gmail.com>,_roland_shoemaker_<rolandshoemaker@gmail.com>:commonmark:0.9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/commonmark@0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "59-pygments",
+      "name": "pygments",
+      "version": "2.14.0",
+      "author": "Georg Brandl",
+      "cpe": "cpe:/a:georg_brandl:pygments:2.14.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pygments@2.14.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "60-rpmfile",
+      "name": "rpmfile",
+      "version": "1.0.8",
+      "author": "Sean Ross-Ross",
+      "cpe": "cpe:/a:sean_ross-ross:rpmfile:1.0.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rpmfile@1.0.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "61-toml",
+      "name": "toml",
+      "version": "0.10.2",
+      "author": "William Pearson",
+      "cpe": "cpe:/a:william_pearson:toml:0.10.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "62-xmlschema",
+      "name": "xmlschema",
+      "version": "2.1.1",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:xmlschema:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/xmlschema@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "63-elementpath",
+      "name": "elementpath",
+      "version": "3.0.2",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:elementpath:3.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/elementpath@3.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "64-zstandard",
+      "name": "zstandard",
+      "version": "0.19.0",
+      "author": "Gregory Szorc",
+      "cpe": "cpe:/a:gregory_szorc:zstandard:0.19.0",
+      "purl": "pkg:pypi/zstandard@0.19.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "1-cve-bin-tool",
+      "dependsOn": [
+        "2-aiohttp",
+        "13-beautifulsoup4",
+        "15-cvss",
+        "16-defusedxml",
+        "17-distro",
+        "18-gsutil",
+        "20-importlib-metadata",
+        "44-importlib-resources",
+        "45-jinja2",
+        "47-jsonschema",
+        "50-packaging",
+        "51-plotly",
+        "53-pyyaml",
+        "54-requests",
+        "57-rich",
+        "60-rpmfile",
+        "61-toml",
+        "56-urllib3",
+        "62-xmlschema",
+        "64-zstandard"
+      ]
+    },
+    {
+      "ref": "2-aiohttp",
+      "dependsOn": [
+        "3-aiosignal",
+        "5-async-timeout",
+        "7-asynctest",
+        "8-attrs",
+        "9-charset-normalizer",
+        "4-frozenlist",
+        "10-multidict",
+        "6-typing-extensions",
+        "11-yarl"
+      ]
+    },
+    {
+      "ref": "3-aiosignal",
+      "dependsOn": [
+        "4-frozenlist"
+      ]
+    },
+    {
+      "ref": "5-async-timeout",
+      "dependsOn": [
+        "6-typing-extensions"
+      ]
+    },
+    {
+      "ref": "11-yarl",
+      "dependsOn": [
+        "12-idna",
+        "10-multidict",
+        "6-typing-extensions"
+      ]
+    },
+    {
+      "ref": "13-beautifulsoup4",
+      "dependsOn": [
+        "14-soupsieve"
+      ]
+    },
+    {
+      "ref": "18-gsutil",
+      "dependsOn": [
+        "19-argcomplete",
+        "22-crcmod",
+        "23-fasteners",
+        "24-gcs-oauth2-boto-plugin",
+        "40-google-apitools",
+        "41-google-auth",
+        "26-google-reauth",
+        "29-httplib2",
+        "43-monotonic",
+        "35-pyopenssl",
+        "39-retry-decorator",
+        "28-six"
+      ]
+    },
+    {
+      "ref": "19-argcomplete",
+      "dependsOn": [
+        "20-importlib-metadata"
+      ]
+    },
+    {
+      "ref": "20-importlib-metadata",
+      "dependsOn": [
+        "6-typing-extensions",
+        "21-zipp"
+      ]
+    },
+    {
+      "ref": "24-gcs-oauth2-boto-plugin",
+      "dependsOn": [
+        "25-boto",
+        "26-google-reauth",
+        "29-httplib2",
+        "31-oauth2client",
+        "35-pyopenssl",
+        "39-retry-decorator",
+        "34-rsa",
+        "28-six"
+      ]
+    },
+    {
+      "ref": "26-google-reauth",
+      "dependsOn": [
+        "27-pyu2f"
+      ]
+    },
+    {
+      "ref": "27-pyu2f",
+      "dependsOn": [
+        "28-six"
+      ]
+    },
+    {
+      "ref": "29-httplib2",
+      "dependsOn": [
+        "30-pyparsing"
+      ]
+    },
+    {
+      "ref": "31-oauth2client",
+      "dependsOn": [
+        "29-httplib2",
+        "32-pyasn1",
+        "33-pyasn1-modules",
+        "34-rsa",
+        "28-six"
+      ]
+    },
+    {
+      "ref": "33-pyasn1-modules",
+      "dependsOn": [
+        "32-pyasn1"
+      ]
+    },
+    {
+      "ref": "34-rsa",
+      "dependsOn": [
+        "32-pyasn1"
+      ]
+    },
+    {
+      "ref": "35-pyopenssl",
+      "dependsOn": [
+        "36-cryptography"
+      ]
+    },
+    {
+      "ref": "36-cryptography",
+      "dependsOn": [
+        "37-cffi"
+      ]
+    },
+    {
+      "ref": "37-cffi",
+      "dependsOn": [
+        "38-pycparser"
+      ]
+    },
+    {
+      "ref": "40-google-apitools",
+      "dependsOn": [
+        "23-fasteners",
+        "29-httplib2",
+        "31-oauth2client",
+        "28-six"
+      ]
+    },
+    {
+      "ref": "41-google-auth",
+      "dependsOn": [
+        "42-cachetools",
+        "33-pyasn1-modules",
+        "34-rsa",
+        "28-six"
+      ]
+    },
+    {
+      "ref": "44-importlib-resources",
+      "dependsOn": [
+        "21-zipp"
+      ]
+    },
+    {
+      "ref": "45-jinja2",
+      "dependsOn": [
+        "46-markupsafe"
+      ]
+    },
+    {
+      "ref": "47-jsonschema",
+      "dependsOn": [
+        "8-attrs",
+        "20-importlib-metadata",
+        "44-importlib-resources",
+        "48-pkgutil-resolve-name",
+        "49-pyrsistent",
+        "6-typing-extensions"
+      ]
+    },
+    {
+      "ref": "50-packaging",
+      "dependsOn": [
+        "30-pyparsing"
+      ]
+    },
+    {
+      "ref": "51-plotly",
+      "dependsOn": [
+        "52-tenacity"
+      ]
+    },
+    {
+      "ref": "54-requests",
+      "dependsOn": [
+        "55-certifi",
+        "9-charset-normalizer",
+        "12-idna",
+        "56-urllib3"
+      ]
+    },
+    {
+      "ref": "57-rich",
+      "dependsOn": [
+        "58-commonmark",
+        "59-pygments",
+        "6-typing-extensions"
+      ]
+    },
+    {
+      "ref": "62-xmlschema",
+      "dependsOn": [
+        "63-elementpath"
+      ]
+    }
+  ]
+}

--- a/sbom/cve-bin-tool-py3.7.spdx
+++ b/sbom/cve-bin-tool-py3.7.spdx
@@ -1,0 +1,939 @@
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: cve-bin-tool
+DocumentNamespace: http://spdx.org/spdxdocs/cve-bin-tool-fefbc612-92f3-4da3-9f43-571b5967ab4d
+LicenseListVersion: 3.18
+Creator: Tool: sbom4python-0.4.0
+Created: 2023-01-03T00:50:15Z
+CreatorComment: <text>This document has been automatically generated.</text>
+##### 
+
+PackageName: cve-bin-tool
+SPDXID: SPDXRef-Package-1-cve-bin-tool
+PackageSupplier: Person: Terri_Oda
+PackageVersion: 3.2.1.dev0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license GPL-3.0-or-later
+PackageLicenseConcluded: GPL-3.0-or-later
+PackageLicenseDeclared: GPL-3.0-or-later
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cve-bin-tool@3.2.1.dev0
+##### 
+
+PackageName: aiohttp
+SPDXID: SPDXRef-Package-2-aiohttp
+PackageSupplier: NOASSERTION
+PackageVersion: 3.8.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.3
+##### 
+
+PackageName: aiosignal
+SPDXID: SPDXRef-Package-3-aiosignal
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
+##### 
+
+PackageName: frozenlist
+SPDXID: SPDXRef-Package-4-frozenlist
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+##### 
+
+PackageName: async-timeout
+SPDXID: SPDXRef-Package-5-async-timeout
+PackageSupplier: Organization: Andrew_Svetlov_<andrew.svetlov@gmail.com>
+PackageVersion: 4.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/async-timeout@4.0.2
+##### 
+
+PackageName: typing-extensions
+SPDXID: SPDXRef-Package-6-typing-extensions
+PackageSupplier: NOASSERTION
+PackageVersion: 4.4.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/typing-extensions@4.4.0
+##### 
+
+PackageName: asynctest
+SPDXID: SPDXRef-Package-7-asynctest
+PackageSupplier: Person: Martin_Richard
+PackageVersion: 0.13.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/asynctest@0.13.0
+##### 
+
+PackageName: attrs
+SPDXID: SPDXRef-Package-8-attrs
+PackageSupplier: Person: Hynek_Schlawack
+PackageVersion: 22.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/attrs@22.2.0
+##### 
+
+PackageName: charset-normalizer
+SPDXID: SPDXRef-Package-9-charset-normalizer
+PackageSupplier: Organization: Ahmed_TAHRI_@Ousret
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/charset-normalizer@2.1.1
+##### 
+
+PackageName: multidict
+SPDXID: SPDXRef-Package-10-multidict
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 6.0.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/multidict@6.0.4
+##### 
+
+PackageName: yarl
+SPDXID: SPDXRef-Package-11-yarl
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 1.8.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/yarl@1.8.2
+##### 
+
+PackageName: idna
+SPDXID: SPDXRef-Package-12-idna
+PackageSupplier: NOASSERTION
+PackageVersion: 3.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/idna@3.4
+##### 
+
+PackageName: beautifulsoup4
+SPDXID: SPDXRef-Package-13-beautifulsoup4
+PackageSupplier: Person: Leonard_Richardson
+PackageVersion: 4.11.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/beautifulsoup4@4.11.1
+##### 
+
+PackageName: soupsieve
+SPDXID: SPDXRef-Package-14-soupsieve
+PackageSupplier: NOASSERTION
+PackageVersion: 2.3.2.post1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/soupsieve@2.3.2.post1
+##### 
+
+PackageName: cvss
+SPDXID: SPDXRef-Package-15-cvss
+PackageSupplier: Organization: Stanislav_Kontar,_Red_Hat_Product_Security
+PackageVersion: 2.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license LGPLv3+
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cvss@2.5
+##### 
+
+PackageName: defusedxml
+SPDXID: SPDXRef-Package-16-defusedxml
+PackageSupplier: Person: Christian_Heimes
+PackageVersion: 0.7.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license PSFL
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/defusedxml@0.7.1
+##### 
+
+PackageName: distro
+SPDXID: SPDXRef-Package-17-distro
+PackageSupplier: Person: Nir_Cohen
+PackageVersion: 1.8.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/distro@1.8.0
+##### 
+
+PackageName: gsutil
+SPDXID: SPDXRef-Package-18-gsutil
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 5.17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gsutil@5.17
+##### 
+
+PackageName: argcomplete
+SPDXID: SPDXRef-Package-19-argcomplete
+PackageSupplier: Person: Andrey_Kislyuk
+PackageVersion: 2.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache Software License
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/argcomplete@2.0.0
+##### 
+
+PackageName: importlib-metadata
+SPDXID: SPDXRef-Package-20-importlib-metadata
+PackageSupplier: Organization: Jason_R._Coombs
+PackageVersion: 4.13.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/importlib-metadata@4.13.0
+##### 
+
+PackageName: zipp
+SPDXID: SPDXRef-Package-21-zipp
+PackageSupplier: Organization: Jason_R._Coombs
+PackageVersion: 3.11.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zipp@3.11.0
+##### 
+
+PackageName: crcmod
+SPDXID: SPDXRef-Package-22-crcmod
+PackageSupplier: Person: Ray_Buvel
+PackageVersion: 1.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/crcmod@1.7
+##### 
+
+PackageName: fasteners
+SPDXID: SPDXRef-Package-23-fasteners
+PackageSupplier: Person: Joshua_Harlow
+PackageVersion: 0.18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/fasteners@0.18
+##### 
+
+PackageName: gcs-oauth2-boto-plugin
+SPDXID: SPDXRef-Package-24-gcs-oauth2-boto-plugin
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 3.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gcs-oauth2-boto-plugin@3.0
+##### 
+
+PackageName: boto
+SPDXID: SPDXRef-Package-25-boto
+PackageSupplier: Person: Mitch_Garnaat
+PackageVersion: 2.49.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/boto@2.49.0
+##### 
+
+PackageName: google-reauth
+SPDXID: SPDXRef-Package-26-google-reauth
+PackageSupplier: Person: Google
+PackageVersion: 0.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-reauth@0.1.1
+##### 
+
+PackageName: pyu2f
+SPDXID: SPDXRef-Package-27-pyu2f
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 0.1.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyu2f@0.1.5
+##### 
+
+PackageName: six
+SPDXID: SPDXRef-Package-28-six
+PackageSupplier: Person: Benjamin_Peterson
+PackageVersion: 1.16.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/six@1.16.0
+##### 
+
+PackageName: httplib2
+SPDXID: SPDXRef-Package-29-httplib2
+PackageSupplier: Person: Joe_Gregorio
+PackageVersion: 0.20.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/httplib2@0.20.4
+##### 
+
+PackageName: pyparsing
+SPDXID: SPDXRef-Package-30-pyparsing
+PackageSupplier: NOASSERTION
+PackageVersion: 3.0.9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyparsing@3.0.9
+##### 
+
+PackageName: oauth2client
+SPDXID: SPDXRef-Package-31-oauth2client
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 4.1.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/oauth2client@4.1.3
+##### 
+
+PackageName: pyasn1
+SPDXID: SPDXRef-Package-32-pyasn1
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.4.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1@0.4.8
+##### 
+
+PackageName: pyasn1-modules
+SPDXID: SPDXRef-Package-33-pyasn1-modules
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.2.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1-modules@0.2.8
+##### 
+
+PackageName: rsa
+SPDXID: SPDXRef-Package-34-rsa
+PackageSupplier: Organization: Sybren_A._Stuvel
+PackageVersion: 4.7.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rsa@4.7.2
+##### 
+
+PackageName: pyopenssl
+SPDXID: SPDXRef-Package-35-pyopenssl
+PackageSupplier: Organization: The_pyOpenSSL_developers
+PackageVersion: 23.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyopenssl@23.0.0
+##### 
+
+PackageName: cryptography
+SPDXID: SPDXRef-Package-36-cryptography
+PackageSupplier: Organization: The_Python_Cryptographic_Authority_and_individual_contributors
+PackageVersion: 39.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license (Apache-2.0 OR BSD-3-Clause) AND PSF-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@39.0.0
+##### 
+
+PackageName: cffi
+SPDXID: SPDXRef-Package-37-cffi
+PackageSupplier: Organization: Armin_Rigo,_Maciej_Fijalkowski
+PackageVersion: 1.15.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cffi@1.15.1
+##### 
+
+PackageName: pycparser
+SPDXID: SPDXRef-Package-38-pycparser
+PackageSupplier: Person: Eli_Bendersky
+PackageVersion: 2.21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pycparser@2.21
+##### 
+
+PackageName: retry-decorator
+SPDXID: SPDXRef-Package-39-retry-decorator
+PackageSupplier: Person: Patrick_Ng
+PackageVersion: 1.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/retry-decorator@1.1.1
+##### 
+
+PackageName: google-apitools
+SPDXID: SPDXRef-Package-40-google-apitools
+PackageSupplier: Person: Craig_Citro
+PackageVersion: 0.5.32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-apitools@0.5.32
+##### 
+
+PackageName: google-auth
+SPDXID: SPDXRef-Package-41-google-auth
+PackageSupplier: Organization: Google_Cloud_Platform
+PackageVersion: 2.15.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.15.0
+##### 
+
+PackageName: cachetools
+SPDXID: SPDXRef-Package-42-cachetools
+PackageSupplier: Person: Thomas_Kemmer
+PackageVersion: 5.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cachetools@5.2.0
+##### 
+
+PackageName: monotonic
+SPDXID: SPDXRef-Package-43-monotonic
+PackageSupplier: Person: Ori_Livneh
+PackageVersion: 1.6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/monotonic@1.6
+##### 
+
+PackageName: importlib-resources
+SPDXID: SPDXRef-Package-44-importlib-resources
+PackageSupplier: Person: Barry_Warsaw
+PackageVersion: 5.10.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/importlib-resources@5.10.2
+##### 
+
+PackageName: jinja2
+SPDXID: SPDXRef-Package-45-jinja2
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 3.1.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jinja2@3.1.2
+##### 
+
+PackageName: markupsafe
+SPDXID: SPDXRef-Package-46-markupsafe
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.1
+##### 
+
+PackageName: jsonschema
+SPDXID: SPDXRef-Package-47-jsonschema
+PackageSupplier: Person: Julian_Berman
+PackageVersion: 4.17.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.17.3
+##### 
+
+PackageName: pkgutil-resolve-name
+SPDXID: SPDXRef-Package-48-pkgutil-resolve-name
+PackageSupplier: Person: Vinay_Sajip
+PackageVersion: 1.3.10
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pkgutil-resolve-name@1.3.10
+##### 
+
+PackageName: pyrsistent
+SPDXID: SPDXRef-Package-49-pyrsistent
+PackageSupplier: Person: Tobias_Gustafsson
+PackageVersion: 0.19.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyrsistent@0.19.3
+##### 
+
+PackageName: packaging
+SPDXID: SPDXRef-Package-50-packaging
+PackageSupplier: Organization: Donald_Stufft_and_individual_contributors
+PackageVersion: 21.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause or Apache-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/packaging@21.3
+##### 
+
+PackageName: plotly
+SPDXID: SPDXRef-Package-51-plotly
+PackageSupplier: Person: Chris_P
+PackageVersion: 5.11.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/plotly@5.11.0
+##### 
+
+PackageName: tenacity
+SPDXID: SPDXRef-Package-52-tenacity
+PackageSupplier: Person: Julien_Danjou
+PackageVersion: 8.1.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/tenacity@8.1.0
+##### 
+
+PackageName: pyyaml
+SPDXID: SPDXRef-Package-53-pyyaml
+PackageSupplier: Person: Kirill_Simonov
+PackageVersion: 6.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
+##### 
+
+PackageName: requests
+SPDXID: SPDXRef-Package-54-requests
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2.28.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/requests@2.28.1
+##### 
+
+PackageName: certifi
+SPDXID: SPDXRef-Package-55-certifi
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2022.12.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MPL-2.0
+PackageLicenseConcluded: MPL-2.0
+PackageLicenseDeclared: MPL-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2022.12.7
+##### 
+
+PackageName: urllib3
+SPDXID: SPDXRef-Package-56-urllib3
+PackageSupplier: Person: Andrey_Petrov
+PackageVersion: 1.26.13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/urllib3@1.26.13
+##### 
+
+PackageName: rich
+SPDXID: SPDXRef-Package-57-rich
+PackageSupplier: Person: Will_McGugan
+PackageVersion: 13.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rich@13.0.0
+##### 
+
+PackageName: commonmark
+SPDXID: SPDXRef-Package-58-commonmark
+PackageSupplier: Organization: Bibek_Kafle_<bkafle662@gmail.com>,_Roland_Shoemaker_<rolandshoemaker@gmail.com>
+PackageVersion: 0.9.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/commonmark@0.9.1
+##### 
+
+PackageName: pygments
+SPDXID: SPDXRef-Package-59-pygments
+PackageSupplier: Person: Georg_Brandl
+PackageVersion: 2.14.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pygments@2.14.0
+##### 
+
+PackageName: rpmfile
+SPDXID: SPDXRef-Package-60-rpmfile
+PackageSupplier: Person: Sean_Ross-Ross
+PackageVersion: 1.0.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpmfile@1.0.8
+##### 
+
+PackageName: toml
+SPDXID: SPDXRef-Package-61-toml
+PackageSupplier: Person: William_Pearson
+PackageVersion: 0.10.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/toml@0.10.2
+##### 
+
+PackageName: xmlschema
+SPDXID: SPDXRef-Package-62-xmlschema
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/xmlschema@2.1.1
+##### 
+
+PackageName: elementpath
+SPDXID: SPDXRef-Package-63-elementpath
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 3.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/elementpath@3.0.2
+##### 
+
+PackageName: zstandard
+SPDXID: SPDXRef-Package-64-zstandard
+PackageSupplier: Person: Gregory_Szorc
+PackageVersion: 0.19.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zstandard@0.19.0
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1-cve-bin-tool
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-13-beautifulsoup4
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-15-cvss
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-16-defusedxml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-17-distro
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-18-gsutil
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-2-aiohttp
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-20-importlib-metadata
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-44-importlib-resources
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-45-jinja2
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-47-jsonschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-50-packaging
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-51-plotly
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-53-pyyaml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-54-requests
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-56-urllib3
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-57-rich
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-60-rpmfile
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-61-toml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-62-xmlschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-64-zstandard
+Relationship: SPDXRef-Package-11-yarl CONTAINS SPDXRef-Package-10-multidict
+Relationship: SPDXRef-Package-11-yarl CONTAINS SPDXRef-Package-12-idna
+Relationship: SPDXRef-Package-11-yarl CONTAINS SPDXRef-Package-6-typing-extensions
+Relationship: SPDXRef-Package-13-beautifulsoup4 CONTAINS SPDXRef-Package-14-soupsieve
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-19-argcomplete
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-22-crcmod
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-23-fasteners
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-24-gcs-oauth2-boto-plugin
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-26-google-reauth
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-28-six
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-29-httplib2
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-35-pyopenssl
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-39-retry-decorator
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-40-google-apitools
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-41-google-auth
+Relationship: SPDXRef-Package-18-gsutil CONTAINS SPDXRef-Package-43-monotonic
+Relationship: SPDXRef-Package-19-argcomplete CONTAINS SPDXRef-Package-20-importlib-metadata
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-10-multidict
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-11-yarl
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-3-aiosignal
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-5-async-timeout
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-6-typing-extensions
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-7-asynctest
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-8-attrs
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-9-charset-normalizer
+Relationship: SPDXRef-Package-20-importlib-metadata CONTAINS SPDXRef-Package-21-zipp
+Relationship: SPDXRef-Package-20-importlib-metadata CONTAINS SPDXRef-Package-6-typing-extensions
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-25-boto
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-26-google-reauth
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-28-six
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-29-httplib2
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-31-oauth2client
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-34-rsa
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-35-pyopenssl
+Relationship: SPDXRef-Package-24-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-39-retry-decorator
+Relationship: SPDXRef-Package-26-google-reauth CONTAINS SPDXRef-Package-27-pyu2f
+Relationship: SPDXRef-Package-27-pyu2f CONTAINS SPDXRef-Package-28-six
+Relationship: SPDXRef-Package-29-httplib2 CONTAINS SPDXRef-Package-30-pyparsing
+Relationship: SPDXRef-Package-3-aiosignal CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-31-oauth2client CONTAINS SPDXRef-Package-28-six
+Relationship: SPDXRef-Package-31-oauth2client CONTAINS SPDXRef-Package-29-httplib2
+Relationship: SPDXRef-Package-31-oauth2client CONTAINS SPDXRef-Package-32-pyasn1
+Relationship: SPDXRef-Package-31-oauth2client CONTAINS SPDXRef-Package-33-pyasn1-modules
+Relationship: SPDXRef-Package-31-oauth2client CONTAINS SPDXRef-Package-34-rsa
+Relationship: SPDXRef-Package-33-pyasn1-modules CONTAINS SPDXRef-Package-32-pyasn1
+Relationship: SPDXRef-Package-34-rsa CONTAINS SPDXRef-Package-32-pyasn1
+Relationship: SPDXRef-Package-35-pyopenssl CONTAINS SPDXRef-Package-36-cryptography
+Relationship: SPDXRef-Package-36-cryptography CONTAINS SPDXRef-Package-37-cffi
+Relationship: SPDXRef-Package-37-cffi CONTAINS SPDXRef-Package-38-pycparser
+Relationship: SPDXRef-Package-40-google-apitools CONTAINS SPDXRef-Package-23-fasteners
+Relationship: SPDXRef-Package-40-google-apitools CONTAINS SPDXRef-Package-28-six
+Relationship: SPDXRef-Package-40-google-apitools CONTAINS SPDXRef-Package-29-httplib2
+Relationship: SPDXRef-Package-40-google-apitools CONTAINS SPDXRef-Package-31-oauth2client
+Relationship: SPDXRef-Package-41-google-auth CONTAINS SPDXRef-Package-28-six
+Relationship: SPDXRef-Package-41-google-auth CONTAINS SPDXRef-Package-33-pyasn1-modules
+Relationship: SPDXRef-Package-41-google-auth CONTAINS SPDXRef-Package-34-rsa
+Relationship: SPDXRef-Package-41-google-auth CONTAINS SPDXRef-Package-42-cachetools
+Relationship: SPDXRef-Package-44-importlib-resources CONTAINS SPDXRef-Package-21-zipp
+Relationship: SPDXRef-Package-45-jinja2 CONTAINS SPDXRef-Package-46-markupsafe
+Relationship: SPDXRef-Package-47-jsonschema CONTAINS SPDXRef-Package-20-importlib-metadata
+Relationship: SPDXRef-Package-47-jsonschema CONTAINS SPDXRef-Package-44-importlib-resources
+Relationship: SPDXRef-Package-47-jsonschema CONTAINS SPDXRef-Package-48-pkgutil-resolve-name
+Relationship: SPDXRef-Package-47-jsonschema CONTAINS SPDXRef-Package-49-pyrsistent
+Relationship: SPDXRef-Package-47-jsonschema CONTAINS SPDXRef-Package-6-typing-extensions
+Relationship: SPDXRef-Package-47-jsonschema CONTAINS SPDXRef-Package-8-attrs
+Relationship: SPDXRef-Package-5-async-timeout CONTAINS SPDXRef-Package-6-typing-extensions
+Relationship: SPDXRef-Package-50-packaging CONTAINS SPDXRef-Package-30-pyparsing
+Relationship: SPDXRef-Package-51-plotly CONTAINS SPDXRef-Package-52-tenacity
+Relationship: SPDXRef-Package-54-requests CONTAINS SPDXRef-Package-12-idna
+Relationship: SPDXRef-Package-54-requests CONTAINS SPDXRef-Package-55-certifi
+Relationship: SPDXRef-Package-54-requests CONTAINS SPDXRef-Package-56-urllib3
+Relationship: SPDXRef-Package-54-requests CONTAINS SPDXRef-Package-9-charset-normalizer
+Relationship: SPDXRef-Package-57-rich CONTAINS SPDXRef-Package-58-commonmark
+Relationship: SPDXRef-Package-57-rich CONTAINS SPDXRef-Package-59-pygments
+Relationship: SPDXRef-Package-57-rich CONTAINS SPDXRef-Package-6-typing-extensions
+Relationship: SPDXRef-Package-62-xmlschema CONTAINS SPDXRef-Package-63-elementpath

--- a/sbom/cve-bin-tool-py3.8.json
+++ b/sbom/cve-bin-tool-py3.8.json
@@ -1,0 +1,1141 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuidffba2e96-a09e-4330-bb10-e8dab45e971d",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-01-03T00:49:29Z",
+    "tools": [
+      {
+        "name": "sbom4python",
+        "version": "0.4.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "application",
+      "bom-ref": "1-cve-bin-tool",
+      "name": "cve-bin-tool",
+      "version": "3.2.1.dev0",
+      "author": "Terri Oda",
+      "cpe": "cpe:/a:terri_oda:cve-bin-tool:3.2.1.dev0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0-or-later",
+            "url": "https://www.gnu.org/licenses/gpl-3.0-standalone.html"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cve-bin-tool@3.2.1.dev0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "2-aiohttp",
+      "name": "aiohttp",
+      "version": "3.8.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp@3.8.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "3-aiosignal",
+      "name": "aiosignal",
+      "version": "1.3.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiosignal@1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "4-frozenlist",
+      "name": "frozenlist",
+      "version": "1.3.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/frozenlist@1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "5-async-timeout",
+      "name": "async-timeout",
+      "version": "4.0.2",
+      "author": "Andrew Svetlov <andrew.svetlov@gmail.com>",
+      "cpe": "cpe:/a:andrew_svetlov_<andrew.svetlov@gmail.com>:async-timeout:4.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/async-timeout@4.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "6-attrs",
+      "name": "attrs",
+      "version": "22.2.0",
+      "author": "Hynek Schlawack",
+      "cpe": "cpe:/a:hynek_schlawack:attrs:22.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/attrs@22.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "7-charset-normalizer",
+      "name": "charset-normalizer",
+      "version": "2.1.1",
+      "author": "Ahmed TAHRI @Ousret",
+      "cpe": "cpe:/a:ahmed_tahri_@ousret:charset-normalizer:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "8-multidict",
+      "name": "multidict",
+      "version": "6.0.4",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:multidict:6.0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/multidict@6.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "9-yarl",
+      "name": "yarl",
+      "version": "1.8.2",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:yarl:1.8.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/yarl@1.8.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "10-idna",
+      "name": "idna",
+      "version": "3.4",
+      "purl": "pkg:pypi/idna@3.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "11-beautifulsoup4",
+      "name": "beautifulsoup4",
+      "version": "4.11.1",
+      "author": "Leonard Richardson",
+      "cpe": "cpe:/a:leonard_richardson:beautifulsoup4:4.11.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/beautifulsoup4@4.11.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "12-soupsieve",
+      "name": "soupsieve",
+      "version": "2.3.2.post1",
+      "purl": "pkg:pypi/soupsieve@2.3.2.post1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "13-cvss",
+      "name": "cvss",
+      "version": "2.5",
+      "author": "Stanislav Kontar, Red Hat Product Security",
+      "cpe": "cpe:/a:stanislav_kontar,_red_hat_product_security:cvss:2.5",
+      "purl": "pkg:pypi/cvss@2.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "14-defusedxml",
+      "name": "defusedxml",
+      "version": "0.7.1",
+      "author": "Christian Heimes",
+      "cpe": "cpe:/a:christian_heimes:defusedxml:0.7.1",
+      "purl": "pkg:pypi/defusedxml@0.7.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "15-distro",
+      "name": "distro",
+      "version": "1.8.0",
+      "author": "Nir Cohen",
+      "cpe": "cpe:/a:nir_cohen:distro:1.8.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/distro@1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "16-gsutil",
+      "name": "gsutil",
+      "version": "5.17",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gsutil:5.17",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gsutil@5.17"
+    },
+    {
+      "type": "library",
+      "bom-ref": "17-argcomplete",
+      "name": "argcomplete",
+      "version": "2.0.0",
+      "author": "Andrey Kislyuk",
+      "cpe": "cpe:/a:andrey_kislyuk:argcomplete:2.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/argcomplete@2.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "18-crcmod",
+      "name": "crcmod",
+      "version": "1.7",
+      "author": "Ray Buvel",
+      "cpe": "cpe:/a:ray_buvel:crcmod:1.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/crcmod@1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "19-fasteners",
+      "name": "fasteners",
+      "version": "0.18",
+      "author": "Joshua Harlow",
+      "cpe": "cpe:/a:joshua_harlow:fasteners:0.18",
+      "purl": "pkg:pypi/fasteners@0.18"
+    },
+    {
+      "type": "library",
+      "bom-ref": "20-gcs-oauth2-boto-plugin",
+      "name": "gcs-oauth2-boto-plugin",
+      "version": "3.0",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gcs-oauth2-boto-plugin:3.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gcs-oauth2-boto-plugin@3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "21-boto",
+      "name": "boto",
+      "version": "2.49.0",
+      "author": "Mitch Garnaat",
+      "cpe": "cpe:/a:mitch_garnaat:boto:2.49.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/boto@2.49.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "22-google-reauth",
+      "name": "google-reauth",
+      "version": "0.1.1",
+      "author": "Google",
+      "cpe": "cpe:/a:google:google-reauth:0.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-reauth@0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "23-pyu2f",
+      "name": "pyu2f",
+      "version": "0.1.5",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:pyu2f:0.1.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyu2f@0.1.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "24-six",
+      "name": "six",
+      "version": "1.16.0",
+      "author": "Benjamin Peterson",
+      "cpe": "cpe:/a:benjamin_peterson:six:1.16.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "25-httplib2",
+      "name": "httplib2",
+      "version": "0.20.4",
+      "author": "Joe Gregorio",
+      "cpe": "cpe:/a:joe_gregorio:httplib2:0.20.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/httplib2@0.20.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "26-pyparsing",
+      "name": "pyparsing",
+      "version": "3.0.9",
+      "purl": "pkg:pypi/pyparsing@3.0.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "27-oauth2client",
+      "name": "oauth2client",
+      "version": "4.1.3",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:oauth2client:4.1.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/oauth2client@4.1.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "28-pyasn1",
+      "name": "pyasn1",
+      "version": "0.4.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1:0.4.8",
+      "purl": "pkg:pypi/pyasn1@0.4.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "29-pyasn1-modules",
+      "name": "pyasn1-modules",
+      "version": "0.2.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1-modules:0.2.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1-modules@0.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "30-rsa",
+      "name": "rsa",
+      "version": "4.7.2",
+      "author": "Sybren A. Stuvel",
+      "cpe": "cpe:/a:sybren_a._stuvel:rsa:4.7.2",
+      "purl": "pkg:pypi/rsa@4.7.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "31-pyopenssl",
+      "name": "pyopenssl",
+      "version": "23.0.0",
+      "author": "The pyOpenSSL developers",
+      "cpe": "cpe:/a:the_pyopenssl_developers:pyopenssl:23.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyopenssl@23.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "32-cryptography",
+      "name": "cryptography",
+      "version": "39.0.0",
+      "author": "The Python Cryptographic Authority and individual contributors",
+      "cpe": "cpe:/a:the_python_cryptographic_authority_and_individual_contributors:cryptography:39.0.0",
+      "purl": "pkg:pypi/cryptography@39.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "33-cffi",
+      "name": "cffi",
+      "version": "1.15.1",
+      "author": "Armin Rigo, Maciej Fijalkowski",
+      "cpe": "cpe:/a:armin_rigo,_maciej_fijalkowski:cffi:1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cffi@1.15.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "34-pycparser",
+      "name": "pycparser",
+      "version": "2.21",
+      "author": "Eli Bendersky",
+      "cpe": "cpe:/a:eli_bendersky:pycparser:2.21",
+      "purl": "pkg:pypi/pycparser@2.21"
+    },
+    {
+      "type": "library",
+      "bom-ref": "35-retry-decorator",
+      "name": "retry-decorator",
+      "version": "1.1.1",
+      "author": "Patrick Ng",
+      "cpe": "cpe:/a:patrick_ng:retry-decorator:1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/retry-decorator@1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "36-google-apitools",
+      "name": "google-apitools",
+      "version": "0.5.32",
+      "author": "Craig Citro",
+      "cpe": "cpe:/a:craig_citro:google-apitools:0.5.32",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-apitools@0.5.32"
+    },
+    {
+      "type": "library",
+      "bom-ref": "37-google-auth",
+      "name": "google-auth",
+      "version": "2.15.0",
+      "author": "Google Cloud Platform",
+      "cpe": "cpe:/a:google_cloud_platform:google-auth:2.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-auth@2.15.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "38-cachetools",
+      "name": "cachetools",
+      "version": "5.2.0",
+      "author": "Thomas Kemmer",
+      "cpe": "cpe:/a:thomas_kemmer:cachetools:5.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cachetools@5.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "39-monotonic",
+      "name": "monotonic",
+      "version": "1.6",
+      "author": "Ori Livneh",
+      "cpe": "cpe:/a:ori_livneh:monotonic:1.6",
+      "purl": "pkg:pypi/monotonic@1.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "40-importlib-resources",
+      "name": "importlib-resources",
+      "version": "5.10.2",
+      "author": "Barry Warsaw",
+      "cpe": "cpe:/a:barry_warsaw:importlib-resources:5.10.2",
+      "purl": "pkg:pypi/importlib-resources@5.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "41-zipp",
+      "name": "zipp",
+      "version": "3.11.0",
+      "author": "Jason R. Coombs",
+      "cpe": "cpe:/a:jason_r._coombs:zipp:3.11.0",
+      "purl": "pkg:pypi/zipp@3.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "42-jinja2",
+      "name": "jinja2",
+      "version": "3.1.2",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:jinja2:3.1.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jinja2@3.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "43-markupsafe",
+      "name": "markupsafe",
+      "version": "2.1.1",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:markupsafe:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/markupsafe@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "44-jsonschema",
+      "name": "jsonschema",
+      "version": "4.17.3",
+      "author": "Julian Berman",
+      "cpe": "cpe:/a:julian_berman:jsonschema:4.17.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.17.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "45-pkgutil-resolve-name",
+      "name": "pkgutil-resolve-name",
+      "version": "1.3.10",
+      "author": "Vinay Sajip",
+      "cpe": "cpe:/a:vinay_sajip:pkgutil-resolve-name:1.3.10",
+      "purl": "pkg:pypi/pkgutil-resolve-name@1.3.10"
+    },
+    {
+      "type": "library",
+      "bom-ref": "46-pyrsistent",
+      "name": "pyrsistent",
+      "version": "0.19.3",
+      "author": "Tobias Gustafsson",
+      "cpe": "cpe:/a:tobias_gustafsson:pyrsistent:0.19.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyrsistent@0.19.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "47-packaging",
+      "name": "packaging",
+      "version": "21.3",
+      "author": "Donald Stufft and individual contributors",
+      "cpe": "cpe:/a:donald_stufft_and_individual_contributors:packaging:21.3",
+      "purl": "pkg:pypi/packaging@21.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "48-plotly",
+      "name": "plotly",
+      "version": "5.11.0",
+      "author": "Chris P",
+      "cpe": "cpe:/a:chris_p:plotly:5.11.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/plotly@5.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "49-tenacity",
+      "name": "tenacity",
+      "version": "8.1.0",
+      "author": "Julien Danjou",
+      "cpe": "cpe:/a:julien_danjou:tenacity:8.1.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/tenacity@8.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "50-pyyaml",
+      "name": "pyyaml",
+      "version": "6.0",
+      "author": "Kirill Simonov",
+      "cpe": "cpe:/a:kirill_simonov:pyyaml:6.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyyaml@6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "51-requests",
+      "name": "requests",
+      "version": "2.28.1",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:requests:2.28.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.28.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "52-certifi",
+      "name": "certifi",
+      "version": "2022.12.7",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:certifi:2022.12.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "url": "https://www.mozilla.org/MPL/2.0/"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2022.12.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "53-urllib3",
+      "name": "urllib3",
+      "version": "1.26.13",
+      "author": "Andrey Petrov",
+      "cpe": "cpe:/a:andrey_petrov:urllib3:1.26.13",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@1.26.13"
+    },
+    {
+      "type": "library",
+      "bom-ref": "54-rich",
+      "name": "rich",
+      "version": "13.0.0",
+      "author": "Will McGugan",
+      "cpe": "cpe:/a:will_mcgugan:rich:13.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rich@13.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "55-commonmark",
+      "name": "commonmark",
+      "version": "0.9.1",
+      "author": "Bibek Kafle <bkafle662@gmail.com>, Roland Shoemaker <rolandshoemaker@gmail.com>",
+      "cpe": "cpe:/a:bibek_kafle_<bkafle662@gmail.com>,_roland_shoemaker_<rolandshoemaker@gmail.com>:commonmark:0.9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/commonmark@0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "56-pygments",
+      "name": "pygments",
+      "version": "2.14.0",
+      "author": "Georg Brandl",
+      "cpe": "cpe:/a:georg_brandl:pygments:2.14.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pygments@2.14.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "57-typing-extensions",
+      "name": "typing-extensions",
+      "version": "4.4.0",
+      "purl": "pkg:pypi/typing-extensions@4.4.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "58-rpmfile",
+      "name": "rpmfile",
+      "version": "1.0.8",
+      "author": "Sean Ross-Ross",
+      "cpe": "cpe:/a:sean_ross-ross:rpmfile:1.0.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rpmfile@1.0.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "59-toml",
+      "name": "toml",
+      "version": "0.10.2",
+      "author": "William Pearson",
+      "cpe": "cpe:/a:william_pearson:toml:0.10.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "60-xmlschema",
+      "name": "xmlschema",
+      "version": "2.1.1",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:xmlschema:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/xmlschema@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "61-elementpath",
+      "name": "elementpath",
+      "version": "3.0.2",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:elementpath:3.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/elementpath@3.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "62-zstandard",
+      "name": "zstandard",
+      "version": "0.19.0",
+      "author": "Gregory Szorc",
+      "cpe": "cpe:/a:gregory_szorc:zstandard:0.19.0",
+      "purl": "pkg:pypi/zstandard@0.19.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "1-cve-bin-tool",
+      "dependsOn": [
+        "2-aiohttp",
+        "11-beautifulsoup4",
+        "13-cvss",
+        "14-defusedxml",
+        "15-distro",
+        "16-gsutil",
+        "40-importlib-resources",
+        "42-jinja2",
+        "44-jsonschema",
+        "47-packaging",
+        "48-plotly",
+        "50-pyyaml",
+        "51-requests",
+        "54-rich",
+        "58-rpmfile",
+        "59-toml",
+        "53-urllib3",
+        "60-xmlschema",
+        "62-zstandard"
+      ]
+    },
+    {
+      "ref": "2-aiohttp",
+      "dependsOn": [
+        "3-aiosignal",
+        "5-async-timeout",
+        "6-attrs",
+        "7-charset-normalizer",
+        "4-frozenlist",
+        "8-multidict",
+        "9-yarl"
+      ]
+    },
+    {
+      "ref": "3-aiosignal",
+      "dependsOn": [
+        "4-frozenlist"
+      ]
+    },
+    {
+      "ref": "9-yarl",
+      "dependsOn": [
+        "10-idna",
+        "8-multidict"
+      ]
+    },
+    {
+      "ref": "11-beautifulsoup4",
+      "dependsOn": [
+        "12-soupsieve"
+      ]
+    },
+    {
+      "ref": "16-gsutil",
+      "dependsOn": [
+        "17-argcomplete",
+        "18-crcmod",
+        "19-fasteners",
+        "20-gcs-oauth2-boto-plugin",
+        "36-google-apitools",
+        "37-google-auth",
+        "22-google-reauth",
+        "25-httplib2",
+        "39-monotonic",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "20-gcs-oauth2-boto-plugin",
+      "dependsOn": [
+        "21-boto",
+        "22-google-reauth",
+        "25-httplib2",
+        "27-oauth2client",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "22-google-reauth",
+      "dependsOn": [
+        "23-pyu2f"
+      ]
+    },
+    {
+      "ref": "23-pyu2f",
+      "dependsOn": [
+        "24-six"
+      ]
+    },
+    {
+      "ref": "25-httplib2",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "27-oauth2client",
+      "dependsOn": [
+        "25-httplib2",
+        "28-pyasn1",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "29-pyasn1-modules",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "30-rsa",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "31-pyopenssl",
+      "dependsOn": [
+        "32-cryptography"
+      ]
+    },
+    {
+      "ref": "32-cryptography",
+      "dependsOn": [
+        "33-cffi"
+      ]
+    },
+    {
+      "ref": "33-cffi",
+      "dependsOn": [
+        "34-pycparser"
+      ]
+    },
+    {
+      "ref": "36-google-apitools",
+      "dependsOn": [
+        "19-fasteners",
+        "25-httplib2",
+        "27-oauth2client",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "37-google-auth",
+      "dependsOn": [
+        "38-cachetools",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "40-importlib-resources",
+      "dependsOn": [
+        "41-zipp"
+      ]
+    },
+    {
+      "ref": "42-jinja2",
+      "dependsOn": [
+        "43-markupsafe"
+      ]
+    },
+    {
+      "ref": "44-jsonschema",
+      "dependsOn": [
+        "6-attrs",
+        "40-importlib-resources",
+        "45-pkgutil-resolve-name",
+        "46-pyrsistent"
+      ]
+    },
+    {
+      "ref": "47-packaging",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "48-plotly",
+      "dependsOn": [
+        "49-tenacity"
+      ]
+    },
+    {
+      "ref": "51-requests",
+      "dependsOn": [
+        "52-certifi",
+        "7-charset-normalizer",
+        "10-idna",
+        "53-urllib3"
+      ]
+    },
+    {
+      "ref": "54-rich",
+      "dependsOn": [
+        "55-commonmark",
+        "56-pygments",
+        "57-typing-extensions"
+      ]
+    },
+    {
+      "ref": "60-xmlschema",
+      "dependsOn": [
+        "61-elementpath"
+      ]
+    }
+  ]
+}

--- a/sbom/cve-bin-tool-py3.8.spdx
+++ b/sbom/cve-bin-tool-py3.8.spdx
@@ -1,0 +1,903 @@
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: cve-bin-tool
+DocumentNamespace: http://spdx.org/spdxdocs/cve-bin-tool-19d971c0-b6f4-4900-95ab-83ecfe6f9173
+LicenseListVersion: 3.18
+Creator: Tool: sbom4python-0.4.0
+Created: 2023-01-03T00:48:21Z
+CreatorComment: <text>This document has been automatically generated.</text>
+##### 
+
+PackageName: cve-bin-tool
+SPDXID: SPDXRef-Package-1-cve-bin-tool
+PackageSupplier: Person: Terri_Oda
+PackageVersion: 3.2.1.dev0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license GPL-3.0-or-later
+PackageLicenseConcluded: GPL-3.0-or-later
+PackageLicenseDeclared: GPL-3.0-or-later
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cve-bin-tool@3.2.1.dev0
+##### 
+
+PackageName: aiohttp
+SPDXID: SPDXRef-Package-2-aiohttp
+PackageSupplier: NOASSERTION
+PackageVersion: 3.8.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.3
+##### 
+
+PackageName: aiosignal
+SPDXID: SPDXRef-Package-3-aiosignal
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
+##### 
+
+PackageName: frozenlist
+SPDXID: SPDXRef-Package-4-frozenlist
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+##### 
+
+PackageName: async-timeout
+SPDXID: SPDXRef-Package-5-async-timeout
+PackageSupplier: Organization: Andrew_Svetlov_<andrew.svetlov@gmail.com>
+PackageVersion: 4.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/async-timeout@4.0.2
+##### 
+
+PackageName: attrs
+SPDXID: SPDXRef-Package-6-attrs
+PackageSupplier: Person: Hynek_Schlawack
+PackageVersion: 22.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/attrs@22.2.0
+##### 
+
+PackageName: charset-normalizer
+SPDXID: SPDXRef-Package-7-charset-normalizer
+PackageSupplier: Organization: Ahmed_TAHRI_@Ousret
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/charset-normalizer@2.1.1
+##### 
+
+PackageName: multidict
+SPDXID: SPDXRef-Package-8-multidict
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 6.0.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/multidict@6.0.4
+##### 
+
+PackageName: yarl
+SPDXID: SPDXRef-Package-9-yarl
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 1.8.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/yarl@1.8.2
+##### 
+
+PackageName: idna
+SPDXID: SPDXRef-Package-10-idna
+PackageSupplier: NOASSERTION
+PackageVersion: 3.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/idna@3.4
+##### 
+
+PackageName: beautifulsoup4
+SPDXID: SPDXRef-Package-11-beautifulsoup4
+PackageSupplier: Person: Leonard_Richardson
+PackageVersion: 4.11.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/beautifulsoup4@4.11.1
+##### 
+
+PackageName: soupsieve
+SPDXID: SPDXRef-Package-12-soupsieve
+PackageSupplier: NOASSERTION
+PackageVersion: 2.3.2.post1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/soupsieve@2.3.2.post1
+##### 
+
+PackageName: cvss
+SPDXID: SPDXRef-Package-13-cvss
+PackageSupplier: Organization: Stanislav_Kontar,_Red_Hat_Product_Security
+PackageVersion: 2.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license LGPLv3+
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cvss@2.5
+##### 
+
+PackageName: defusedxml
+SPDXID: SPDXRef-Package-14-defusedxml
+PackageSupplier: Person: Christian_Heimes
+PackageVersion: 0.7.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license PSFL
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/defusedxml@0.7.1
+##### 
+
+PackageName: distro
+SPDXID: SPDXRef-Package-15-distro
+PackageSupplier: Person: Nir_Cohen
+PackageVersion: 1.8.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/distro@1.8.0
+##### 
+
+PackageName: gsutil
+SPDXID: SPDXRef-Package-16-gsutil
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 5.17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gsutil@5.17
+##### 
+
+PackageName: argcomplete
+SPDXID: SPDXRef-Package-17-argcomplete
+PackageSupplier: Person: Andrey_Kislyuk
+PackageVersion: 2.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache Software License
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/argcomplete@2.0.0
+##### 
+
+PackageName: crcmod
+SPDXID: SPDXRef-Package-18-crcmod
+PackageSupplier: Person: Ray_Buvel
+PackageVersion: 1.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/crcmod@1.7
+##### 
+
+PackageName: fasteners
+SPDXID: SPDXRef-Package-19-fasteners
+PackageSupplier: Person: Joshua_Harlow
+PackageVersion: 0.18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/fasteners@0.18
+##### 
+
+PackageName: gcs-oauth2-boto-plugin
+SPDXID: SPDXRef-Package-20-gcs-oauth2-boto-plugin
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 3.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gcs-oauth2-boto-plugin@3.0
+##### 
+
+PackageName: boto
+SPDXID: SPDXRef-Package-21-boto
+PackageSupplier: Person: Mitch_Garnaat
+PackageVersion: 2.49.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/boto@2.49.0
+##### 
+
+PackageName: google-reauth
+SPDXID: SPDXRef-Package-22-google-reauth
+PackageSupplier: Person: Google
+PackageVersion: 0.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-reauth@0.1.1
+##### 
+
+PackageName: pyu2f
+SPDXID: SPDXRef-Package-23-pyu2f
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 0.1.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyu2f@0.1.5
+##### 
+
+PackageName: six
+SPDXID: SPDXRef-Package-24-six
+PackageSupplier: Person: Benjamin_Peterson
+PackageVersion: 1.16.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/six@1.16.0
+##### 
+
+PackageName: httplib2
+SPDXID: SPDXRef-Package-25-httplib2
+PackageSupplier: Person: Joe_Gregorio
+PackageVersion: 0.20.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/httplib2@0.20.4
+##### 
+
+PackageName: pyparsing
+SPDXID: SPDXRef-Package-26-pyparsing
+PackageSupplier: NOASSERTION
+PackageVersion: 3.0.9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyparsing@3.0.9
+##### 
+
+PackageName: oauth2client
+SPDXID: SPDXRef-Package-27-oauth2client
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 4.1.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/oauth2client@4.1.3
+##### 
+
+PackageName: pyasn1
+SPDXID: SPDXRef-Package-28-pyasn1
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.4.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1@0.4.8
+##### 
+
+PackageName: pyasn1-modules
+SPDXID: SPDXRef-Package-29-pyasn1-modules
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.2.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1-modules@0.2.8
+##### 
+
+PackageName: rsa
+SPDXID: SPDXRef-Package-30-rsa
+PackageSupplier: Organization: Sybren_A._Stuvel
+PackageVersion: 4.7.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rsa@4.7.2
+##### 
+
+PackageName: pyopenssl
+SPDXID: SPDXRef-Package-31-pyopenssl
+PackageSupplier: Organization: The_pyOpenSSL_developers
+PackageVersion: 23.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyopenssl@23.0.0
+##### 
+
+PackageName: cryptography
+SPDXID: SPDXRef-Package-32-cryptography
+PackageSupplier: Organization: The_Python_Cryptographic_Authority_and_individual_contributors
+PackageVersion: 39.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license (Apache-2.0 OR BSD-3-Clause) AND PSF-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@39.0.0
+##### 
+
+PackageName: cffi
+SPDXID: SPDXRef-Package-33-cffi
+PackageSupplier: Organization: Armin_Rigo,_Maciej_Fijalkowski
+PackageVersion: 1.15.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cffi@1.15.1
+##### 
+
+PackageName: pycparser
+SPDXID: SPDXRef-Package-34-pycparser
+PackageSupplier: Person: Eli_Bendersky
+PackageVersion: 2.21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pycparser@2.21
+##### 
+
+PackageName: retry-decorator
+SPDXID: SPDXRef-Package-35-retry-decorator
+PackageSupplier: Person: Patrick_Ng
+PackageVersion: 1.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/retry-decorator@1.1.1
+##### 
+
+PackageName: google-apitools
+SPDXID: SPDXRef-Package-36-google-apitools
+PackageSupplier: Person: Craig_Citro
+PackageVersion: 0.5.32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-apitools@0.5.32
+##### 
+
+PackageName: google-auth
+SPDXID: SPDXRef-Package-37-google-auth
+PackageSupplier: Organization: Google_Cloud_Platform
+PackageVersion: 2.15.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.15.0
+##### 
+
+PackageName: cachetools
+SPDXID: SPDXRef-Package-38-cachetools
+PackageSupplier: Person: Thomas_Kemmer
+PackageVersion: 5.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cachetools@5.2.0
+##### 
+
+PackageName: monotonic
+SPDXID: SPDXRef-Package-39-monotonic
+PackageSupplier: Person: Ori_Livneh
+PackageVersion: 1.6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/monotonic@1.6
+##### 
+
+PackageName: importlib-resources
+SPDXID: SPDXRef-Package-40-importlib-resources
+PackageSupplier: Person: Barry_Warsaw
+PackageVersion: 5.10.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/importlib-resources@5.10.2
+##### 
+
+PackageName: zipp
+SPDXID: SPDXRef-Package-41-zipp
+PackageSupplier: Organization: Jason_R._Coombs
+PackageVersion: 3.11.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zipp@3.11.0
+##### 
+
+PackageName: jinja2
+SPDXID: SPDXRef-Package-42-jinja2
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 3.1.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jinja2@3.1.2
+##### 
+
+PackageName: markupsafe
+SPDXID: SPDXRef-Package-43-markupsafe
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.1
+##### 
+
+PackageName: jsonschema
+SPDXID: SPDXRef-Package-44-jsonschema
+PackageSupplier: Person: Julian_Berman
+PackageVersion: 4.17.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.17.3
+##### 
+
+PackageName: pkgutil-resolve-name
+SPDXID: SPDXRef-Package-45-pkgutil-resolve-name
+PackageSupplier: Person: Vinay_Sajip
+PackageVersion: 1.3.10
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pkgutil-resolve-name@1.3.10
+##### 
+
+PackageName: pyrsistent
+SPDXID: SPDXRef-Package-46-pyrsistent
+PackageSupplier: Person: Tobias_Gustafsson
+PackageVersion: 0.19.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyrsistent@0.19.3
+##### 
+
+PackageName: packaging
+SPDXID: SPDXRef-Package-47-packaging
+PackageSupplier: Organization: Donald_Stufft_and_individual_contributors
+PackageVersion: 21.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause or Apache-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/packaging@21.3
+##### 
+
+PackageName: plotly
+SPDXID: SPDXRef-Package-48-plotly
+PackageSupplier: Person: Chris_P
+PackageVersion: 5.11.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/plotly@5.11.0
+##### 
+
+PackageName: tenacity
+SPDXID: SPDXRef-Package-49-tenacity
+PackageSupplier: Person: Julien_Danjou
+PackageVersion: 8.1.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/tenacity@8.1.0
+##### 
+
+PackageName: pyyaml
+SPDXID: SPDXRef-Package-50-pyyaml
+PackageSupplier: Person: Kirill_Simonov
+PackageVersion: 6.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
+##### 
+
+PackageName: requests
+SPDXID: SPDXRef-Package-51-requests
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2.28.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/requests@2.28.1
+##### 
+
+PackageName: certifi
+SPDXID: SPDXRef-Package-52-certifi
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2022.12.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MPL-2.0
+PackageLicenseConcluded: MPL-2.0
+PackageLicenseDeclared: MPL-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2022.12.7
+##### 
+
+PackageName: urllib3
+SPDXID: SPDXRef-Package-53-urllib3
+PackageSupplier: Person: Andrey_Petrov
+PackageVersion: 1.26.13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/urllib3@1.26.13
+##### 
+
+PackageName: rich
+SPDXID: SPDXRef-Package-54-rich
+PackageSupplier: Person: Will_McGugan
+PackageVersion: 13.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rich@13.0.0
+##### 
+
+PackageName: commonmark
+SPDXID: SPDXRef-Package-55-commonmark
+PackageSupplier: Organization: Bibek_Kafle_<bkafle662@gmail.com>,_Roland_Shoemaker_<rolandshoemaker@gmail.com>
+PackageVersion: 0.9.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/commonmark@0.9.1
+##### 
+
+PackageName: pygments
+SPDXID: SPDXRef-Package-56-pygments
+PackageSupplier: Person: Georg_Brandl
+PackageVersion: 2.14.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pygments@2.14.0
+##### 
+
+PackageName: typing-extensions
+SPDXID: SPDXRef-Package-57-typing-extensions
+PackageSupplier: NOASSERTION
+PackageVersion: 4.4.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/typing-extensions@4.4.0
+##### 
+
+PackageName: rpmfile
+SPDXID: SPDXRef-Package-58-rpmfile
+PackageSupplier: Person: Sean_Ross-Ross
+PackageVersion: 1.0.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpmfile@1.0.8
+##### 
+
+PackageName: toml
+SPDXID: SPDXRef-Package-59-toml
+PackageSupplier: Person: William_Pearson
+PackageVersion: 0.10.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/toml@0.10.2
+##### 
+
+PackageName: xmlschema
+SPDXID: SPDXRef-Package-60-xmlschema
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/xmlschema@2.1.1
+##### 
+
+PackageName: elementpath
+SPDXID: SPDXRef-Package-61-elementpath
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 3.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/elementpath@3.0.2
+##### 
+
+PackageName: zstandard
+SPDXID: SPDXRef-Package-62-zstandard
+PackageSupplier: Person: Gregory_Szorc
+PackageVersion: 0.19.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zstandard@0.19.0
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1-cve-bin-tool
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-11-beautifulsoup4
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-13-cvss
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-14-defusedxml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-15-distro
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-16-gsutil
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-2-aiohttp
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-40-importlib-resources
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-42-jinja2
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-44-jsonschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-47-packaging
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-48-plotly
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-50-pyyaml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-51-requests
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-53-urllib3
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-54-rich
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-58-rpmfile
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-59-toml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-60-xmlschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-62-zstandard
+Relationship: SPDXRef-Package-11-beautifulsoup4 CONTAINS SPDXRef-Package-12-soupsieve
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-17-argcomplete
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-18-crcmod
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-19-fasteners
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-20-gcs-oauth2-boto-plugin
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-22-google-reauth
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-31-pyopenssl
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-35-retry-decorator
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-36-google-apitools
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-37-google-auth
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-39-monotonic
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-3-aiosignal
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-5-async-timeout
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-6-attrs
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-7-charset-normalizer
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-8-multidict
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-9-yarl
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-21-boto
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-22-google-reauth
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-27-oauth2client
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-31-pyopenssl
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-35-retry-decorator
+Relationship: SPDXRef-Package-22-google-reauth CONTAINS SPDXRef-Package-23-pyu2f
+Relationship: SPDXRef-Package-23-pyu2f CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-25-httplib2 CONTAINS SPDXRef-Package-26-pyparsing
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-29-pyasn1-modules
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-29-pyasn1-modules CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-3-aiosignal CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-30-rsa CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-31-pyopenssl CONTAINS SPDXRef-Package-32-cryptography
+Relationship: SPDXRef-Package-32-cryptography CONTAINS SPDXRef-Package-33-cffi
+Relationship: SPDXRef-Package-33-cffi CONTAINS SPDXRef-Package-34-pycparser
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-19-fasteners
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-27-oauth2client
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-29-pyasn1-modules
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-38-cachetools
+Relationship: SPDXRef-Package-40-importlib-resources CONTAINS SPDXRef-Package-41-zipp
+Relationship: SPDXRef-Package-42-jinja2 CONTAINS SPDXRef-Package-43-markupsafe
+Relationship: SPDXRef-Package-44-jsonschema CONTAINS SPDXRef-Package-40-importlib-resources
+Relationship: SPDXRef-Package-44-jsonschema CONTAINS SPDXRef-Package-45-pkgutil-resolve-name
+Relationship: SPDXRef-Package-44-jsonschema CONTAINS SPDXRef-Package-46-pyrsistent
+Relationship: SPDXRef-Package-44-jsonschema CONTAINS SPDXRef-Package-6-attrs
+Relationship: SPDXRef-Package-47-packaging CONTAINS SPDXRef-Package-26-pyparsing
+Relationship: SPDXRef-Package-48-plotly CONTAINS SPDXRef-Package-49-tenacity
+Relationship: SPDXRef-Package-51-requests CONTAINS SPDXRef-Package-10-idna
+Relationship: SPDXRef-Package-51-requests CONTAINS SPDXRef-Package-52-certifi
+Relationship: SPDXRef-Package-51-requests CONTAINS SPDXRef-Package-53-urllib3
+Relationship: SPDXRef-Package-51-requests CONTAINS SPDXRef-Package-7-charset-normalizer
+Relationship: SPDXRef-Package-54-rich CONTAINS SPDXRef-Package-55-commonmark
+Relationship: SPDXRef-Package-54-rich CONTAINS SPDXRef-Package-56-pygments
+Relationship: SPDXRef-Package-54-rich CONTAINS SPDXRef-Package-57-typing-extensions
+Relationship: SPDXRef-Package-60-xmlschema CONTAINS SPDXRef-Package-61-elementpath
+Relationship: SPDXRef-Package-9-yarl CONTAINS SPDXRef-Package-10-idna
+Relationship: SPDXRef-Package-9-yarl CONTAINS SPDXRef-Package-8-multidict

--- a/sbom/cve-bin-tool-py3.9.json
+++ b/sbom/cve-bin-tool-py3.9.json
@@ -1,0 +1,1097 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.4",
+  "serialNumber": "urn:uuid44df97ba-2a0d-4fbb-b836-d3a16e801a41",
+  "version": 1,
+  "metadata": {
+    "timestamp": "2023-01-02T23:37:09Z",
+    "tools": [
+      {
+        "name": "sbom4python",
+        "version": "0.4.0"
+      }
+    ]
+  },
+  "components": [
+    {
+      "type": "application",
+      "bom-ref": "1-cve-bin-tool",
+      "name": "cve-bin-tool",
+      "version": "3.2.1.dev0",
+      "author": "Terri Oda",
+      "cpe": "cpe:/a:terri_oda:cve-bin-tool:3.2.1.dev0",
+      "licenses": [
+        {
+          "license": {
+            "id": "GPL-3.0-or-later",
+            "url": "https://www.gnu.org/licenses/gpl-3.0-standalone.html"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cve-bin-tool@3.2.1.dev0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "2-aiohttp",
+      "name": "aiohttp",
+      "version": "3.8.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiohttp@3.8.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "3-aiosignal",
+      "name": "aiosignal",
+      "version": "1.3.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/aiosignal@1.3.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "4-frozenlist",
+      "name": "frozenlist",
+      "version": "1.3.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/frozenlist@1.3.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "5-async-timeout",
+      "name": "async-timeout",
+      "version": "4.0.2",
+      "author": "Andrew Svetlov <andrew.svetlov@gmail.com>",
+      "cpe": "cpe:/a:andrew_svetlov_<andrew.svetlov@gmail.com>:async-timeout:4.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/async-timeout@4.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "6-attrs",
+      "name": "attrs",
+      "version": "22.2.0",
+      "author": "Hynek Schlawack",
+      "cpe": "cpe:/a:hynek_schlawack:attrs:22.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/attrs@22.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "7-charset-normalizer",
+      "name": "charset-normalizer",
+      "version": "2.1.1",
+      "author": "Ahmed TAHRI @Ousret",
+      "cpe": "cpe:/a:ahmed_tahri_@ousret:charset-normalizer:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/charset-normalizer@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "8-multidict",
+      "name": "multidict",
+      "version": "6.0.4",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:multidict:6.0.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/multidict@6.0.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "9-yarl",
+      "name": "yarl",
+      "version": "1.8.2",
+      "author": "Andrew Svetlov",
+      "cpe": "cpe:/a:andrew_svetlov:yarl:1.8.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/yarl@1.8.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "10-idna",
+      "name": "idna",
+      "version": "3.4",
+      "purl": "pkg:pypi/idna@3.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "11-beautifulsoup4",
+      "name": "beautifulsoup4",
+      "version": "4.11.1",
+      "author": "Leonard Richardson",
+      "cpe": "cpe:/a:leonard_richardson:beautifulsoup4:4.11.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/beautifulsoup4@4.11.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "12-soupsieve",
+      "name": "soupsieve",
+      "version": "2.3.2.post1",
+      "purl": "pkg:pypi/soupsieve@2.3.2.post1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "13-cvss",
+      "name": "cvss",
+      "version": "2.5",
+      "author": "Stanislav Kontar, Red Hat Product Security",
+      "cpe": "cpe:/a:stanislav_kontar,_red_hat_product_security:cvss:2.5",
+      "purl": "pkg:pypi/cvss@2.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "14-defusedxml",
+      "name": "defusedxml",
+      "version": "0.7.1",
+      "author": "Christian Heimes",
+      "cpe": "cpe:/a:christian_heimes:defusedxml:0.7.1",
+      "purl": "pkg:pypi/defusedxml@0.7.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "15-distro",
+      "name": "distro",
+      "version": "1.8.0",
+      "author": "Nir Cohen",
+      "cpe": "cpe:/a:nir_cohen:distro:1.8.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/distro@1.8.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "16-gsutil",
+      "name": "gsutil",
+      "version": "5.17",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gsutil:5.17",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gsutil@5.17"
+    },
+    {
+      "type": "library",
+      "bom-ref": "17-argcomplete",
+      "name": "argcomplete",
+      "version": "2.0.0",
+      "author": "Andrey Kislyuk",
+      "cpe": "cpe:/a:andrey_kislyuk:argcomplete:2.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/argcomplete@2.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "18-crcmod",
+      "name": "crcmod",
+      "version": "1.7",
+      "author": "Ray Buvel",
+      "cpe": "cpe:/a:ray_buvel:crcmod:1.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/crcmod@1.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "19-fasteners",
+      "name": "fasteners",
+      "version": "0.18",
+      "author": "Joshua Harlow",
+      "cpe": "cpe:/a:joshua_harlow:fasteners:0.18",
+      "purl": "pkg:pypi/fasteners@0.18"
+    },
+    {
+      "type": "library",
+      "bom-ref": "20-gcs-oauth2-boto-plugin",
+      "name": "gcs-oauth2-boto-plugin",
+      "version": "3.0",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:gcs-oauth2-boto-plugin:3.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/gcs-oauth2-boto-plugin@3.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "21-boto",
+      "name": "boto",
+      "version": "2.49.0",
+      "author": "Mitch Garnaat",
+      "cpe": "cpe:/a:mitch_garnaat:boto:2.49.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/boto@2.49.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "22-google-reauth",
+      "name": "google-reauth",
+      "version": "0.1.1",
+      "author": "Google",
+      "cpe": "cpe:/a:google:google-reauth:0.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-reauth@0.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "23-pyu2f",
+      "name": "pyu2f",
+      "version": "0.1.5",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:pyu2f:0.1.5",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyu2f@0.1.5"
+    },
+    {
+      "type": "library",
+      "bom-ref": "24-six",
+      "name": "six",
+      "version": "1.16.0",
+      "author": "Benjamin Peterson",
+      "cpe": "cpe:/a:benjamin_peterson:six:1.16.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/six@1.16.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "25-httplib2",
+      "name": "httplib2",
+      "version": "0.20.4",
+      "author": "Joe Gregorio",
+      "cpe": "cpe:/a:joe_gregorio:httplib2:0.20.4",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/httplib2@0.20.4"
+    },
+    {
+      "type": "library",
+      "bom-ref": "26-pyparsing",
+      "name": "pyparsing",
+      "version": "3.0.9",
+      "purl": "pkg:pypi/pyparsing@3.0.9"
+    },
+    {
+      "type": "library",
+      "bom-ref": "27-oauth2client",
+      "name": "oauth2client",
+      "version": "4.1.3",
+      "author": "Google Inc.",
+      "cpe": "cpe:/a:google_inc.:oauth2client:4.1.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/oauth2client@4.1.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "28-pyasn1",
+      "name": "pyasn1",
+      "version": "0.4.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1:0.4.8",
+      "purl": "pkg:pypi/pyasn1@0.4.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "29-pyasn1-modules",
+      "name": "pyasn1-modules",
+      "version": "0.2.8",
+      "author": "Ilya Etingof",
+      "cpe": "cpe:/a:ilya_etingof:pyasn1-modules:0.2.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyasn1-modules@0.2.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "30-rsa",
+      "name": "rsa",
+      "version": "4.7.2",
+      "author": "Sybren A. Stuvel",
+      "cpe": "cpe:/a:sybren_a._stuvel:rsa:4.7.2",
+      "purl": "pkg:pypi/rsa@4.7.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "31-pyopenssl",
+      "name": "pyopenssl",
+      "version": "23.0.0",
+      "author": "The pyOpenSSL developers",
+      "cpe": "cpe:/a:the_pyopenssl_developers:pyopenssl:23.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyopenssl@23.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "32-cryptography",
+      "name": "cryptography",
+      "version": "39.0.0",
+      "author": "The Python Cryptographic Authority and individual contributors",
+      "cpe": "cpe:/a:the_python_cryptographic_authority_and_individual_contributors:cryptography:39.0.0",
+      "purl": "pkg:pypi/cryptography@39.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "33-cffi",
+      "name": "cffi",
+      "version": "1.15.1",
+      "author": "Armin Rigo, Maciej Fijalkowski",
+      "cpe": "cpe:/a:armin_rigo,_maciej_fijalkowski:cffi:1.15.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cffi@1.15.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "34-pycparser",
+      "name": "pycparser",
+      "version": "2.21",
+      "author": "Eli Bendersky",
+      "cpe": "cpe:/a:eli_bendersky:pycparser:2.21",
+      "purl": "pkg:pypi/pycparser@2.21"
+    },
+    {
+      "type": "library",
+      "bom-ref": "35-retry-decorator",
+      "name": "retry-decorator",
+      "version": "1.1.1",
+      "author": "Patrick Ng",
+      "cpe": "cpe:/a:patrick_ng:retry-decorator:1.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/retry-decorator@1.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "36-google-apitools",
+      "name": "google-apitools",
+      "version": "0.5.32",
+      "author": "Craig Citro",
+      "cpe": "cpe:/a:craig_citro:google-apitools:0.5.32",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-apitools@0.5.32"
+    },
+    {
+      "type": "library",
+      "bom-ref": "37-google-auth",
+      "name": "google-auth",
+      "version": "2.15.0",
+      "author": "Google Cloud Platform",
+      "cpe": "cpe:/a:google_cloud_platform:google-auth:2.15.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/google-auth@2.15.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "38-cachetools",
+      "name": "cachetools",
+      "version": "5.2.0",
+      "author": "Thomas Kemmer",
+      "cpe": "cpe:/a:thomas_kemmer:cachetools:5.2.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/cachetools@5.2.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "39-monotonic",
+      "name": "monotonic",
+      "version": "1.6",
+      "author": "Ori Livneh",
+      "cpe": "cpe:/a:ori_livneh:monotonic:1.6",
+      "purl": "pkg:pypi/monotonic@1.6"
+    },
+    {
+      "type": "library",
+      "bom-ref": "40-jinja2",
+      "name": "jinja2",
+      "version": "3.1.2",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:jinja2:3.1.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jinja2@3.1.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "41-markupsafe",
+      "name": "markupsafe",
+      "version": "2.1.1",
+      "author": "Armin Ronacher",
+      "cpe": "cpe:/a:armin_ronacher:markupsafe:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/markupsafe@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "42-jsonschema",
+      "name": "jsonschema",
+      "version": "4.17.3",
+      "author": "Julian Berman",
+      "cpe": "cpe:/a:julian_berman:jsonschema:4.17.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/jsonschema@4.17.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "43-pyrsistent",
+      "name": "pyrsistent",
+      "version": "0.19.3",
+      "author": "Tobias Gustafsson",
+      "cpe": "cpe:/a:tobias_gustafsson:pyrsistent:0.19.3",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyrsistent@0.19.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "44-packaging",
+      "name": "packaging",
+      "version": "21.3",
+      "author": "Donald Stufft and individual contributors",
+      "cpe": "cpe:/a:donald_stufft_and_individual_contributors:packaging:21.3",
+      "purl": "pkg:pypi/packaging@21.3"
+    },
+    {
+      "type": "library",
+      "bom-ref": "45-plotly",
+      "name": "plotly",
+      "version": "5.11.0",
+      "author": "Chris P",
+      "cpe": "cpe:/a:chris_p:plotly:5.11.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/plotly@5.11.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "46-tenacity",
+      "name": "tenacity",
+      "version": "8.1.0",
+      "author": "Julien Danjou",
+      "cpe": "cpe:/a:julien_danjou:tenacity:8.1.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/tenacity@8.1.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "47-pyyaml",
+      "name": "pyyaml",
+      "version": "6.0",
+      "author": "Kirill Simonov",
+      "cpe": "cpe:/a:kirill_simonov:pyyaml:6.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pyyaml@6.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "48-requests",
+      "name": "requests",
+      "version": "2.28.1",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:requests:2.28.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/requests@2.28.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "49-certifi",
+      "name": "certifi",
+      "version": "2022.12.7",
+      "author": "Kenneth Reitz",
+      "cpe": "cpe:/a:kenneth_reitz:certifi:2022.12.7",
+      "licenses": [
+        {
+          "license": {
+            "id": "MPL-2.0",
+            "url": "https://www.mozilla.org/MPL/2.0/"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/certifi@2022.12.7"
+    },
+    {
+      "type": "library",
+      "bom-ref": "50-urllib3",
+      "name": "urllib3",
+      "version": "1.26.13",
+      "author": "Andrey Petrov",
+      "cpe": "cpe:/a:andrey_petrov:urllib3:1.26.13",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/urllib3@1.26.13"
+    },
+    {
+      "type": "library",
+      "bom-ref": "51-rich",
+      "name": "rich",
+      "version": "13.0.0",
+      "author": "Will McGugan",
+      "cpe": "cpe:/a:will_mcgugan:rich:13.0.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rich@13.0.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "52-commonmark",
+      "name": "commonmark",
+      "version": "0.9.1",
+      "author": "Bibek Kafle <bkafle662@gmail.com>, Roland Shoemaker <rolandshoemaker@gmail.com>",
+      "cpe": "cpe:/a:bibek_kafle_<bkafle662@gmail.com>,_roland_shoemaker_<rolandshoemaker@gmail.com>:commonmark:0.9.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-3-Clause",
+            "url": "https://opensource.org/licenses/BSD-3-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/commonmark@0.9.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "53-pygments",
+      "name": "pygments",
+      "version": "2.14.0",
+      "author": "Georg Brandl",
+      "cpe": "cpe:/a:georg_brandl:pygments:2.14.0",
+      "licenses": [
+        {
+          "license": {
+            "id": "BSD-2-Clause",
+            "url": "https://opensource.org/licenses/BSD-2-Clause"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/pygments@2.14.0"
+    },
+    {
+      "type": "library",
+      "bom-ref": "54-rpmfile",
+      "name": "rpmfile",
+      "version": "1.0.8",
+      "author": "Sean Ross-Ross",
+      "cpe": "cpe:/a:sean_ross-ross:rpmfile:1.0.8",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/rpmfile@1.0.8"
+    },
+    {
+      "type": "library",
+      "bom-ref": "55-toml",
+      "name": "toml",
+      "version": "0.10.2",
+      "author": "William Pearson",
+      "cpe": "cpe:/a:william_pearson:toml:0.10.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/toml@0.10.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "56-xmlschema",
+      "name": "xmlschema",
+      "version": "2.1.1",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:xmlschema:2.1.1",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/xmlschema@2.1.1"
+    },
+    {
+      "type": "library",
+      "bom-ref": "57-elementpath",
+      "name": "elementpath",
+      "version": "3.0.2",
+      "author": "Davide Brunato",
+      "cpe": "cpe:/a:davide_brunato:elementpath:3.0.2",
+      "licenses": [
+        {
+          "license": {
+            "id": "MIT",
+            "url": "https://opensource.org/licenses/MIT"
+          }
+        }
+      ],
+      "purl": "pkg:pypi/elementpath@3.0.2"
+    },
+    {
+      "type": "library",
+      "bom-ref": "58-zstandard",
+      "name": "zstandard",
+      "version": "0.19.0",
+      "author": "Gregory Szorc",
+      "cpe": "cpe:/a:gregory_szorc:zstandard:0.19.0",
+      "purl": "pkg:pypi/zstandard@0.19.0"
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "1-cve-bin-tool",
+      "dependsOn": [
+        "2-aiohttp",
+        "11-beautifulsoup4",
+        "13-cvss",
+        "14-defusedxml",
+        "15-distro",
+        "16-gsutil",
+        "40-jinja2",
+        "42-jsonschema",
+        "44-packaging",
+        "45-plotly",
+        "47-pyyaml",
+        "48-requests",
+        "51-rich",
+        "54-rpmfile",
+        "55-toml",
+        "50-urllib3",
+        "56-xmlschema",
+        "58-zstandard"
+      ]
+    },
+    {
+      "ref": "2-aiohttp",
+      "dependsOn": [
+        "3-aiosignal",
+        "5-async-timeout",
+        "6-attrs",
+        "7-charset-normalizer",
+        "4-frozenlist",
+        "8-multidict",
+        "9-yarl"
+      ]
+    },
+    {
+      "ref": "3-aiosignal",
+      "dependsOn": [
+        "4-frozenlist"
+      ]
+    },
+    {
+      "ref": "9-yarl",
+      "dependsOn": [
+        "10-idna",
+        "8-multidict"
+      ]
+    },
+    {
+      "ref": "11-beautifulsoup4",
+      "dependsOn": [
+        "12-soupsieve"
+      ]
+    },
+    {
+      "ref": "16-gsutil",
+      "dependsOn": [
+        "17-argcomplete",
+        "18-crcmod",
+        "19-fasteners",
+        "20-gcs-oauth2-boto-plugin",
+        "36-google-apitools",
+        "37-google-auth",
+        "22-google-reauth",
+        "25-httplib2",
+        "39-monotonic",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "20-gcs-oauth2-boto-plugin",
+      "dependsOn": [
+        "21-boto",
+        "22-google-reauth",
+        "25-httplib2",
+        "27-oauth2client",
+        "31-pyopenssl",
+        "35-retry-decorator",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "22-google-reauth",
+      "dependsOn": [
+        "23-pyu2f"
+      ]
+    },
+    {
+      "ref": "23-pyu2f",
+      "dependsOn": [
+        "24-six"
+      ]
+    },
+    {
+      "ref": "25-httplib2",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "27-oauth2client",
+      "dependsOn": [
+        "25-httplib2",
+        "28-pyasn1",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "29-pyasn1-modules",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "30-rsa",
+      "dependsOn": [
+        "28-pyasn1"
+      ]
+    },
+    {
+      "ref": "31-pyopenssl",
+      "dependsOn": [
+        "32-cryptography"
+      ]
+    },
+    {
+      "ref": "32-cryptography",
+      "dependsOn": [
+        "33-cffi"
+      ]
+    },
+    {
+      "ref": "33-cffi",
+      "dependsOn": [
+        "34-pycparser"
+      ]
+    },
+    {
+      "ref": "36-google-apitools",
+      "dependsOn": [
+        "19-fasteners",
+        "25-httplib2",
+        "27-oauth2client",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "37-google-auth",
+      "dependsOn": [
+        "38-cachetools",
+        "29-pyasn1-modules",
+        "30-rsa",
+        "24-six"
+      ]
+    },
+    {
+      "ref": "40-jinja2",
+      "dependsOn": [
+        "41-markupsafe"
+      ]
+    },
+    {
+      "ref": "42-jsonschema",
+      "dependsOn": [
+        "6-attrs",
+        "43-pyrsistent"
+      ]
+    },
+    {
+      "ref": "44-packaging",
+      "dependsOn": [
+        "26-pyparsing"
+      ]
+    },
+    {
+      "ref": "45-plotly",
+      "dependsOn": [
+        "46-tenacity"
+      ]
+    },
+    {
+      "ref": "48-requests",
+      "dependsOn": [
+        "49-certifi",
+        "7-charset-normalizer",
+        "10-idna",
+        "50-urllib3"
+      ]
+    },
+    {
+      "ref": "51-rich",
+      "dependsOn": [
+        "52-commonmark",
+        "53-pygments"
+      ]
+    },
+    {
+      "ref": "56-xmlschema",
+      "dependsOn": [
+        "57-elementpath"
+      ]
+    }
+  ]
+}

--- a/sbom/cve-bin-tool-py3.9.spdx
+++ b/sbom/cve-bin-tool-py3.9.spdx
@@ -1,0 +1,846 @@
+SPDXVersion: SPDX-2.2
+DataLicense: CC0-1.0
+SPDXID: SPDXRef-DOCUMENT
+DocumentName: cve-bin-tool
+DocumentNamespace: http://spdx.org/spdxdocs/cve-bin-tool-9e355190-e497-42b0-ae2a-f2bb05d8796e
+LicenseListVersion: 3.18
+Creator: Tool: sbom4python-0.4.0
+Created: 2023-01-02T23:36:08Z
+CreatorComment: <text>This document has been automatically generated.</text>
+##### 
+
+PackageName: cve-bin-tool
+SPDXID: SPDXRef-Package-1-cve-bin-tool
+PackageSupplier: Person: Terri_Oda
+PackageVersion: 3.2.1.dev0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license GPL-3.0-or-later
+PackageLicenseConcluded: GPL-3.0-or-later
+PackageLicenseDeclared: GPL-3.0-or-later
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cve-bin-tool@3.2.1.dev0
+##### 
+
+PackageName: aiohttp
+SPDXID: SPDXRef-Package-2-aiohttp
+PackageSupplier: NOASSERTION
+PackageVersion: 3.8.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.3
+##### 
+
+PackageName: aiosignal
+SPDXID: SPDXRef-Package-3-aiosignal
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
+##### 
+
+PackageName: frozenlist
+SPDXID: SPDXRef-Package-4-frozenlist
+PackageSupplier: NOASSERTION
+PackageVersion: 1.3.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+##### 
+
+PackageName: async-timeout
+SPDXID: SPDXRef-Package-5-async-timeout
+PackageSupplier: Organization: Andrew_Svetlov_<andrew.svetlov@gmail.com>
+PackageVersion: 4.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/async-timeout@4.0.2
+##### 
+
+PackageName: attrs
+SPDXID: SPDXRef-Package-6-attrs
+PackageSupplier: Person: Hynek_Schlawack
+PackageVersion: 22.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/attrs@22.2.0
+##### 
+
+PackageName: charset-normalizer
+SPDXID: SPDXRef-Package-7-charset-normalizer
+PackageSupplier: Organization: Ahmed_TAHRI_@Ousret
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/charset-normalizer@2.1.1
+##### 
+
+PackageName: multidict
+SPDXID: SPDXRef-Package-8-multidict
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 6.0.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/multidict@6.0.4
+##### 
+
+PackageName: yarl
+SPDXID: SPDXRef-Package-9-yarl
+PackageSupplier: Person: Andrew_Svetlov
+PackageVersion: 1.8.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/yarl@1.8.2
+##### 
+
+PackageName: idna
+SPDXID: SPDXRef-Package-10-idna
+PackageSupplier: NOASSERTION
+PackageVersion: 3.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/idna@3.4
+##### 
+
+PackageName: beautifulsoup4
+SPDXID: SPDXRef-Package-11-beautifulsoup4
+PackageSupplier: Person: Leonard_Richardson
+PackageVersion: 4.11.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/beautifulsoup4@4.11.1
+##### 
+
+PackageName: soupsieve
+SPDXID: SPDXRef-Package-12-soupsieve
+PackageSupplier: NOASSERTION
+PackageVersion: 2.3.2.post1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/soupsieve@2.3.2.post1
+##### 
+
+PackageName: cvss
+SPDXID: SPDXRef-Package-13-cvss
+PackageSupplier: Organization: Stanislav_Kontar,_Red_Hat_Product_Security
+PackageVersion: 2.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license LGPLv3+
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cvss@2.5
+##### 
+
+PackageName: defusedxml
+SPDXID: SPDXRef-Package-14-defusedxml
+PackageSupplier: Person: Christian_Heimes
+PackageVersion: 0.7.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license PSFL
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/defusedxml@0.7.1
+##### 
+
+PackageName: distro
+SPDXID: SPDXRef-Package-15-distro
+PackageSupplier: Person: Nir_Cohen
+PackageVersion: 1.8.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/distro@1.8.0
+##### 
+
+PackageName: gsutil
+SPDXID: SPDXRef-Package-16-gsutil
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 5.17
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gsutil@5.17
+##### 
+
+PackageName: argcomplete
+SPDXID: SPDXRef-Package-17-argcomplete
+PackageSupplier: Person: Andrey_Kislyuk
+PackageVersion: 2.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache Software License
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/argcomplete@2.0.0
+##### 
+
+PackageName: crcmod
+SPDXID: SPDXRef-Package-18-crcmod
+PackageSupplier: Person: Ray_Buvel
+PackageVersion: 1.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/crcmod@1.7
+##### 
+
+PackageName: fasteners
+SPDXID: SPDXRef-Package-19-fasteners
+PackageSupplier: Person: Joshua_Harlow
+PackageVersion: 0.18
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/fasteners@0.18
+##### 
+
+PackageName: gcs-oauth2-boto-plugin
+SPDXID: SPDXRef-Package-20-gcs-oauth2-boto-plugin
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 3.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/gcs-oauth2-boto-plugin@3.0
+##### 
+
+PackageName: boto
+SPDXID: SPDXRef-Package-21-boto
+PackageSupplier: Person: Mitch_Garnaat
+PackageVersion: 2.49.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/boto@2.49.0
+##### 
+
+PackageName: google-reauth
+SPDXID: SPDXRef-Package-22-google-reauth
+PackageSupplier: Person: Google
+PackageVersion: 0.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-reauth@0.1.1
+##### 
+
+PackageName: pyu2f
+SPDXID: SPDXRef-Package-23-pyu2f
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 0.1.5
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyu2f@0.1.5
+##### 
+
+PackageName: six
+SPDXID: SPDXRef-Package-24-six
+PackageSupplier: Person: Benjamin_Peterson
+PackageVersion: 1.16.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/six@1.16.0
+##### 
+
+PackageName: httplib2
+SPDXID: SPDXRef-Package-25-httplib2
+PackageSupplier: Person: Joe_Gregorio
+PackageVersion: 0.20.4
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/httplib2@0.20.4
+##### 
+
+PackageName: pyparsing
+SPDXID: SPDXRef-Package-26-pyparsing
+PackageSupplier: NOASSERTION
+PackageVersion: 3.0.9
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license 
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyparsing@3.0.9
+##### 
+
+PackageName: oauth2client
+SPDXID: SPDXRef-Package-27-oauth2client
+PackageSupplier: Person: Google_Inc.
+PackageVersion: 4.1.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/oauth2client@4.1.3
+##### 
+
+PackageName: pyasn1
+SPDXID: SPDXRef-Package-28-pyasn1
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.4.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1@0.4.8
+##### 
+
+PackageName: pyasn1-modules
+SPDXID: SPDXRef-Package-29-pyasn1-modules
+PackageSupplier: Person: Ilya_Etingof
+PackageVersion: 0.2.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyasn1-modules@0.2.8
+##### 
+
+PackageName: rsa
+SPDXID: SPDXRef-Package-30-rsa
+PackageSupplier: Organization: Sybren_A._Stuvel
+PackageVersion: 4.7.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license ASL 2
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rsa@4.7.2
+##### 
+
+PackageName: pyopenssl
+SPDXID: SPDXRef-Package-31-pyopenssl
+PackageSupplier: Organization: The_pyOpenSSL_developers
+PackageVersion: 23.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache License, Version 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyopenssl@23.0.0
+##### 
+
+PackageName: cryptography
+SPDXID: SPDXRef-Package-32-cryptography
+PackageSupplier: Organization: The_Python_Cryptographic_Authority_and_individual_contributors
+PackageVersion: 39.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license (Apache-2.0 OR BSD-3-Clause) AND PSF-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@39.0.0
+##### 
+
+PackageName: cffi
+SPDXID: SPDXRef-Package-33-cffi
+PackageSupplier: Organization: Armin_Rigo,_Maciej_Fijalkowski
+PackageVersion: 1.15.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cffi@1.15.1
+##### 
+
+PackageName: pycparser
+SPDXID: SPDXRef-Package-34-pycparser
+PackageSupplier: Person: Eli_Bendersky
+PackageVersion: 2.21
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pycparser@2.21
+##### 
+
+PackageName: retry-decorator
+SPDXID: SPDXRef-Package-35-retry-decorator
+PackageSupplier: Person: Patrick_Ng
+PackageVersion: 1.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/retry-decorator@1.1.1
+##### 
+
+PackageName: google-apitools
+SPDXID: SPDXRef-Package-36-google-apitools
+PackageSupplier: Person: Craig_Citro
+PackageVersion: 0.5.32
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-apitools@0.5.32
+##### 
+
+PackageName: google-auth
+SPDXID: SPDXRef-Package-37-google-auth
+PackageSupplier: Organization: Google_Cloud_Platform
+PackageVersion: 2.15.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.15.0
+##### 
+
+PackageName: cachetools
+SPDXID: SPDXRef-Package-38-cachetools
+PackageSupplier: Person: Thomas_Kemmer
+PackageVersion: 5.2.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cachetools@5.2.0
+##### 
+
+PackageName: monotonic
+SPDXID: SPDXRef-Package-39-monotonic
+PackageSupplier: Person: Ori_Livneh
+PackageVersion: 1.6
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/monotonic@1.6
+##### 
+
+PackageName: jinja2
+SPDXID: SPDXRef-Package-40-jinja2
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 3.1.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jinja2@3.1.2
+##### 
+
+PackageName: markupsafe
+SPDXID: SPDXRef-Package-41-markupsafe
+PackageSupplier: Person: Armin_Ronacher
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.1
+##### 
+
+PackageName: jsonschema
+SPDXID: SPDXRef-Package-42-jsonschema
+PackageSupplier: Person: Julian_Berman
+PackageVersion: 4.17.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.17.3
+##### 
+
+PackageName: pyrsistent
+SPDXID: SPDXRef-Package-43-pyrsistent
+PackageSupplier: Person: Tobias_Gustafsson
+PackageVersion: 0.19.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyrsistent@0.19.3
+##### 
+
+PackageName: packaging
+SPDXID: SPDXRef-Package-44-packaging
+PackageSupplier: Organization: Donald_Stufft_and_individual_contributors
+PackageVersion: 21.3
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause or Apache-2.0
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/packaging@21.3
+##### 
+
+PackageName: plotly
+SPDXID: SPDXRef-Package-45-plotly
+PackageSupplier: Person: Chris_P
+PackageVersion: 5.11.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/plotly@5.11.0
+##### 
+
+PackageName: tenacity
+SPDXID: SPDXRef-Package-46-tenacity
+PackageSupplier: Person: Julien_Danjou
+PackageVersion: 8.1.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/tenacity@8.1.0
+##### 
+
+PackageName: pyyaml
+SPDXID: SPDXRef-Package-47-pyyaml
+PackageSupplier: Person: Kirill_Simonov
+PackageVersion: 6.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
+##### 
+
+PackageName: requests
+SPDXID: SPDXRef-Package-48-requests
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2.28.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license Apache 2.0
+PackageLicenseConcluded: Apache-2.0
+PackageLicenseDeclared: Apache-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/requests@2.28.1
+##### 
+
+PackageName: certifi
+SPDXID: SPDXRef-Package-49-certifi
+PackageSupplier: Person: Kenneth_Reitz
+PackageVersion: 2022.12.7
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MPL-2.0
+PackageLicenseConcluded: MPL-2.0
+PackageLicenseDeclared: MPL-2.0
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2022.12.7
+##### 
+
+PackageName: urllib3
+SPDXID: SPDXRef-Package-50-urllib3
+PackageSupplier: Person: Andrey_Petrov
+PackageVersion: 1.26.13
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/urllib3@1.26.13
+##### 
+
+PackageName: rich
+SPDXID: SPDXRef-Package-51-rich
+PackageSupplier: Person: Will_McGugan
+PackageVersion: 13.0.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rich@13.0.0
+##### 
+
+PackageName: commonmark
+SPDXID: SPDXRef-Package-52-commonmark
+PackageSupplier: Organization: Bibek_Kafle_<bkafle662@gmail.com>,_Roland_Shoemaker_<rolandshoemaker@gmail.com>
+PackageVersion: 0.9.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-3-Clause
+PackageLicenseConcluded: BSD-3-Clause
+PackageLicenseDeclared: BSD-3-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/commonmark@0.9.1
+##### 
+
+PackageName: pygments
+SPDXID: SPDXRef-Package-53-pygments
+PackageSupplier: Person: Georg_Brandl
+PackageVersion: 2.14.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD-2-Clause
+PackageLicenseConcluded: BSD-2-Clause
+PackageLicenseDeclared: BSD-2-Clause
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pygments@2.14.0
+##### 
+
+PackageName: rpmfile
+SPDXID: SPDXRef-Package-54-rpmfile
+PackageSupplier: Person: Sean_Ross-Ross
+PackageVersion: 1.0.8
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpmfile@1.0.8
+##### 
+
+PackageName: toml
+SPDXID: SPDXRef-Package-55-toml
+PackageSupplier: Person: William_Pearson
+PackageVersion: 0.10.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/toml@0.10.2
+##### 
+
+PackageName: xmlschema
+SPDXID: SPDXRef-Package-56-xmlschema
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 2.1.1
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/xmlschema@2.1.1
+##### 
+
+PackageName: elementpath
+SPDXID: SPDXRef-Package-57-elementpath
+PackageSupplier: Person: Davide_Brunato
+PackageVersion: 3.0.2
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license MIT
+PackageLicenseConcluded: MIT
+PackageLicenseDeclared: MIT
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/elementpath@3.0.2
+##### 
+
+PackageName: zstandard
+SPDXID: SPDXRef-Package-58-zstandard
+PackageSupplier: Person: Gregory_Szorc
+PackageVersion: 0.19.0
+PackageDownloadLocation: NOASSERTION
+FilesAnalyzed: false
+##### Reported license BSD
+PackageLicenseConcluded: NOASSERTION
+PackageLicenseDeclared: NOASSERTION
+PackageCopyrightText: NOASSERTION
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zstandard@0.19.0
+Relationship: SPDXRef-DOCUMENT DESCRIBES SPDXRef-Package-1-cve-bin-tool
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-11-beautifulsoup4
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-13-cvss
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-14-defusedxml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-15-distro
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-16-gsutil
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-2-aiohttp
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-40-jinja2
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-42-jsonschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-44-packaging
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-45-plotly
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-47-pyyaml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-48-requests
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-50-urllib3
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-51-rich
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-54-rpmfile
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-55-toml
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-56-xmlschema
+Relationship: SPDXRef-Package-1-cve-bin-tool CONTAINS SPDXRef-Package-58-zstandard
+Relationship: SPDXRef-Package-11-beautifulsoup4 CONTAINS SPDXRef-Package-12-soupsieve
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-17-argcomplete
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-18-crcmod
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-19-fasteners
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-20-gcs-oauth2-boto-plugin
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-22-google-reauth
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-31-pyopenssl
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-35-retry-decorator
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-36-google-apitools
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-37-google-auth
+Relationship: SPDXRef-Package-16-gsutil CONTAINS SPDXRef-Package-39-monotonic
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-3-aiosignal
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-5-async-timeout
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-6-attrs
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-7-charset-normalizer
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-8-multidict
+Relationship: SPDXRef-Package-2-aiohttp CONTAINS SPDXRef-Package-9-yarl
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-21-boto
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-22-google-reauth
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-27-oauth2client
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-31-pyopenssl
+Relationship: SPDXRef-Package-20-gcs-oauth2-boto-plugin CONTAINS SPDXRef-Package-35-retry-decorator
+Relationship: SPDXRef-Package-22-google-reauth CONTAINS SPDXRef-Package-23-pyu2f
+Relationship: SPDXRef-Package-23-pyu2f CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-25-httplib2 CONTAINS SPDXRef-Package-26-pyparsing
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-29-pyasn1-modules
+Relationship: SPDXRef-Package-27-oauth2client CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-29-pyasn1-modules CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-3-aiosignal CONTAINS SPDXRef-Package-4-frozenlist
+Relationship: SPDXRef-Package-30-rsa CONTAINS SPDXRef-Package-28-pyasn1
+Relationship: SPDXRef-Package-31-pyopenssl CONTAINS SPDXRef-Package-32-cryptography
+Relationship: SPDXRef-Package-32-cryptography CONTAINS SPDXRef-Package-33-cffi
+Relationship: SPDXRef-Package-33-cffi CONTAINS SPDXRef-Package-34-pycparser
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-19-fasteners
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-25-httplib2
+Relationship: SPDXRef-Package-36-google-apitools CONTAINS SPDXRef-Package-27-oauth2client
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-24-six
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-29-pyasn1-modules
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-30-rsa
+Relationship: SPDXRef-Package-37-google-auth CONTAINS SPDXRef-Package-38-cachetools
+Relationship: SPDXRef-Package-40-jinja2 CONTAINS SPDXRef-Package-41-markupsafe
+Relationship: SPDXRef-Package-42-jsonschema CONTAINS SPDXRef-Package-43-pyrsistent
+Relationship: SPDXRef-Package-42-jsonschema CONTAINS SPDXRef-Package-6-attrs
+Relationship: SPDXRef-Package-44-packaging CONTAINS SPDXRef-Package-26-pyparsing
+Relationship: SPDXRef-Package-45-plotly CONTAINS SPDXRef-Package-46-tenacity
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-10-idna
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-49-certifi
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-50-urllib3
+Relationship: SPDXRef-Package-48-requests CONTAINS SPDXRef-Package-7-charset-normalizer
+Relationship: SPDXRef-Package-51-rich CONTAINS SPDXRef-Package-52-commonmark
+Relationship: SPDXRef-Package-51-rich CONTAINS SPDXRef-Package-53-pygments
+Relationship: SPDXRef-Package-56-xmlschema CONTAINS SPDXRef-Package-57-elementpath
+Relationship: SPDXRef-Package-9-yarl CONTAINS SPDXRef-Package-10-idna
+Relationship: SPDXRef-Package-9-yarl CONTAINS SPDXRef-Package-8-multidict


### PR DESCRIPTION
Born from discussion in related issue https://github.com/intel/cve-bin-tool/issues/1646#issuecomment-1369296509.

This will run a scheduled workflow that should update SBOMs every week if there are any changes. Also added an option to run it manually if there's a need (as part of a release workflow for example).