### PR TITLE
fix: java parser failing to match vendor on product without '-'

### DIFF
--- a/cve_bin_tool/parsers/java.py
+++ b/cve_bin_tool/parsers/java.py
@@ -26,16 +26,14 @@ class JavaParser(Parser):
                 product = product.replace("-parent", "")
             product = product.replace("-", "_")
             vendor_package_pair = self.cve_db.get_vendor_product_pairs(product)
-            if vendor_package_pair != []:
-                info = []
-                for pair in vendor_package_pair:
-                    vendor = pair["vendor"]
-                    file_path = self.filename
-                    self.logger.debug(f"{file_path} {product} {version} by {vendor}")
-                    info.append(
-                        ScanInfo(ProductInfo(vendor, product, version), file_path)
-                    )
-                return info
+        if vendor_package_pair != []:
+            info = []
+            for pair in vendor_package_pair:
+                vendor = pair["vendor"]
+                file_path = self.filename
+                self.logger.debug(f"{file_path} {product} {version} by {vendor}")
+                info.append(ScanInfo(ProductInfo(vendor, product, version), file_path))
+            return info
         return None
 
     def run_checker(self, filename):


### PR DESCRIPTION
if the product did not have - in name and the vendor was found it would return None even though the match was found

* fixes #2960