### PR TITLE
fix(parser): handle multiple vendors in python

### DIFF
--- a/cve_bin_tool/parsers/python.py
+++ b/cve_bin_tool/parsers/python.py
@@ -74,15 +74,6 @@ class PythonParser(Parser):
     def __init__(self, cve_db, logger):
         super().__init__(cve_db, logger)
 
-    def find_vendor(self, product, version):
-        vendor_package_pair = self.cve_db.get_vendor_product_pairs(product)
-        if vendor_package_pair != []:
-            vendor = vendor_package_pair[0]["vendor"]
-            file_path = self.filename
-            self.logger.debug(f"{file_path} is {product} {version}")
-            return ScanInfo(ProductInfo(vendor, product, version), file_path)
-        return None
-
     def run_checker(self, filename):
         """
         This generator runs only for python packages.
@@ -95,9 +86,13 @@ class PythonParser(Parser):
         try:
             product = search(compile(r"^Name: (.+)$", MULTILINE), lines).group(1)
             version = search(compile(r"^Version: (.+)$", MULTILINE), lines).group(1)
-            product_info = self.find_vendor(product, version)
-            if product_info is not None:
-                yield product_info
+            vendor_package_pair = self.cve_db.get_vendor_product_pairs(product)
+            if vendor_package_pair != []:
+                for pair in vendor_package_pair:
+                    vendor = pair["vendor"]
+                    file_path = self.filename
+                    self.logger.debug(f"{file_path} is {vendor}.{product} {version}")
+                    yield ScanInfo(ProductInfo(vendor, product, version), file_path)
 
         # There are packages with a METADATA file in them containing different data from what the tool expects
         except AttributeError:


### PR DESCRIPTION
Curent python parser will only return the first vendor when parsing PKG-INFO for python packages which have multiple vendors such as paramiko: https://www.cvedetails.com/product-search.php?vendor_id=0&search=paramiko

Fix this behavior, to avoid missing CVEs.

It is highly likely that Java parser has the same kind of issue but this could be fixed in a dedicated commit by a Java "expert"