### PR TITLE
fix: improve bind checker

### DIFF
--- a/cve_bin_tool/checkers/bind.py
+++ b/cve_bin_tool/checkers/bind.py
@@ -19,7 +19,7 @@ class BindChecker(Checker):
         # see https://github.com/intel/cve-bin-tool/tree/main/cve_bin_tool/checkers#helper-script for more details
         # r"/bind9.xsl",
     ]
-    FILENAME_PATTERNS = [r"named"]
+    FILENAME_PATTERNS = []
     VERSION_PATTERNS = [
         r"BIND ([0-9]+\.[0-9]+\.[0-9]+)",  # for .rpm, .tgz, etc.
         r"bind[0-9]*-([0-9]+\.[0-9]+\.[0-9]+)",  # for .deb


### PR DESCRIPTION
Drop `named` from `FILENAME_PATTERNS` to avoid returning an UNKNOWN bind version with `systemd-hostnamed`

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>