### PR TITLE
fix: add timeout in NVD API 2.0 code

### DIFF
--- a/cve_bin_tool/nvd_api.py
+++ b/cve_bin_tool/nvd_api.py
@@ -31,6 +31,8 @@ MAX_FAIL = 5
 INTERVAL_PERIOD = 6
 # Number of simultaneous connections
 MAX_HOSTS = 1
+# 15 min timeout for requests
+NVD_TIMEOUT = 900
 
 
 class NVD_API:
@@ -145,7 +147,7 @@ class NVD_API:
         if not self.session:
             connector = aiohttp.TCPConnector(limit_per_host=self.max_hosts)
             connection_timeout = aiohttp.ClientTimeout(
-                total=None,  # default value is 5 minutes, set to `None` for unlimited timeout
+                total=NVD_TIMEOUT,  # default value is 5 minutes, set to `None` for unlimited timeout
                 sock_connect=10,  # How long to wait before an open socket allowed to connect
                 sock_read=10,  # How long to wait with no data being read before timing out
             )


### PR DESCRIPTION
Submitter notes: added the timeout suggested by another contributor and tested that pulling from NVD still works.

fixes: #2580