### PR TITLE
feat(cve_scanner): add vendor to affected

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -337,10 +337,11 @@ class CVEScanner:
         return parsed_version, version_between
 
     def affected(self):
-        """Returns list of product name and version tuples identified from
+        """Returns list of vendor.product and version tuples identified from
         scan"""
         return sorted(
-            (cve_data.product, cve_data.version) for cve_data in self.all_cve_data
+            (cve_data.vendor + "." + cve_data.product, cve_data.version)
+            for cve_data in self.all_cve_data
         )
 
     def __enter__(self):

--- a/test/test_csv2cve.py
+++ b/test/test_csv2cve.py
@@ -27,7 +27,7 @@ class TestCSV2CVE:
         assert (
             "cve_bin_tool",
             logging.INFO,
-            "Known CVEs in ('curl', '7.34.0'), ('kerberos', '1.15.1'), ('kerberos_5', '1.15.1'):",
+            "Known CVEs in ('haxx.curl', '7.34.0'), ('mit.kerberos', '1.15.1'), ('mit.kerberos_5', '1.15.1'):",
         ) in caplog.record_tuples
 
         for cve in [


### PR DESCRIPTION
Display `vendor.product` in affected instead of just the `product` as some products have multiple vendors (e.g. `zlib`)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>