### PR TITLE
fix: handle data.tar.zst within deb archives

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -193,6 +193,7 @@ class BaseExtractor:
     async def extract_file_deb(self, filename, extraction_path):
         """Extract debian packages"""
         is_ar = True
+        is_zst = False
         process_can_fail = True
         if await aio_inpath("file"):
             stdout, stderr, return_code = await aio_run_command(
@@ -200,6 +201,8 @@ class BaseExtractor:
             )
             if not re.search(b"Debian binary package", stdout):
                 is_ar = False
+            if re.search(b"data compression zst", stdout):
+                is_zst = True
         if is_ar:
             if not await aio_inpath("ar"):
                 with ErrorHandler(mode=self.error_mode, logger=self.logger):
@@ -216,9 +219,12 @@ class BaseExtractor:
                 await aio_unpack_archive(filename, extraction_path, format="gztar")
 
         datafile = await aio_glob(str(Path(extraction_path) / "data.tar.*"))
-        with ErrorHandler(mode=ErrorMode.Ignore) as e:
-            await aio_unpack_archive(datafile[0], extraction_path)
-        return e.exit_code
+        if is_zst:
+            return await self.extract_file_zst(datafile[0], extraction_path)
+        else:
+            with ErrorHandler(mode=ErrorMode.Ignore) as e:
+                await aio_unpack_archive(datafile[0], extraction_path)
+            return e.exit_code
 
     async def extract_file_apk(self, filename, extraction_path):
         """Check whether it is alpine or android package"""


### PR DESCRIPTION
The deb extractor within `extractor.py` now handles zstd-compressed archive contents, which is supported in newer dpkg releases.

fixes: #2942