### PR TITLE
fix: improve iptables checker

### DIFF
--- a/cve_bin_tool/checkers/iptables.py
+++ b/cve_bin_tool/checkers/iptables.py
@@ -17,7 +17,7 @@ class IptablesChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
-        r"([0-9]+\.[0-9]+\.[0-9]+\.?[0-9]*)\r?\niptables",
+        r"\r?\n([0-9]{1,2}\.[0-9]+\.[0-9]+\.?[0-9]*)\r?\niptables",
         r"iptables-([0-9]+\.[0-9]+\.[0-9]+\.?[0-9]*)",
         r"iptables-rules>[a-zA-Z %:\r\n]*([0-9]+\.[0-9]+\.[0-9]+\.?[0-9]*)",
         r"iptables-save v%s on %s\r?\n([0-9]+\.[0-9]+\.[0-9]+\.?[0-9]*)",


### PR DESCRIPTION
Update iptables checker to avoid returning a false positive with the following string:

```
192.168.1.1
iptables -t nP
```