### PR TITLE
fix: replace space in test filename

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -125,7 +125,7 @@ class TestScanner:
             # Replace space in filename to avoid a failure on Windows
             with tempfile.NamedTemporaryFile(
                 "w+b",
-                suffix=filename.replace(" ", "_"),
+                suffix=filename.replace(":", "_"),
                 dir=self.mapping_test_dir,
                 delete=False,
             ) as f:

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -122,8 +122,12 @@ class TestScanner:
             f"{'.'.join(list(product))}-{version}.out",
         ]
         for filename in filenames:
+            # Replace space in filename to avoid a failure on Windows
             with tempfile.NamedTemporaryFile(
-                "w+b", suffix=filename, dir=self.mapping_test_dir, delete=False
+                "w+b",
+                suffix=filename.replace(" ", "_"),
+                dir=self.mapping_test_dir,
+                delete=False,
             ) as f:
                 f.write(b"\x7f\x45\x4c\x46\x02\x01\x01\x03\n")
                 f.writelines(version_strings)


### PR DESCRIPTION
Replace space in test filename to avoid a failure on Windows (raised since commit 877691522d51bb104d7e88ddcd4ab18e48515623)

Fix #2533

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>