### PR TITLE
ci: fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -344,5 +344,5 @@ updates:
   - package-ecosystem: maven
     directory: /test/language_data
     schedule:
-      interval: never
+      interval: monthly
 


### PR DESCRIPTION
Missed one "never" in the last commit.