### PR TITLE
fix: drop Python 3.5 "compatibility function"

### DIFF
--- a/cve_bin_tool/checkers/__init__.py
+++ b/cve_bin_tool/checkers/__init__.py
@@ -293,12 +293,6 @@ VendorProductPair = collections.namedtuple("VendorProductPair", ["vendor", "prod
 
 
 class CheckerMetaClass(type):
-    def __init__(cls, name, bases, namespace, **kwargs):
-        """
-        Needed for compatibility with Python 3.5
-        """
-        super().__init__(name, bases, namespace)
-
     def __new__(cls, name, bases, props):
         # Create the class
         cls = super().__new__(cls, name, bases, props)


### PR DESCRIPTION
Drop Python 3.5 "compatibility function" as Python 3.5 is not supported anymore (no security update since 13 Sep 2020:
https://endoflife.date/python)