### PR TITLE
fix: improve make_condensed_from_download

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -167,11 +167,18 @@ class TestScanner:
                 # Remove until .extracted plus 1 for the '/' after it. This will
                 # give us the path to the file relative to the root of the
                 # archive it came from
+                try:
+                    filename_path = filename[
+                        filename.index(dot_extracted) + len(dot_extracted) + 1 :
+                    ]
+                # Some files (e.g. OpenWRT Linux Kernel) are not an archive so
+                # dot_extracted won't be found
+                except ValueError:
+                    filename_path = os.path.basename(filename)
+
                 file_lines_pairs.append(
                     (
-                        filename[
-                            filename.index(dot_extracted) + len(dot_extracted) + 1 :
-                        ],
+                        filename_path,
                         lines,
                     )
                 )


### PR DESCRIPTION
Update `make_condensed_from_download` to allow it to condense binary which is not an archive. This is needed for the upcoming linux_kernel checker and its OpenWRT vmlinuz test binaries