### PR TITLE
feat: human readable sbom integration

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -20,4 +20,6 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 docs:
+	# build human readable sboms first 
+	$(MAKE) -C ../sbom
 	$(SPHINXBUILD) $(SPHINXOPTS) $(SOURCEDIR) $(BUILDDIR)

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -19,6 +19,7 @@ The CVE Binary Tool helps you determine if your system includes known vulnerabil
    RELEASE.md
    CONTRIBUTING.md
    CHECKERS.md
+   sboms_for_humans/README.md
 
 Indices and tables
 ==================

--- a/doc/requirements.csv
+++ b/doc/requirements.csv
@@ -2,3 +2,4 @@ vendor,product
 sphinx-doc_not_in_db,Sphinx
 ryanfox_not_in_db,sphinx_markdown_tables
 executablebooks_not_in_db,myst_parser
+anthonyharrison_not_in_db,sbom2doc

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 Sphinx==4.4.0
 sphinx_markdown_tables
 myst_parser
+sbom2doc

--- a/doc/sboms_for_humans
+++ b/doc/sboms_for_humans
@@ -1,0 +1,1 @@
+../sbom/sboms_for_humans/

--- a/sbom/Makefile
+++ b/sbom/Makefile
@@ -1,0 +1,7 @@
+.PHONY: all
+
+SBOMS != ls *.spdx
+
+all: $(SBOMS)
+	$(info  SBOMS is $(SBOMS))
+	$(foreach file, $(SBOMS), sbom2doc --input-file $(file) --format markdown --output-file "sboms_for_humans/$(basename $(file)).md"; echo "- [$(basename $(file))]($(basename $(file)).md)" >> sboms_for_humans/README.md;)

--- a/sbom/Makefile
+++ b/sbom/Makefile
@@ -3,5 +3,4 @@
 SBOMS != ls *.spdx
 
 all: $(SBOMS)
-	$(info  SBOMS is $(SBOMS))
 	$(foreach file, $(SBOMS), sbom2doc --input-file $(file) --format markdown --output-file "sboms_for_humans/$(basename $(file)).md"; echo "- [$(basename $(file))]($(basename $(file)).md)" >> sboms_for_humans/README.md;)

--- a/sbom/sboms_for_humans/README.md
+++ b/sbom/sboms_for_humans/README.md
@@ -1,0 +1,13 @@
+
+# SBOMs For Humans
+
+Made possible with [sbom2doc](https://github.com/anthonyharrison/sbom2doc)
+
+These files are automatically generated as part of the `docs/` build process for [cve-bin-tool.readthedocs.io](https://cve-bin-tool.readthedocs.io)
+
+To manually build human readable files:
+- install `docs/requirements.txt`
+- navigate to the `sbom/` directory in your terminal and run `make`
+
+Generated human readable SBOMs:
+


### PR DESCRIPTION
this commit adds a build process for SBOM markdown files triggered by the docs build process.

From your review in the previous implementation: 
>Could we maybe make it so the human-friendly SBOM formats are generated only for the readthedocs site (e.g. run the  >sbom to markdown conversion in doc/Makefile) but not checked in to github as md files every week?

The `sbom/Makefile` is triggered in `doc/Makefile`. 

I like this one!