### PR TITLE
fix: typehints in input_engine.py

### DIFF
--- a/cve_bin_tool/input_engine.py
+++ b/cve_bin_tool/input_engine.py
@@ -7,7 +7,7 @@ import re
 from collections import defaultdict
 from logging import Logger
 from pathlib import Path
-from typing import Any, DefaultDict, Dict, Iterable, Set, Union
+from typing import Any, DefaultDict, Dict, Iterable, Set, Union, TypedDict
 
 from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.error_handler import (
@@ -22,6 +22,8 @@ from cve_bin_tool.util import ProductInfo, Remarks
 
 # TriageData is dictionary of cve_number mapped to dictionary of remarks, comments and custom severity
 TriageData = Dict[str, Union[Dict[str, Any], Set[str]]]
+# It is not possible to typehint cve_number this way because we don't know what it is.
+# TriageData = Dict[str, TypedDict('TriageData', {"paths": Set[str], "default": Dict[str, Any]}, total=False)]
 
 
 class InputEngine:
@@ -31,7 +33,7 @@ class InputEngine:
     def __init__(
         self,
         filename: str,
-        logger: Logger = None,
+        logger: Logger | None = None,
         error_mode=ErrorMode.TruncTrace,
         filetype="autodetect",
     ):
@@ -139,7 +141,7 @@ class InputEngine:
                             else:
                                 vendor = "UNKNOWN"
 
-                        if version is not None and self.validate_product(product):
+                        if vendor is not None and version is not None and self.validate_product(product):
                             product_info = ProductInfo(
                                 vendor.strip(), product.strip(), version.strip()
                             )

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -41,7 +41,7 @@ class Remarks(OrderedEnum):
     Mitigated = 4, "4", "Mitigated", "m", "M"
     Ignored = 5, "5", "Ignored", "i", "I"
 
-    def __new__(cls, value: int, *aliases: str) -> Remarks:
+    def __new__(cls, value: str, *aliases: str) -> Remarks:
         obj = object.__new__(cls)
         obj._value_ = value
         for alias in aliases:


### PR DESCRIPTION
Fixes #2769 

I have fixed three of the errors, only one left which I am unable to solve after trying multiple approaches.
```
cve_bin_tool/input_engine.py:153: error: Unsupported target for indexed assignment ("Union[Dict[str, Any], Set[str]]")  [index]
```

The problem here is that on line 152 in input_engine.py we try to make an assignment assuming the it is an dict, but in the typing information we also take an optional Set[str] type. 
```python
if severity:
    self.parsed_data[product_info][id.strip() or "default"]["severity"] = severity.strip()
```

I tried to use TypedDict, but for that I have to know the keys in advance, which is not possible for cve_number as it is dynamic.
