### PR TITLE
fix: improve test_json.py

### DIFF
--- a/test/test_json.py
+++ b/test/test_json.py
@@ -10,7 +10,7 @@ import datetime
 import gzip
 import json
 from pathlib import Path
-from test.utils import LONG_TESTS
+from test.utils import EXTERNAL_SYSTEM, LONG_TESTS
 
 import pytest
 import requests
@@ -24,6 +24,9 @@ NVD_SCHEMA = "https://scap.nist.gov/schema/nvd/feed/1.1/nvd_cve_feed_json_1.1.sc
 # NVD feeds from "https://nvd.nist.gov/vuln/data-feeds#JSON_FEED" but stored locally
 
 
+@pytest.mark.skipif(
+    not EXTERNAL_SYSTEM(), reason="Skipping tests to reduce network calls"
+)
 class TestJSON:
     # Download the schema
     SCHEMA = requests.get(NVD_SCHEMA).json()


### PR DESCRIPTION
Don't run test_json.py if `EXTERNAL_SYSTEM` is False to avoid a test failure if NVD schema can't be downloaded

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>