### PR TITLE
fix: fix long tests

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -32,11 +32,12 @@ test_data = list(
     map(lambda x: importlib.import_module(f"test.test_data.{x}"), all_test_name[2:])
 )
 mapping_test_data = map(lambda x: x.mapping_test_data, test_data)
-package_test_data = map(lambda x: x.package_test_data, test_data)
-for data in package_test_data:
+package_test_data = []
+for data in map(lambda x: x.package_test_data, test_data):
     for i in range(len(data)):
         if "other_products" not in data[i]:
             data[i]["other_products"] = []
+    package_test_data.append(data)
 all_the_tests = []
 for i in test_data:
     prod = i.package_test_data


### PR DESCRIPTION
All long tests are broken since https://github.com/intel/cve-bin-tool/commit/23b25e166e23c996bc7be3983f1c7dc6f5aab8f6 because for an obscure reason, `package_test_data` becomes empty after the loop so fix this issue