### PR TITLE
fix: don't follow symlink

### DIFF
--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -173,6 +173,7 @@ class DirWalk:
                     and not self.pattern_match(
                         str(Path(dirpath) / filename), self.folder_exclude_pattern
                     )
+                    and not (Path(dirpath) / filename).is_symlink()
                 ]
                 dirnames[:] = [
                     dirname


### PR DESCRIPTION
Update `DirWalk.walk` to disable following symlinks, this will avoid scanning host binaries when analyzing an embedded rootfs target (e.g. if the target has an `./bin/echo` symlink pointing to `/bin/busybox`)