### PR TITLE
fix: update tcpdump checker

### DIFF
--- a/cve_bin_tool/checkers/tcpdump.py
+++ b/cve_bin_tool/checkers/tcpdump.py
@@ -21,6 +21,6 @@ class TcpdumpChecker(Checker):
         r"tcpdump-([0-9]+\.[0-9]+\.[0-9]+)",
         r"([0-9]+\.[0-9]+\.[0-9]+)\r?\n[0-9a-f]*lookup_(?:emem|protoid)",
         r"Running\r?\n([0-9]+\.[0-9]+\.[0-9]+)\r?\n0123456789",
-        r"tcpdump[0-9a-zA-Z ,!'%:_=\(\)\\\.\-\r\n]*([0-9]+\.[0-9]+\.[0-9]+)",
+        r"tcpdump[0-9a-zA-Z ,!'%:_=\(\)\\\.\-\r\n]*\r?\n([0-9]+\.[0-9]+\.[0-9]+)",
     ]
     VENDOR_PRODUCT = [("tcpdump", "tcpdump")]

--- a/test/test_data/tcpdump.py
+++ b/test/test_data/tcpdump.py
@@ -23,6 +23,7 @@ mapping_test_data = [
         "version": "4.9.2",
         "version_strings": ["Running\n4.9.2\n0123456789"],
     },
+    {"product": "tcpdump", "version": "4.1.1", "version_strings": ["tcpdump\n4.1.1"]},
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Update tcpdump checker to avoid a false positive with `shortcut-fe.ko`