### PR TITLE
chore: Change version to 3.2.1rc0 for pre-release

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -8,7 +8,7 @@ from packaging import version
 
 from cve_bin_tool.log import LOGGER
 
-VERSION: str = "3.2.1dev0"
+VERSION: str = "3.2.1rc0"
 
 
 def check_latest_version():


### PR DESCRIPTION
We need a quick release for a change to the curl data source.