### PR TITLE
ci: add mypy for type checking

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tool: ['isort', 'black', 'pyupgrade', 'flake8', 'bandit', 'gitlint']
+        tool: ['isort', 'black', 'pyupgrade', 'flake8', 'bandit', 'gitlint', 'mypy']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,38 @@ repos:
     rev: v0.17.0
     hooks:
     - id: gitlint
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.991
+    hooks:
+    - id: mypy
+      additional_dependencies:
+        - types-beautifulsoup4
+        - types-jsonschema
+        - types-PyYAML
+        - types-requests
+        - types-setuptools
+        - types-toml
+      files: |
+        (?x)^(
+            cve_bin_tool/parsers/.*|
+            cve_bin_tool/__init__.py|
+            cve_bin_tool/async_utils.py|
+            cve_bin_tool/file.py|
+            cve_bin_tool/linkify.py|
+            cve_bin_tool/log.py|
+            cve_bin_tool/strings.py|
+            cve_bin_tool/theme.py|
+            cve_bin_tool/util.py|
+            cve_bin_tool/validator.py|
+            cve_bin_tool/version.py|
+            doc/.*|
+            test/test_data/.*|
+            test/__init__.py|
+            test/test_file.py|s
+            test/test_requirements.py|
+            test/test_strings.py|
+            test/test_triage.py|
+            test/test_version.py|
+            test/utils.py|
+        )$

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,6 +4,7 @@ pre-commit==2.20.0
 flake8==5.0.4
 bandit==1.7.4
 gitlint== v0.17.0
+mypy==v0.991
 py>=1.10.0
 pytest
 pytest-xdist


### PR DESCRIPTION
This will type check only the files specified in the pre-commit config. This way we won't regress and we can slowly (or quickly) add new files to be checked.

I've also added mypy to the dev-requirements.txt (it's curious that we had type stubs there already and even mypy config in the root of the project but not mypy itself).

Related to #2316.