### PR TITLE
fix: improve tcpdump checker

### DIFF
--- a/cve_bin_tool/checkers/tcpdump.py
+++ b/cve_bin_tool/checkers/tcpdump.py
@@ -19,6 +19,6 @@ class TcpdumpChecker(Checker):
     # lookup_{emem,protoid} are static functions provided by tcpdump in addrtoname.c
     VERSION_PATTERNS = [
         r"tcpdump-([0-9]+\.[0-9]+\.[0-9]+)",
-        r"([0-9]+\.[0-9]+\.[0-9]+)\r?\n[0-9a-f]*lookup_",
+        r"([0-9]+\.[0-9]+\.[0-9]+)\r?\n[0-9a-f]*lookup_(?:emem|protoid)",
     ]
     VENDOR_PRODUCT = [("tcpdump", "tcpdump")]

--- a/test/test_data/qemu.py
+++ b/test/test_data/qemu.py
@@ -14,7 +14,7 @@ package_test_data = [
         "package_name": "qemu-0.9.1-1.el3.rf.x86_64.rpm",
         "product": "qemu",
         "version": "0.9.1",
-        "other_products": ["gcc", "tcpdump"],
+        "other_products": ["gcc"],
     },
     {
         "url": "http://ftp.fr.debian.org/debian/pool/main/q/qemu/",


### PR DESCRIPTION
Update checker to avoid false positives (e.g. with qemu)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>