### PR TITLE
Let 'cve-bin-tool --version' return success

### DIFF
--- a/cve_bin_tool/error_handler.py
+++ b/cve_bin_tool/error_handler.py
@@ -130,7 +130,9 @@ class ErrorMode(Enum):
 def excepthook(exc_type, exc_val, exc_tb):
     trace = Traceback.from_exception(exc_type, exc_val, exc_tb)
     CONSOLE.print(trace)
-    if ERROR_CODES.get(exc_type):
+    if isinstance(exc_val, SystemExit):
+        sys.exit(exc_val.code)
+    elif ERROR_CODES.get(exc_type):
         sys.exit(ERROR_CODES[exc_type])
 
 
@@ -164,7 +166,10 @@ class ErrorHandler:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if isinstance(exc_val, BaseException):
+        if isinstance(exc_val, SystemExit):
+            self.exit_code = exc_val.code
+            self.exc_val = exc_val
+        elif isinstance(exc_val, BaseException):
             self.exit_code = ERROR_CODES.get(exc_type, -1)
             self.exc_val = exc_val
         if self.mode == ErrorMode.Ignore:
@@ -186,7 +191,6 @@ class ErrorHandler:
 # Error code 3 is reserved for "we found negative cves" (should be impossible)
 # Error code 4-20 are reserved just in case
 ERROR_CODES = {
-    SystemExit: 2,
     FileNotFoundError: 21,
     InvalidCsvError: 22,
     InvalidJsonError: 22,

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -96,6 +96,12 @@ class TestCLI(TempDirTest):
             main(["cve-bin-tool"])
         assert e.value.args[0] == ERROR_CODES[InsufficientArgs]
 
+    def test_version(self):
+        """Test that the version returns 0"""
+        with pytest.raises(SystemExit) as e:
+            main(["cve-bin-tool", "--version"])
+        assert e.value.args[0] == 0
+
     def test_invalid_file_or_directory(self):
         """Test behaviour with an invalid file/directory"""
         with pytest.raises(SystemExit) as e:
@@ -136,22 +142,22 @@ class TestCLI(TempDirTest):
         # no directory specified
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param"])
-        assert e.value.args[0] == ERROR_CODES[SystemExit]
+        assert e.value.args[0] == 2
 
         # bad parameter (but good directory)
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param", self.tempdir])
-        assert e.value.args[0] == ERROR_CODES[SystemExit]
+        assert e.value.args[0] == 2
 
         # worse parameter
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "--bad-param && cat hi", self.tempdir])
-        assert e.value.args[0] == ERROR_CODES[SystemExit]
+        assert e.value.args[0] == 2
 
         # bad parameter after directory
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", self.tempdir, "--bad-param;cat hi"])
-        assert e.value.args[0] == ERROR_CODES[SystemExit]
+        assert e.value.args[0] == 2
 
     @pytest.mark.skipif(not LONG_TESTS(), reason="Update flag tests are long tests")
     @pytest.mark.skipif(
@@ -389,11 +395,11 @@ class TestCLI(TempDirTest):
         # Check command line parameters - wrong case
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-S", "HIGH", self.tempdir])
-        assert e.value.args[0] == ERROR_CODES[SystemExit]
+        assert e.value.args[0] == 2
         # Check command line parameters - wrong option
         with pytest.raises(SystemExit) as e:
             main(["cve-bin-tool", "-S", "ALL", self.tempdir])
-        assert e.value.args[0] == ERROR_CODES[SystemExit]
+        assert e.value.args[0] == 2
 
         my_test_filename = "sevtest.csv"
         my_test_filename_pathlib = Path(my_test_filename)


### PR DESCRIPTION
Previously, `cve-bin-tool --version` returned an error code of '2', as if it was an invalid argument.

With this change, it returns successfully, consistent with standard argparse behavior.