### PR TITLE
ci: switch cache job to use a specific version of ubuntu

### DIFF
--- a/.github/workflows/update-cache.yml
+++ b/.github/workflows/update-cache.yml
@@ -15,7 +15,7 @@ jobs:
   linux:
     if: github.repository == 'intel/cve-bin-tool'
     name: Update linux cached database
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
closes #2820

ubuntu 20.4 seems more suitable

![1678902502](https://user-images.githubusercontent.com/64733912/225399931-18129085-6da9-47d9-9218-ff4d9c2604f9.png)

src: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
