### PR TITLE
fix: improve wireshark checker

### DIFF
--- a/cve_bin_tool/checkers/wireshark.py
+++ b/cve_bin_tool/checkers/wireshark.py
@@ -17,5 +17,5 @@ class WiresharkChecker(Checker):
         r"Are you a member of the 'wireshark' group\? Try running",
     ]
     FILENAME_PATTERNS = [r"rawshark", r"wireshark"]
-    VERSION_PATTERNS = [r"Wireshark ([0-9]+\.[0-9]+\.[0-9]+)"]
+    VERSION_PATTERNS = [r"Wireshark ([0-9]+\.[0-9]+\.[0-9]+)\."]
     VENDOR_PRODUCT = [("wireshark", "wireshark")]

--- a/test/test_data/wireshark.py
+++ b/test/test_data/wireshark.py
@@ -5,7 +5,7 @@ mapping_test_data = [
     {
         "product": "wireshark",
         "version": "1.10.12",
-        "version_strings": ["Wireshark 1.10.12"],
+        "version_strings": ["Wireshark 1.10.12."],
     }
 ]
 package_test_data = [
@@ -36,5 +36,12 @@ package_test_data = [
         "product": "wireshark",
         "version": "2.6.2",
         "other_products": [],
+    },
+    {
+        "url": "http://ftp.fr.debian.org/debian/pool/main/w/wireshark/",
+        "package_name": "libwireshark16_4.0.3-1_amd64.deb",
+        "product": "wireshark",
+        "version": "4.0.3",
+        "other_products": ["lua", "nghttp2"],
     },
 ]


### PR DESCRIPTION
Improve wireshark checker to avoid returning strings such as 3.4.1 for version 3.4.10

While at it, also add a debian test package