### PR TITLE
fix: xmlschema log msg

### DIFF
--- a/cve_bin_tool/validator.py
+++ b/cve_bin_tool/validator.py
@@ -1,7 +1,10 @@
 # Copyright (C) 2022 Anthony Harrison
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
 from pathlib import Path
+
+logging.getLogger("xmlschema").setLevel(logging.WARNING)
 
 import xmlschema
 


### PR DESCRIPTION
Signed-off-by: ayush_gitk <ayushsharmaa101@gmail.com>

fixes #2530 

The logger level is being set to `logging.WARNING` for 'xmlschema'  so to suppress any INFO or DEBUG message that comes during using the `cve-bin-tool`.