### PR TITLE
fix: improve gcc checker

### DIFF
--- a/cve_bin_tool/checkers/gcc.py
+++ b/cve_bin_tool/checkers/gcc.py
@@ -35,4 +35,4 @@ class GccChecker(Checker):
         r"GCC: \(GNU\) ([0-9]+\.[0-9]+(\.[0-9]+)?)",
         # r"gcc ([0-9]+\.[0-9]+(\.[0-9]+)?)",  # does not return correct version number on some packages
     ]
-    VENDOR_PRODUCT = [("gnu", "gcc"), ("gcc", "gcc")]
+    VENDOR_PRODUCT = [("gnu", "gcc")]


### PR DESCRIPTION
Drop `gcc:gcc` CPE ID which doesn't exist in NVD NIST database: https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Agcc%3Agcc

The only CVE that referenced this ID is the very old CVE-1999-1439: https://nvd.nist.gov/vuln/detail/CVE-1999-1439

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>