### PR TITLE
ci: up timeouts on short and long tests

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         python: ['3.7', '3.8', '3.9', '3.11']
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@128a63446a954579617e875aaab7d2978154e969 # v2.4.0
@@ -121,7 +121,7 @@ jobs:
   long_tests:
     name: Long tests on Python 3.10
     runs-on: ubuntu-22.04
-    timeout-minutes: 45
+    timeout-minutes: 90
     env:
       LONG_TESTS: 1
     steps:
@@ -307,12 +307,11 @@ jobs:
         run: >
           pytest -v
           test/test_json.py
-          
 
   windows_tests:
     name: Windows tests
     runs-on: windows-latest
-    timeout-minutes: 55
+    timeout-minutes: 90
     env:
       NO_EXIT_CVE_NUM: 1
       PYTHONIOENCODING: 'utf8'
@@ -381,7 +380,7 @@ jobs:
   windows_long_tests:
     name: Windows long tests
     runs-on: windows-latest
-    timeout-minutes: 80
+    timeout-minutes: 120
     env:
       LONG_TESTS: 1
       NO_EXIT_CVE_NUM: 1


### PR DESCRIPTION
The short tests on both windows and now linux have been periodically timing out. This raises the limits for both the long and the short tests while we decide if the short tests need to be reduced to improve our CI experience.

Fixes #3046 