### PR TITLE
fix(tests): use importlib_metadata.version on 3.7

### DIFF
--- a/test/test_requirements.py
+++ b/test/test_requirements.py
@@ -5,8 +5,14 @@ import csv
 import json
 import re
 import subprocess
+import sys
 import tempfile
-from importlib.metadata import version
+
+if sys.version_info >= (3, 8):
+    from importlib.metadata import version
+else:
+    from importlib_metadata import version
+
 from pathlib import Path
 
 ROOT_PATH = Path(__file__).parent.parent


### PR DESCRIPTION
There is no `importlib.metadata` on Python 3.7.

Without this fix test discovery fails in VSC with pytest. I guess it just means that not a lot of people if anyone use 3.7 in VSC for the development of cve-bin-tool anymore? 😄

We haven't noticed this issue in CI because this test only runs [on latest Python](https://github.com/intel/cve-bin-tool/blob/10c97660312b4138cc79a03df204f5174389ba39/.github/workflows/cve_scan.yml#L17).