### PR TITLE
ci: skip scorecard runs on every push until error is fixed

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -3,9 +3,12 @@ on:
   branch_protection_rule:
 
   schedule:
-    - cron: '00 00 * * 0'
-  push:
-    branches: [ "main" ]
+    # Run at 5:07 on Mondays
+    - cron: '7 5 * * 1'
+
+   # Disabled because it's segfaulting
+   #  push:
+   #    branches: [ "main" ]
 
 permissions: read-all
 


### PR DESCRIPTION
* Related: #2707 

For some reason this job is working in that I have info in the security tab about results, but it's generating an error on every pull request.  This changes it to run only weekly, and changes the time of the weekly run to not be at midnight since that tends to be an entirely too popular time to run such things.

It can be re-enabled per pull request if someone can figure out why it's generating a segfault every time, but until that's fixed I don't think running in on main is helpful (and in fact, it's actively detrimental right now since I can't tell easily if a more critical test starts failing).