### PR TITLE
fix: fix false positives with filename patterns

### DIFF
--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -318,7 +318,7 @@ class Checker(metaclass=CheckerMetaClass):
     def get_version(self, lines, filename):
         version_info = dict()
 
-        if any(pattern.search(filename) for pattern in self.FILENAME_PATTERNS):
+        if any(pattern.match(filename) for pattern in self.FILENAME_PATTERNS):
             version_info["is_or_contains"] = "is"
 
         if "is_or_contains" not in version_info and self.guess_contains(lines):


### PR DESCRIPTION
Use `match` instead of `search` to only detect a match at the beginning of the filename for `FILENAME_PATTERNS` otherwise false positives will be raised. For example:
 - `named` (i.e. bind) for `systemd-hostnamed`
 - `eroute` (i.e. openswan) for `traceroute6`
 - `scp` (i.e. openssh) for `libxt_dscp.so`
 - `libc` (i.e. glibc) for `libuClibc.so`

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>