### PR TITLE
feat(scanner): slight update in version display

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -266,7 +266,7 @@ class CVEScanner:
                 # error_mode.value will only be greater than 1 if quiet mode.
                 if self.error_mode.value > 1:
                     self.logger.info(
-                        f"{len(cves)} CVE(s) in {product_info.vendor}.{product_info.product} v{product_info.version}"
+                        f"{len(cves)} CVE(s) in {product_info.vendor}.{product_info.product} version {product_info.version}"
                     )
                 self.all_cve_data[product_info]["cves"] = cves
                 self.all_cve_data[product_info]["paths"] |= triage_data["paths"]

--- a/test/test_csv2cve.py
+++ b/test/test_csv2cve.py
@@ -30,8 +30,8 @@ class TestCSV2CVE:
         ) in caplog.record_tuples
 
         for cve_count, product in [
-            [60, "haxx.curl v7.34.0"],
-            [10, "mit.kerberos_5 v1.15.1"],
+            [60, "haxx.curl version 7.34.0"],
+            [10, "mit.kerberos_5 version 1.15.1"],
         ]:
             retrieved_cve_count = 0
             for captured_line in caplog.record_tuples:


### PR DESCRIPTION
Replace `v{product_info.version}` by `version {product_info.version}` to allow the version number to be displayed in the same color (i.e. `4.19.205` will be displayed in blue and `version` in white instead of displaying `19.205` in blue and `v4.` in white)