### PR TITLE
fix: remaining mypy errors in csv2cve.py

### DIFF
--- a/cve_bin_tool/csv2cve.py
+++ b/cve_bin_tool/csv2cve.py
@@ -20,7 +20,7 @@ def main(argv: list[str] | None = None):
             "Python no longer provides security updates for version 3.6 as of December 2021. Please upgrade to python 3.7+ to use CVE Binary Tool."
         )
     logger: logging.Logger = LOGGER.getChild("CSV2CVE")
-    argv: list[str] = argv or sys.argv
+    argv = argv or sys.argv
     if len(argv) < 2:
         with ErrorHandler(logger=logger):
             raise InsufficientArgs("csv file required")


### PR DESCRIPTION
fixes: #2764

The argv parameter was originally type annotated in the main function signature. Removing the second type annotation to argv resolved all four mypy errors.

Although only changing a type annnoation I ran code quality tools with pre-commit and tests were run on WSL using Python 3.11. On the first run of tests I received over 900 failures with the following errors:

`RuntimeError: Cannot run the event loop while another loop is running`

`RuntimeError: This event loop is already running`

Adding:
```
import nest_asyncio
nest_asyncio.apply()
```
to my local tests directory's `__init__.py` resulted in 6 failing tests on the second run. See below for test summary:

![cve-bin-tool-2023-03-03 221143](https://user-images.githubusercontent.com/17526532/222845199-17c1aaf1-a2de-4d7a-9229-cafc222408d1.png)
