### PR TITLE
fix: improve proftpd checker

### DIFF
--- a/cve_bin_tool/checkers/proftpd.py
+++ b/cve_bin_tool/checkers/proftpd.py
@@ -17,5 +17,5 @@ from cve_bin_tool.checkers import Checker
 class ProftpdChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
-    VERSION_PATTERNS = [r"ProFTPD ([0-9]+\.[0-9]+\.[0-9a-z]+)"]
+    VERSION_PATTERNS = [r"ProFTPD ([0-9]+\.[0-9]+\.[0-9a-z]+) "]
     VENDOR_PRODUCT = [("proftpd_project", "proftpd"), ("proftpd", "proftpd")]

--- a/test/test_data/lynx.py
+++ b/test/test_data/lynx.py
@@ -19,27 +19,23 @@ package_test_data = [
         "package_name": "lynx-2.9.0-dev.10.2.fc37.1.aarch64.rpm",
         "product": "lynx",
         "version": "2.9.0dev.10",
-        "other_products": ["proftpd"],
     },
     {
         "url": "http://rpmfind.net/linux/fedora-secondary/development/rawhide/Everything/ppc64le/os/Packages/l/",
         "package_name": "lynx-2.9.0-dev.10.2.fc37.1.ppc64le.rpm",
         "product": "lynx",
         "version": "2.9.0dev.10",
-        "other_products": ["proftpd"],
     },
     {
         "url": "http://ftp.fr.debian.org/debian/pool/main/l/lynx/",
         "package_name": "lynx_2.8.9dev11-1_arm64.deb",
         "product": "lynx",
         "version": "2.8.9dev.11",
-        "other_products": ["proftpd"],
     },
     {
         "url": "https://downloads.openwrt.org/releases/packages-19.07/x86_64/packages/",
         "package_name": "lynx_2.8.9rel.1-1_x86_64.ipk",
         "product": "lynx",
         "version": "2.8.9rel.1",
-        "other_products": ["proftpd"],
     },
 ]

--- a/test/test_data/proftpd.py
+++ b/test/test_data/proftpd.py
@@ -5,7 +5,7 @@ mapping_test_data = [
     {
         "product": "proftpd",
         "version": "1.3.8rc4",
-        "version_strings": ["ProFTPD 1.3.8rc4"],
+        "version_strings": ["ProFTPD 1.3.8rc4 "],
     }
 ]
 package_test_data = [


### PR DESCRIPTION
Improve proftpd checker to avoid a false positive with lynx which has a check for broken ProFTPD 1.2.5rc1 and so embeds the following string: `ProFTPD 1.2.5`