### PR TITLE
ci: extend windows timeouts

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -248,7 +248,7 @@ jobs:
   windows_tests:
     name: Windows tests
     runs-on: windows-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'
@@ -298,7 +298,7 @@ jobs:
   windows_long_tests:
     name: Windows long tests
     runs-on: windows-latest
-    timeout-minutes: 50
+    timeout-minutes: 60
     env:
       LONG_TESTS: 1
       NO_EXIT_CVE_NUM: 1


### PR DESCRIPTION
Windows has been a bit spotty again lately, failing around 82% on the last job I checked.  This might extend it enough to keep things moving, though I'm wondering if we need to do something else with windows because an hour is a long time...