### PR TITLE
fix: improve dbus checker

### DIFF
--- a/cve_bin_tool/checkers/dbus.py
+++ b/cve_bin_tool/checkers/dbus.py
@@ -15,20 +15,7 @@ from cve_bin_tool.checkers import Checker
 
 
 class DbusChecker(Checker):
-    CONTAINS_PATTERNS = [
-        r"dbus_connection_get_adt_audit_session_data",
-        r"dbus_connection_set_dispatch_status_function",
-        # Alternate optional contains patterns,
-        # see https://github.com/intel/cve-bin-tool/tree/main/cve_bin_tool/checkers#helper-script for more details
-        # r"dbus_connection_set_max_received_unix_fds",
-        # r"dbus_connection_set_windows_user_function",
-        # r"_dbus_connection_get_linux_security_label",
-        # r"_dbus_connection_set_pending_fds_function",
-        # r"_dbus_credentials_new_from_current_process",
-        # r"_dbus_hash_table_insert_string_preallocated",
-        # r"org\.freedesktop\.DBus\.Error\.LimitsExceeded",
-        # r"org\.freedesktop\.DBus\.Error\.Spawn\.ExecFailed",
-    ]
+    CONTAINS_PATTERNS = []
     FILENAME_PATTERNS = [r"dbus"]
     VERSION_PATTERNS = [
         r"LIBDBUS_PRIVATE_([0-9]+\.[0-9]+(\.[0-9]+)?)",


### PR DESCRIPTION
Drop `dbus_connection_set_dispatch_status_function` to avoid returning an `UNKNOWN` dbus version for `bluetoothd` or `libavahi-client.so`

While at it, also drop `dbus_connection_get_adt_audit_session_data` which could also raise false positives

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>