### PR TITLE
fix: commonmark no longer a dependency

### DIFF
--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -123,7 +123,6 @@ class TestLanguageScanner:
         "zstandard",
         "requests",
         "urllib3",
-        "commonmark",
         "rsa",
         "aiohttp",
         "httplib2",


### PR DESCRIPTION
Commonmark was removed as a dependency (in favour of markdown-it) by one of the packages cve-bin-tool uses.  The SBOMs all updated correctly and have been merged, but our python language scanner test used our own requirements.txt and was expecting it.  This removes it from the test, although it doesn't add the new dependency.