### PR TITLE
fix: improve product_not_present

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -296,7 +296,10 @@ class TestScanner:
             for option in other_products:
                 assert (
                     option in list_products
-                ), f"""{option} not found in {package_name}."""
+                ), f"""{option} not found in {package_name}. Remove {option} from other_products."""
+                assert (
+                    option in product_not_present
+                ), f"""{option} not found in {product_not_present}. Remove {option} from other_products or add a test for {option} in test_data."""
                 product_not_present.remove(option)
         for not_product in product_not_present:
             assert (


### PR DESCRIPTION
If the user adds a valid product in `other_products` but this product doesn't have any test in test_data (e.g. open_source for asterisk), `product_not_present.remove(option)` will fail.

Add a dedicated message to help the user in this case

While at it, also improve the message when the product is not found in the test package

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>