### PR TITLE
docs: Explain how to claim an issue

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ If you've already contributed to other open source projects, contributing to the
     - [String Formatting](#string-formatting)
   - [Making documentation](#making-documentation)
   - [Where should I start?](#where-should-i-start)
+    - [Claiming an issue](#claiming-an-issue)
 
 ## Imposter syndrome disclaimer
 
@@ -406,3 +407,11 @@ Here's three things we recommend:
 If you get stuck or find something that you think should work but doesn't, ask for help in an issue or stop by [the cve-bin-tool gitter](https://gitter.im/cve-bin-tool/community) to ask questions.
 
 Note that our "good first issue" bugs are in high demand during the February-April due to the start of Google Summer of Code.  It's totally fine to comment on a bug and say you're interested in working on it, but if you don't actually have any pull request with a tentative fix up within a week or so, someone else may pick it up and finish it. If you want to spend more time thinking, the new checkers (especially ones no one has asked for) might be a good place for a relaxed first commit.
+
+### Claiming an issue
+
+- You do not need to have an issue assigned to you before you work on it.  To "claim" an issue either make a linked pull request or comment on the issue saying you'll be working on it.  
+- If someone else has already commented or opened a pull request, assume it is claimed and find another issue to work on.  
+- If it's been more than 1 week without progress, you can ask in a comment if the claimant is still working on it before claiming it yourself (give them at least 3 days to respond before assuming they have moved on).
+
+The reason we do it this way is to free up time for our maintainers to do more code review rather than having them handling bug assignment.  This is especially important to help us function during busy times of year when we take in a large number of new contributors such as Hacktoberfest (October) and the beginning of Google Summer of Code (January-March).

--- a/doc/new-contributor-tips.md
+++ b/doc/new-contributor-tips.md
@@ -2,8 +2,14 @@ This file contains the tips/links I put into bugs marked "good first issue" so
 that new contributors have the guidance they need right in the bug.
 
 **Short tips for new contributors:**
+
 * [cve-bin-tool's contributor docs](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md)
 * If you've contributed to open source but not this project, you might just want our [checklist for a great pull request](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md#checklist-for-a-great-pull-request)
-* cve-bin-tool uses https://www.conventionalcommits.org/ style for commit messages, and we have a test that checks the title of your PR.  A good potential title for this one is in the title of this issue.
-* You can make an issue auto close by including a comment "fixes #ISSUENUMBER" in your PR comments where ISSUENUMBER is the actual number of the issue.
+* cve-bin-tool uses <https://www.conventionalcommits.org/> style for commit messages, and we have a test that checks the title of your pull request (PR).  A good potential title for this one is in the title of this issue.
+* You can make an issue auto close by including a comment "fixes #ISSUENUMBER" in your PR comments where ISSUENUMBER is the actual number of the issue.  This "links" the issue to the pull request.
 
+**Claiming issues:**
+
+* You do not need to have an issue assigned to you before you work on it.  To "claim" an issue either make a linked pull request or comment on the issue saying you'll be working on it.  
+* If someone else has already commented or opened a pull request, assume it is claimed and find another issue to work on.  
+* If it's been more than 1 week without progress, you can ask in a comment if the claimant is still working on it before claiming it yourself (give them at least 3 days to respond before assuming they have moved on).


### PR DESCRIPTION
Explain how to "claim" an issue on github in both the tips I cut/paste into "good first issue" bugs and also in the contributor documents.  Honestly I though it was in the contributor documents but if it is it didn't have its own section.