### PR TITLE
fix: improve zlib checker

### DIFF
--- a/cve_bin_tool/checkers/zlib.py
+++ b/cve_bin_tool/checkers/zlib.py
@@ -21,7 +21,6 @@ class ZlibChecker(Checker):
     CONTAINS_PATTERNS = [
         rf"deflate[{printable}]*Copyright 1995-2005 Jean-loup Gailly",
         rf"Copyright 1995-2005 Mark Adler[{printable}]*inflate",
-        r"too many length or distance symbols",
         r"Copyright 1995-2017 Jean-loup Gailly and Mark Adler",
         r"Copyright 1995-2017 Mark Adler",
     ]

--- a/test/test_data/zlib.py
+++ b/test/test_data/zlib.py
@@ -5,10 +5,7 @@ mapping_test_data = [
     {
         "product": "zlib",
         "version": "1.2.2",
-        "version_strings": [
-            "deflate 1.2.2 Copyright 1995-2005 Jean-loup Gailly",
-            "too many length or distance symbols",
-        ],
+        "version_strings": ["deflate 1.2.2 Copyright 1995-2005 Jean-loup Gailly"],
     }
 ]
 package_test_data = [


### PR DESCRIPTION
Drop `too many length or distance symbols` from `CONTAINS_PATTERNS` to avoid returning an `UNKNOWN` zlib version with libfreetype

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>