### PR TITLE
ci: use linux cache since windows is broken

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -266,7 +266,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/cve-bin-tool
-          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
+          key: linux-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
       - name: Install cve-bin-tool
         run: |
           python -m pip install --upgrade pip
@@ -317,7 +317,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cache/cve-bin-tool
-          key: ${{ runner.os }}-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
+          key: linux-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
       - name: Install cve-bin-tool
         run: |
           python -m pip install --upgrade pip
@@ -377,3 +377,4 @@ jobs:
           flags: win-longtests
           name: codecov-umbrella
           fail_ci_if_error: false
+


### PR DESCRIPTION
This is absolutely a cheat, but I can't think of any particular reason we need two caches and windows is clearly flakier than linux in github actions.