### PR TITLE
fix: handle multiple vendors in sbom_manager

### DIFF
--- a/cve_bin_tool/sbom_manager/__init__.py
+++ b/cve_bin_tool/sbom_manager/__init__.py
@@ -70,10 +70,11 @@ class SBOMManager:
             # Using lower to normalize product names across databases
             product, version = m[0].lower(), m[1]
             if version != "":
-                # Now add vendor to create product record....
-                # print (f"Find vendor for {product} {version}")
-                vendor = self.get_vendor(product)
-                if vendor is not None:
+                # Now add vendors to create product record....
+                # print (f"Find vendors for {product} {version}")
+                vendor_package_pair = self.cvedb.get_vendor_product_pairs(product)
+                for pair in vendor_package_pair:
+                    vendor = pair["vendor"]
                     parsed_data.append(ProductInfo(vendor, product, version))
                     # print(vendor,product,version)
 
@@ -87,13 +88,6 @@ class SBOMManager:
 
         LOGGER.debug(f"SBOM Data {self.sbom_data}")
         return self.sbom_data
-
-    def get_vendor(self, product: str) -> str | None:
-        vendor_package_pair = self.cvedb.get_vendor_product_pairs(product)
-        if vendor_package_pair != []:
-            vendor = vendor_package_pair[0]["vendor"]
-            return vendor
-        return None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As already done in commit f5dc1e330cf5f095441bde67e65f15a7edbff8b7 for python, update sbom_manager to avoid missing CVEs when there is multiple vendors of the same product