### PR TITLE
docs: Explain recommended versions of python + linter concerns

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -130,6 +130,7 @@ dsa
 dtls
 e
 elfutils
+endoflife
 enscript
 entrypoint
 Eqt

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -338,6 +338,7 @@ msys
 mtr
 mutt
 myfork
+mypy
 mysql
 Mystylesheet
 MYUSERNAME

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Replace MYUSERNAME with your own GitHub username.
 
 CVE Binary Tool supports [any version of python that has ongoing security support](https://endoflife.date/python).  There can be a bit of lag before we enable a new release or fully disable an old one.  If you don't need multiple versions of python for a specific bug, we recommend starting with either the most recent version of python or the one before (e.g. the first or second thing on [the "active python releases" list](https://www.python.org/downloads/)).
 
-Note that some of our [linters](#running-linters) (tools used to help with code quality) may not work on the oldest version of python.  That's the last one on [the "active python releases" list](https://www.python.org/downloads/).  So if you're doing development on the oldest version of python, you should switch to a newer version before you run linters on your code or do a `git commit` for best results.
+Note that some of our [linters](#running-linters) (tools used to help with code quality) may not work on the oldest version of python.  That's the last one on [the "active python releases" list](https://www.python.org/downloads/).  So if you're doing development on the oldest version of python, for best results you should switch to a newer version before you run linters on your code or do a `git commit`.
 
 ## Setting up a virtualenv
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -178,6 +178,7 @@ CVE Binary Tool uses a few tools to improve code quality and readability:
 - `pyupgrade` helps us be forward compatible with new versions of python.
 - `bandit` is more of a static analysis tool than a linter and helps us find potential security flaws in the code.
 - `gitlint` helps ensure that the commit messages follow [Conventional Commits](https://conventionalcommits.org).
+- `mypy` helps ensure type definitions are correct when provided.
 
 We provide a `dev-requirements.txt` file which includes all the precise versions of tools as they'll be used in GitHub Actions.  You an install them all using pip:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,9 +88,9 @@ Replace MYUSERNAME with your own GitHub username.
 
 ## Choosing a version of python
 
-CVE Binary Tool supports [any version of python that has ongoing security support](https://endoflife.date/python).  There can be a bit of lag before we enable a new release or fully disable an old one.  If you don't need multiple versions of python for a specific bug, we recommend starting with either the most recent version of python or the one before (e.g. the first or second thing on [the "active python releases" list](https://www.python.org/downloads/)).
+CVE Binary Tool supports [any version of python that has ongoing security support](https://endoflife.date/python).  There can be a bit of lag before we enable a new release or fully disable an old one.  If you don't need multiple versions of python for a specific bug, we recommend starting with either the most recent version of python or the one before (e.g. the first or second thing on [the "Active Python Releases" list](https://www.python.org/downloads/)).
 
-Note that some of our [linters](#running-linters) (tools used to help with code quality) may not work on the oldest version of python.  That's the last one on [the "active python releases" list](https://www.python.org/downloads/).  So if you're doing development on the oldest version of python, for best results you should switch to a newer version before you run linters on your code or do a `git commit`.
+Note that some of our [linters](#running-linters) (tools used to help with code quality) may not work on the oldest version of python.  That's the last one on [the "Active Python Releases" list](https://www.python.org/downloads/).  So if you're doing development on the oldest version of python, for best results you should switch to a newer version before you run linters on your code or do a `git commit`.
 
 ## Setting up a virtualenv
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,7 @@ If you've already contributed to other open source projects, contributing to the
   - [Code of Conduct](#code-of-conduct)
   - [Development Environment](#development-environment)
   - [Getting and maintaining a local copy of the source code](#getting-and-maintaining-a-local-copy-of-the-source-code)
+  - [Choosing a version of python](#choosing-a-version-of-python)
   - [Setting up a virtualenv](#setting-up-a-virtualenv)
   - [Installing dependencies](#installing-dependencies)
   - [Running your local copy of CVE Binary Tool](#running-your-local-copy-of-cve-binary-tool)
@@ -20,7 +21,7 @@ If you've already contributed to other open source projects, contributing to the
     - [Running black by itself](#running-black-by-itself)
     - [Running bandit by itself](#running-bandit-by-itself)
     - [Other linting tools](#other-linting-tools)
-  - [Making a new branch & pull request](#making-a-new-branch--pull-request)
+  - [Making a new branch \& pull request](#making-a-new-branch--pull-request)
     - [Commit message tips](#commit-message-tips)
     - [Sharing your code with us](#sharing-your-code-with-us)
     - [Checklist for a great pull request](#checklist-for-a-great-pull-request)
@@ -85,6 +86,12 @@ Once you've set up your fork, you will find it useful to set up a git remote for
 
 Replace MYUSERNAME with your own GitHub username.
 
+## Choosing a version of python
+
+CVE Binary Tool supports [any version of python that has ongoing security support](https://endoflife.date/python).  There can be a bit of lag before we enable a new release or fully disable an old one.  If you don't need multiple versions of python for a specific bug, we recommend starting with either the most recent version of python or the one before (e.g. the first or second thing on [the "active python releases" list](https://www.python.org/downloads/)).
+
+Note that some of our [linters](#running-linters) (tools used to help with code quality) may not work on the oldest version of python.  That's the last one on [the "active python releases" list](https://www.python.org/downloads/).  So if you're doing development on the oldest version of python, you should switch to a newer version before you run linters on your code or do a `git commit` for best results.
+
 ## Setting up a virtualenv
 
 This section isn't required, but many contributors find it helpful, especially for running tests using different versions of python.
@@ -97,16 +104,16 @@ To install it:
 pip install virtualenv
 ```
 
-To make a new venv using python 3.9:
+To make a new venv using python 3.11:
 
 ```bash
-virtualenv -p python3.9 ~/Code/venv3.9
+virtualenv -p python3.11 ~/Code/venv3.11
 ```
 
 Each time you want to use a virtualenv, you "activate" it using the activate script:
 
 ```bash
-source ~/Code/venv3.9/bin/activate
+source ~/Code/venv3.11/bin/activate
 ```
 
 And when you're done with the venv, you can deactivate it using the `deactivate` command.


### PR DESCRIPTION
* Related to #2618 
* fixes #2492

This adds an explainer to our contributors docs explaining what versions of python we support, which ones they should probably use to start, and explains that the oldest version may not be supported by all our linters.    Also I updated the version of python used in our virtualenv setup docs to be 3.11 in line with our guidance to use the latest or latest-1. (it was previously 3.9)