### PR TITLE
fix: improve sqlite pattern

### DIFF
--- a/cve_bin_tool/checkers/sqlite.py
+++ b/cve_bin_tool/checkers/sqlite.py
@@ -61,8 +61,8 @@ class SqliteChecker(Checker):
     VENDOR_PRODUCT = [("sqlite", "sqlite")]
     VERSION_PATTERNS = [
         r"Id: SQLite version (\d+\.\d+\.\d+)",
-        r"sqlite(\d+)\.debug",
-    ]  # patterns like the second one aren't ideal (check the end of the file)
+        r"(\d{4}-\d{2}-\d{2} \d+:\d+:\d+ [\w]+)\r?\n(?:SQLite|SQLITE|DESC)",
+    ]
     FILENAME_PATTERNS = [r"sqlite", r"sqlite3"]
 
     mapdb = VersionSignatureDb("sqlite", get_version_map, 30)
@@ -90,7 +90,6 @@ class SqliteChecker(Checker):
 
         The most correct way to do this is to search for the sha1 sums per release.
         Fedora rpms have a simpler SQLite version string.
-        If neither of those work, try to at least guess the major version
         """
 
         version_info = super().get_version(lines, filename)
@@ -105,10 +104,3 @@ class SqliteChecker(Checker):
                 version_info["version"] = mapping[0]
 
         return version_info
-
-
-"""
-Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it
-might work on fedora but not on ubuntu)
-"""

--- a/test/test_data/sqlite.py
+++ b/test/test_data/sqlite.py
@@ -6,7 +6,7 @@ mapping_test_data = [
         "product": "sqlite",
         "version": "3.30.1",
         "version_strings": [
-            "2019-10-10 20:19:45 18db032d058f1436ce3dea84081f4ee5a0f2259ad97301d43c426bc7f3df1b0b",
+            "2019-10-10 20:19:45 18db032d058f1436ce3dea84081f4ee5a0f2259ad97301d43c426bc7f3df1b0b\nSQLITE",
             "ESCAPE expression must be a single character",
         ],
     },
@@ -14,7 +14,7 @@ mapping_test_data = [
         "product": "sqlite",
         "version": "3.16.1",
         "version_strings": [
-            "2017-01-03 18:27:03 979f04392853b8053817a3eea2fc679947b437fd",
+            "2017-01-03 18:27:03 979f04392853b8053817a3eea2fc679947b437fd\nSQLITE",
             "ESCAPE expression must be a single character",
         ],
     },
@@ -22,7 +22,7 @@ mapping_test_data = [
         "product": "sqlite",
         "version": "3.12.2",
         "version_strings": [
-            "2016-04-18 17:30:31 92dc59fd5ad66f646666042eb04195e3a61a9e8e",
+            "2016-04-18 17:30:31 92dc59fd5ad66f646666042eb04195e3a61a9e8e\nSQLITE",
             "ESCAPE expression must be a single character",
         ],
     },
@@ -30,8 +30,15 @@ mapping_test_data = [
         "product": "sqlite",
         "version": "3.12.2",
         "version_strings": [
-            "2016-04-18 17:30:31 92dc59fd5ad66f646666042eb04195e3a61aalt2",
+            "2016-04-18 17:30:31 92dc59fd5ad66f646666042eb04195e3a61aalt2\nSQLITE",
             "ESCAPE expression must be a single character",
+        ],
+    },
+    {
+        "product": "sqlite",
+        "version": "2020.04.06 18:16:31 1e4b6a93987cdfbf829e2ff35ef417c290625f2894ad11949e301af518f1fb44",
+        "version_strings": [
+            "2020-04-06 18:16:31 1e4b6a93987cdfbf829e2ff35ef417c290625f2894ad11949e301af518f1fb44\nSQLite",
         ],
     },
 ]


### PR DESCRIPTION
`sqlite(\d+)\.debug` pattern has been added more than 3 years ago to detect major version of sqlite:
https://github.com/intel/cve-bin-tool/commit/1c8c77206731f3a1f6b79f8f4fa0586ba587bdaa

However, the latest version 2 of sqlite (2.8.17) has been released in December 2005 so it is extremely unlikely that a system ships anything else that version 3.

So drop this pattern and instead add a new one that will display the date/hash if the hash isn't found on https://www.sqlite.org/changes.html

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>