### PR TITLE
ci: Dependabot "duplicated" lines and ignore "*"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,12 +83,12 @@ updates:
       - dependency-name: "dirs-next"
       - dependency-name: "dirs-sys-next"
       - dependency-name: "dns-lookup"
-      - dependency-name: "dtoa"
+#      - dependency-name: "dtoa"
       - dependency-name: "either"
       - dependency-name: "encode_unicode"
       - dependency-name: "endian-type"
       - dependency-name: "env_logger"
-      - dependency-name: "error-code"
+#      - dependency-name: "error-code"
       - dependency-name: "exitcode"
       - dependency-name: "fd-lock"
       - dependency-name: "flame"
@@ -153,7 +153,7 @@ updates:
       - dependency-name: "openssl"
       - dependency-name: "openssl-probe"
       - dependency-name: "openssl-src"
-      - dependency-name: "openssl-sys"
+#      - dependency-name: "openssl-sys"
       - dependency-name: "optional"
       - dependency-name: "page_size"
       - dependency-name: "parking_lot"
@@ -214,7 +214,7 @@ updates:
       - dependency-name: "schannel"
       - dependency-name: "scopeguard"
       - dependency-name: "semver"
-      - dependency-name: "serde"
+#      - dependency-name: "serde"
       - dependency-name: "serde-wasm-bindgen"
       - dependency-name: "serde_cbor"
       - dependency-name: "serde_derive"
@@ -310,11 +310,15 @@ updates:
     directory: /test/language_data
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
 
   - package-ecosystem: gomod
     directory: /test/language_data
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
 
   - package-ecosystem: pip
     directory: /test/language_data
@@ -345,4 +349,6 @@ updates:
     directory: /test/language_data
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "*"
 


### PR DESCRIPTION
Doing some experiemntation to see if we can improve our depenabot.yml config and to try to get the checker to run before things are merged to main because that's just annoying. It looks like it might run on non-fork branches so I'll try that.