### PR TITLE
fix: update tor signature

### DIFF
--- a/cve_bin_tool/checkers/tor.py
+++ b/cve_bin_tool/checkers/tor.py
@@ -18,7 +18,7 @@ from cve_bin_tool.checkers import Checker
 class TorChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
-    VERSION_PATTERNS = [r"Tor ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)"]
+    VERSION_PATTERNS = [r"on Tor ([0-9]+\.[0-9]+\.[0-9]+\.[0-9]+)"]
     VENDOR_PRODUCT = [
         ("debian", "tor"),
         ("tor", "tor"),

--- a/test/test_data/tor.py
+++ b/test/test_data/tor.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 mapping_test_data = [
-    {"product": "tor", "version": "0.4.7.10", "version_strings": ["Tor 0.4.7.10"]}
+    {"product": "tor", "version": "0.4.7.10", "version_strings": ["on Tor 0.4.7.10"]}
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Update tor signature to avoid catching the following string in tor 0.4.5.10 binary:

`The v0 control protocol is not supported by Tor 0.1.2.17 and later; upgrade your controller.`

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>