### PR TITLE
fix: improve putty checker

### DIFF
--- a/cve_bin_tool/checkers/putty.py
+++ b/cve_bin_tool/checkers/putty.py
@@ -17,5 +17,8 @@ from cve_bin_tool.checkers import Checker
 class PuttyChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
-    VERSION_PATTERNS = [r"putty-([0-9]+\.[0-9]+)", r"PuTTY-Release-([0-9]+\.[0-9]+)"]
+    VERSION_PATTERNS = [
+        r"putty-([0-9]+\.[0-9]+)",
+        r"PuTTY-Release-([0-9]+\.[0-9]+)\r?\n",
+    ]
     VENDOR_PRODUCT = [("putty", "putty"), ("simon_tatham", "putty")]

--- a/test/test_data/openssh.py
+++ b/test/test_data/openssh.py
@@ -24,6 +24,6 @@ package_test_data = [
         "package_name": "openssh-client_8.0p1-1_x86_64.ipk",
         "product": "openssh",
         "version": "8.0p1",
-        "other_products": ["putty"],
+        "other_products": [],
     },
 ]


### PR DESCRIPTION
Update second pattern to avoid a false positive in openssh raised by the following string: PuTTY-Release-0.5*,