### PR TITLE
ci: increase timeouts, try specific ubuntu versions

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -348,7 +348,7 @@ jobs:
   windows_long_tests:
     name: Windows long tests
     runs-on: windows-latest
-    timeout-minutes: 60
+    timeout-minutes: 80
     env:
       LONG_TESTS: 1
       NO_EXIT_CVE_NUM: 1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   docs:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -44,11 +44,11 @@ jobs:
 
   tests:
     name: Linux tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.11']
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -109,7 +109,7 @@ jobs:
 
   long_tests:
     name: Long tests on Python 3.10
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 45
     env:
       LONG_TESTS: 1
@@ -285,7 +285,7 @@ jobs:
   windows_tests:
     name: Windows tests
     runs-on: windows-latest
-    timeout-minutes: 45
+    timeout-minutes: 55
     env:
       NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'


### PR DESCRIPTION
* fixes #2833

Trying to address some sporadic CI fails with longer timeouts (particularly on the short tests).  Also trying some specific versions of ubuntu rather than ubuntu-latest because we've seen reductions in queue time before jobs are run.