### PR TITLE
fix: libjpeg-turbo not found in gimp

### DIFF
--- a/test/test_data/gimp.py
+++ b/test/test_data/gimp.py
@@ -10,20 +10,20 @@ package_test_data = [
         "package_name": "gimp-2.6.12-1.fc15.x86_64.rpm",
         "product": "gimp",
         "version": "2.6.12",
-        "other_products": ["libjpeg-turbo"],
+        "other_products": [],
     },
     {
         "url": "http://ftp.osuosl.org/pub/ubuntu/pool/universe/g/gimp/",
         "package_name": "gimp_2.8.22-1_amd64.deb",
         "product": "gimp",
         "version": "2.8.22",
-        "other_products": ["libjpeg-turbo"],
+        "other_products": [],
     },
     {
         "url": "http://mirror.centos.org/centos/7/os/x86_64/Packages/",
         "package_name": "gimp-2.8.22-1.el7.x86_64.rpm",
         "product": "gimp",
         "version": "2.8.22",
-        "other_products": ["libjpeg-turbo"],
+        "other_products": [],
     },
 ]


### PR DESCRIPTION
Remove libjpeg-turbo from other_products of gimp