### PR TITLE
Commented out schedule run option in export_data yaml

### DIFF
--- a/.github/workflows/export_data.yml
+++ b/.github/workflows/export_data.yml
@@ -3,9 +3,9 @@
 name: Export database
 
 on:
-  schedule:
-    # Runs at 00:00 UTC every Sunday
-    - cron: '0 0 * * 0'
+  # schedule:
+  #   # Runs at 00:00 UTC every Sunday
+  #   - cron: '0 0 * * 0'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
### Description

Website: WEBSITE_LINK_OF_THE_PRODUCT

CVEs: CVEDETAILS_PRODUCT_PAGE

closes #2801


### Checklist

- [ ]  Add checker
- [ ]  Add test
- [ ]  Make sure long tests are passing
- [ ]  Add condensed downloads to the commit
- [ ]  Make sure all tests are passing
- [x]  Make sure black/isort tests are passing
- [x]  Run a manual test with a vulnerable version of the product
- [x]  Update the template for this checker
- [x]  Update the reference links
