### PR TITLE
fix: improve libsndfile checker

### DIFF
--- a/cve_bin_tool/checkers/libsndfile.py
+++ b/cve_bin_tool/checkers/libsndfile.py
@@ -5,6 +5,7 @@
 """
 CVE checker for libsndfile
 
+https://www.cvedetails.com/vulnerability-list/vendor_id-8760/product_id-16957/Mega-nerd-Libsndfile.html
 https://www.cvedetails.com/product/36889/Libsndfile-Project-Libsndfile.html?vendor_id=16294
 
 """
@@ -21,4 +22,4 @@ class LibsndfileChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"libsndfile.so"]
     VERSION_PATTERNS = [r"libsndfile-(\d+\.\d+\.\d+[a-z0-9]*)\r?\n"]
-    VENDOR_PRODUCT = [("libsndfile_project", "libsndfile")]
+    VENDOR_PRODUCT = [("libsndfile_project", "libsndfile"), ("mega-nerd", "libsndfile")]


### PR DESCRIPTION
Add additional CPE ID to catch "old" CVEs