### PR TITLE
fix: fix netkit_ftp checker

### DIFF
--- a/cve_bin_tool/checkers/netkit_ftp.py
+++ b/cve_bin_tool/checkers/netkit_ftp.py
@@ -18,4 +18,4 @@ class NetkitFtpChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"ftp"]
     VERSION_PATTERNS = [r"\$NetKit: netkit-ftp-([0-9]+\.[0-9]+) \$"]
-    VENDOR_PRODUCT = [("netkit_ftp", "netkit_ftp")]
+    VENDOR_PRODUCT = [("netkit-ftp", "netkit_ftp")]


### PR DESCRIPTION
Fix typo in vendor of `netkit_ftp` checker to avoid missing CVE-2007-5769 and CVE-2007-6263