### PR TITLE
ci: fix running isort using pre-commit

### DIFF
--- a/.github/workflows/update-dev-requirements.py
+++ b/.github/workflows/update-dev-requirements.py
@@ -23,6 +23,9 @@ for ind, tool in enumerate(tools):
         continue
     package_name = package_match.group(1)
     if package_name in new_pins:
-        tools[ind] = re.sub("==(.*)", f"=={new_pins[package_name]}", tool)
+        if ";" in tool:
+            tools[ind] = re.sub("==(.*);", f"=={new_pins[package_name]};", tool)
+        else:
+            tools[ind] = re.sub("==(.*)", f"=={new_pins[package_name]}", tool)
 with open(requirements_path, "w") as f:
     f.writelines(tools)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
     - id: isort
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,9 +1,10 @@
 black==22.10.0
-isort==5.10.1
+isort; python_version < "3.8"
+isort==5.12.0; python_version >= "3.8"
 pre-commit==2.20.0
 flake8==5.0.4
 bandit==1.7.4
-gitlint== v0.17.0
+gitlint==v0.17.0
 mypy==v0.991
 py>=1.10.0
 pytest


### PR DESCRIPTION
Fixes #2617
This will install isort 5.12.0 for Python >= 3.8 and the latest available for Python 3.7 (3.11.5 right now). Both have the original issue fixed. 5.12.0 requires Python 3.8.
Note that this WILL break running isort hook using pre-commit on Python 3.7. There are ways to skip only isort hook and run all others but I don't think it's worth it to add this to documentation for 5 months when 3.7 goes EOL.
An alternative would be to pin to 3.11.5 until 3.7 goes EOL.
First commit is needed so that the auto-update script doesn't remove environment markers.