### PR TITLE
fix: improve expat checker

### DIFF
--- a/cve_bin_tool/checkers/expat.py
+++ b/cve_bin_tool/checkers/expat.py
@@ -5,7 +5,6 @@ r"""
 CVE checker for libexpat
 
 References:
-http://www.cvedetails.com/vulnerability-list/vendor_id-12037/product_id-22545/Libexpat-Expat.html
 http://www.cvedetails.com/vulnerability-list/vendor_id-16735/product_id-39003/Libexpat-Project-Libexpat.html
 https://github.com/libexpat/libexpat/blob/master/expat/Changes
 
@@ -39,4 +38,4 @@ class ExpatChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"expat"]
     VERSION_PATTERNS = [r"expat_([012]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PRODUCT = [("libexpat", "expat"), ("libexpat_project", "libexpat")]
+    VENDOR_PRODUCT = [("libexpat_project", "libexpat")]

--- a/test/test_data/expat.py
+++ b/test/test_data/expat.py
@@ -3,7 +3,7 @@
 
 mapping_test_data = [
     {
-        "product": "expat",
+        "product": "libexpat",
         "version": "2.0.1",
         "version_strings": [
             "expat_2.0.1 ",
@@ -15,21 +15,21 @@ package_test_data = [
     {
         "url": "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
         "package_name": "expat-2.1.0-12.el7.x86_64.rpm",
-        "product": "expat",
+        "product": "libexpat",
         "version": "2.1.0",
         "other_products": [],
     },
     {
         "url": "https://kojipkgs.fedoraproject.org/packages/expat/2.2.1/1.fc24/x86_64/",
         "package_name": "expat-2.2.1-1.fc24.x86_64.rpm",
-        "product": "expat",
+        "product": "libexpat",
         "version": "2.2.1",
         "other_products": [],
     },
     {
         "url": "http://http.us.debian.org/debian/pool/main/e/expat/",
         "package_name": "libexpat1_2.2.0-2+deb9u3_amd64.deb",
-        "product": "expat",
+        "product": "libexpat",
         "version": "2.2.0",
         "other_products": [],
     },


### PR DESCRIPTION
Drop `libexpat:expat` CPE ID which doesn't exist in NVD NIST database: https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Alibexpat%3Aexpat

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>