### PR TITLE
fix: improve json-c checker

### DIFF
--- a/cve_bin_tool/checkers/json_c.py
+++ b/cve_bin_tool/checkers/json_c.py
@@ -18,7 +18,7 @@ class JsonCChecker(Checker):
     FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
         r"json-c-([0-9]+\.[0-9]+\.?[0-9]*)",
-        r"JSONC_([0-9]+\.[0-9]+\.?[0-9]*)\r?\nGLIBC_",
-        r"([0-9]+\.[0-9]+\.?[0-9]*)[a-zA-Z0-9,% +:\"\.\-\\\r\n]*json_tokener_error",
+        r"([0-9]+\.[0-9]+\.?[0-9]*)\r?\njson-c",
+        r"([0-9]+\.[0-9]+\.?[0-9]*)[a-zA-Z0-9,% *!_()='+:\"\.\-\\\r\n]*json_tokener_error",
     ]
     VENDOR_PRODUCT = [("json-c_project", "json-c")]

--- a/test/test_data/json_c.py
+++ b/test/test_data/json_c.py
@@ -2,11 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 mapping_test_data = [
-    {
-        "product": "json-c",
-        "version": "0.15",
-        "version_strings": ["JSONC_0.15\nGLIBC_2.3"],
-    },
+    {"product": "json-c", "version": "0.15", "version_strings": ["0.15\njson-c"]},
     {
         "product": "json-c",
         "version": "0.12.1",

--- a/test/test_data/tpm2_tss.py
+++ b/test/test_data/tpm2_tss.py
@@ -14,20 +14,20 @@ package_test_data = [
         "package_name": "tpm2-tss-3.2.0-3.fc37.aarch64.rpm",
         "product": "tpm2_software_stack",
         "version": "3.2.0",
-        "other_products": ["json-c"],
+        "other_products": [],
     },
     {
         "url": "http://rpmfind.net/linux/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/t/",
         "package_name": "tpm2-tss-3.2.0-3.fc37.i686.rpm",
         "product": "tpm2_software_stack",
         "version": "3.2.0",
-        "other_products": ["json-c"],
+        "other_products": [],
     },
     {
         "url": "http://ftp.fr.debian.org/debian/pool/main/t/tpm2-tss/",
         "package_name": "libtss2-fapi1_3.0.3-2_amd64.deb",
         "product": "tpm2_software_stack",
         "version": "3.0.3",
-        "other_products": ["json-c"],
+        "other_products": [],
     },
 ]


### PR DESCRIPTION
- Replace `JSONC_([0-9]+\.[0-9]+\.?[0-9]*)\r?\nGLIBC_` pattern which can raise false positive by `([0-9]+\.[0-9]+\.?[0-9]*)\r?\njson-c`
- Improve latest pattern to detect exotic libraries

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>