### PR TITLE
ci: run windows test even when cached db is not present

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -269,11 +269,10 @@ jobs:
           path: cache
           key: Linux-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
           enableCrossOsArchive: true
-          fail-on-cache-miss: true
       - name: Move cache to ~/.cache/cve-bin-tool
         run: |
           mkdir '~\.cache'
-          mv cache '~\.cache\cve-bin-tool'
+          if (Test-Path -Path cache) { mv cache '~\.cache\cve-bin-tool' }
       - name: Install cve-bin-tool
         run: |
           python -m pip install --upgrade pip
@@ -283,7 +282,7 @@ jobs:
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
         run: |
-          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out --offline -n json
+          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out -n json
       - name: Run async tests
         run: >
           pytest -n 4 -v
@@ -324,7 +323,7 @@ jobs:
       - name: Move cache to ~/.cache/cve-bin-tool
         run: |
           mkdir '~\.cache'
-          mv cache '~\.cache\cve-bin-tool'
+          if (Test-Path -Path cache) { mv cache '~\.cache\cve-bin-tool' }
       - name: Install cve-bin-tool
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
#2799 due to this issue, cached db is not being generated everyday. so windows tests are failing, because as of now they are dependent on the cache, and runs on offline mode. this pr will change that temporarily and will make it work on cache by default and also work when the cache is not available (just by simply updating the db).