### PR TITLE
chore: Bump version for 3.2.1 release, sort requirements

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -8,7 +8,7 @@ from packaging import version
 
 from cve_bin_tool.log import LOGGER
 
-VERSION: str = "3.2.1rc0"
+VERSION: str = "3.2.1"
 
 
 def check_latest_version():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,21 @@
-rich
-plotly
-jinja2>=2.11.3
-beautifulsoup4
 aiohttp[speedups]>=3.7.4
-toml
-pyyaml>=5.4
-jsonschema>=3.0.2
-rpmfile>=1.0.6
-zstandard; python_version >= "3.4"
-distro
-defusedxml
-xmlschema
-importlib_metadata>=3.6; python_version < "3.10"
-requests
-urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
-gsutil
+beautifulsoup4
 cvss
-packaging<22.0
+defusedxml
+distro
+gsutil
+importlib_metadata>=3.6; python_version < "3.10"
 importlib_resources; python_version < "3.9"
+jinja2>=2.11.3
+jsonschema>=3.0.2
 lib4sbom>=0.3.0
+packaging<22.0
+plotly
+pyyaml>=5.4
+requests
+rich
+rpmfile>=1.0.6
+toml
+urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
+xmlschema
+zstandard; python_version >= "3.4"


### PR DESCRIPTION
Sorting the requirements makes it easier for me to update our licensing paperwork.