### PR TITLE
chore: bump to dev version 3.2.2dev0

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -8,7 +8,7 @@ from packaging import version
 
 from cve_bin_tool.log import LOGGER
 
-VERSION: str = "3.2.1"
+VERSION: str = "3.2.2dev0"
 
 
 def check_latest_version():


### PR DESCRIPTION
Bump version to 3.2.2dev0 so it's easy to tell if you're using the dev tree (e.g. installed from github) vs a released version.

The next release may actually be numbered 3.3 or 4.0 and will likely occur in late July after GSoC mid-terms depending on feature progress at that time.