### PR TITLE
fix: improve seahorse checker

### DIFF
--- a/cve_bin_tool/checkers/seahorse.py
+++ b/cve_bin_tool/checkers/seahorse.py
@@ -17,5 +17,5 @@ class SeahorseChecker(Checker):
         r"cannot display progress because seahorse window has no progress widget"
     ]
     FILENAME_PATTERNS = [r"seahorse"]
-    VERSION_PATTERNS = [r"seahorse ([0-9]+\.[0-9]+(\.[0-9]+)?)"]
+    VERSION_PATTERNS = [r"seahorse ([0-9]+\.[0-9]+(\.[0-9]+)?)\r?\n"]
     VENDOR_PRODUCT = [("gnome", "seahorse")]


### PR DESCRIPTION
Improve seahorse checker to avoid catching "3.2" or "3.20" strings for 3.20.0 binary