### PR TITLE
chore: SBOM updates july24

### DIFF
--- a/sbom/cve-bin-tool-py3.10.json
+++ b/sbom/cve-bin-tool-py3.10.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
-  "serialNumber": "urn:uuid2d1fb677-cf32-4abd-a3eb-622b5bcc965b",
+  "serialNumber": "urn:uuida0c8c30d-3fd0-4916-8272-82a2ae542925",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-07-10T00:40:56Z",
+    "timestamp": "2023-07-24T00:29:19Z",
     "tools": [
       {
         "name": "sbom4python",
@@ -55,7 +55,7 @@
       "type": "library",
       "bom-ref": "2-aiohttp",
       "name": "aiohttp",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "description": "Async http client/server framework (asyncio)",
       "licenses": [
         {
@@ -67,12 +67,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/aiohttp/3.8.4",
+          "url": "https://pypi.org/project/aiohttp/3.8.5",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/aiohttp@3.8.4",
+      "purl": "pkg:pypi/aiohttp@3.8.5",
       "properties": [
         {
           "name": "License Comments",
@@ -112,7 +112,7 @@
       "type": "library",
       "bom-ref": "4-frozenlist",
       "name": "frozenlist",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "description": "A list-like structure which implements collections.abc.MutableSequence",
       "licenses": [
         {
@@ -124,12 +124,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/frozenlist/1.3.3",
+          "url": "https://pypi.org/project/frozenlist/1.4.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/frozenlist@1.3.3",
+      "purl": "pkg:pypi/frozenlist@1.4.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1050,7 +1050,7 @@
       "type": "library",
       "bom-ref": "32-cryptography",
       "name": "cryptography",
-      "version": "41.0.1",
+      "version": "41.0.2",
       "supplier": {
         "name": "The Python Cryptographic Authority and individual contributors",
         "contact": [
@@ -1059,7 +1059,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*",
       "description": "cryptography is a package which provides cryptographic recipes and primitives to Python developers.",
       "licenses": [
         {
@@ -1070,12 +1070,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/cryptography/41.0.1",
+          "url": "https://pypi.org/project/cryptography/41.0.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/cryptography@41.0.1"
+      "purl": "pkg:pypi/cryptography@41.0.2"
     },
     {
       "type": "library",
@@ -1221,7 +1221,7 @@
       "type": "library",
       "bom-ref": "37-google-auth",
       "name": "google-auth",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "supplier": {
         "name": "Google Cloud Platform",
         "contact": [
@@ -1230,7 +1230,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*",
       "description": "Google Authentication Library",
       "licenses": [
         {
@@ -1242,12 +1242,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/google-auth/2.21.0",
+          "url": "https://pypi.org/project/google-auth/2.22.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/google-auth@2.21.0",
+      "purl": "pkg:pypi/google-auth@2.22.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1416,11 +1416,11 @@
       "type": "library",
       "bom-ref": "43-jsonschema",
       "name": "jsonschema",
-      "version": "4.18.0",
+      "version": "4.18.4",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*",
       "description": "An implementation of JSON Schema validation for Python",
       "licenses": [
         {
@@ -1432,22 +1432,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema/4.18.0",
+          "url": "https://pypi.org/project/jsonschema/4.18.4",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema@4.18.0"
+      "purl": "pkg:pypi/jsonschema@4.18.4"
     },
     {
       "type": "library",
       "bom-ref": "44-jsonschema-specifications",
       "name": "jsonschema-specifications",
-      "version": "2023.6.1",
+      "version": "2023.7.1",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*",
       "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
       "licenses": [
         {
@@ -1459,22 +1459,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema-specifications/2023.6.1",
+          "url": "https://pypi.org/project/jsonschema-specifications/2023.7.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema-specifications@2023.6.1"
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1"
     },
     {
       "type": "library",
       "bom-ref": "45-referencing",
       "name": "referencing",
-      "version": "0.29.1",
+      "version": "0.30.0",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*",
       "description": "JSON Referencing + Python",
       "licenses": [
         {
@@ -1486,22 +1486,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/referencing/0.29.1",
+          "url": "https://pypi.org/project/referencing/0.30.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/referencing@0.29.1"
+      "purl": "pkg:pypi/referencing@0.30.0"
     },
     {
       "type": "library",
       "bom-ref": "46-rpds-py",
       "name": "rpds-py",
-      "version": "0.8.10",
+      "version": "0.9.2",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*",
       "description": "Python bindings to Rust's persistent data structures (rpds)",
       "licenses": [
         {
@@ -1513,12 +1513,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/rpds-py/0.8.10",
+          "url": "https://pypi.org/project/rpds-py/0.9.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/rpds-py@0.8.10"
+      "purl": "pkg:pypi/rpds-py@0.9.2"
     },
     {
       "type": "library",
@@ -1556,7 +1556,7 @@
       "type": "library",
       "bom-ref": "48-pyyaml",
       "name": "pyyaml",
-      "version": "6.0",
+      "version": "6.0.1",
       "supplier": {
         "name": "Kirill Simonov",
         "contact": [
@@ -1565,7 +1565,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*",
       "description": "YAML parser and emitter for Python",
       "licenses": [
         {
@@ -1577,12 +1577,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/PyYAML/6.0",
+          "url": "https://pypi.org/project/PyYAML/6.0.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/pyyaml@6.0"
+      "purl": "pkg:pypi/pyyaml@6.0.1"
     },
     {
       "type": "library",
@@ -1733,7 +1733,7 @@
       "type": "library",
       "bom-ref": "53-python-gnupg",
       "name": "python-gnupg",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "supplier": {
         "name": "Vinay Sajip",
         "contact": [
@@ -1742,7 +1742,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*",
       "description": "A wrapper for the Gnu Privacy Guard (GPG or GnuPG)",
       "licenses": [
         {
@@ -1754,12 +1754,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/python-gnupg/0.5.0",
+          "url": "https://pypi.org/project/python-gnupg/0.5.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/python-gnupg@0.5.0",
+      "purl": "pkg:pypi/python-gnupg@0.5.1",
       "properties": [
         {
           "name": "License Comments",
@@ -1809,7 +1809,7 @@
       "type": "library",
       "bom-ref": "55-certifi",
       "name": "certifi",
-      "version": "2023.5.7",
+      "version": "2023.7.22",
       "supplier": {
         "name": "Kenneth Reitz",
         "contact": [
@@ -1818,7 +1818,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*",
       "description": "Python package for providing Mozilla's CA Bundle.",
       "licenses": [
         {
@@ -1830,12 +1830,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/certifi/2023.5.7",
+          "url": "https://pypi.org/project/certifi/2023.7.22",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/certifi@2023.5.7"
+      "purl": "pkg:pypi/certifi@2023.7.22"
     },
     {
       "type": "library",

--- a/sbom/cve-bin-tool-py3.10.spdx
+++ b/sbom/cve-bin-tool-py3.10.spdx
@@ -2,10 +2,10 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: Python-cve-bin-tool
-DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-8cf27c00-ca66-457e-9fd5-d1ed47312a40
+DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-aae8bdfd-96fa-481a-b8c8-0dbc20fed49c
 LicenseListVersion: 3.20
 Creator: Tool: sbom4python-0.9.2
-Created: 2023-07-10T00:39:41Z
+Created: 2023-07-24T00:28:01Z
 CreatorComment: <text>This document has been automatically generated.</text>
 ##### 
 
@@ -26,17 +26,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:terri_oda:cve-bin-tool:3.2.2.dev0:*:*:
 
 PackageName: aiohttp
 SPDXID: SPDXRef-Package-2-aiohttp
-PackageVersion: 3.8.4
+PackageVersion: 3.8.5
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.4
+PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.5
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>aiohttp declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Async http client/server framework (asyncio)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.4
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.5
 ##### 
 
 PackageName: aiosignal
@@ -55,17 +55,17 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
 
 PackageName: frozenlist
 SPDXID: SPDXRef-Package-4-frozenlist
-PackageVersion: 1.3.3
+PackageVersion: 1.4.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/frozenlist/1.3.3
+PackageDownloadLocation: https://pypi.org/project/frozenlist/1.4.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>frozenlist declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A list-like structure which implements collections.abc.MutableSequence</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.4.0
 ##### 
 
 PackageName: async-timeout
@@ -490,17 +490,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_pyopenssl_developers:pyopenssl:23.
 
 PackageName: cryptography
 SPDXID: SPDXRef-Package-32-cryptography
-PackageVersion: 41.0.1
+PackageVersion: 41.0.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: The Python Cryptographic Authority and individual contributors (cryptography-dev@python.org)
-PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.1
+PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.2
 FilesAnalyzed: false
 PackageLicenseDeclared: Apache-2.0 OR BSD-3-Clause
 PackageLicenseConcluded: Apache-2.0 OR BSD-3-Clause
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>cryptography is a package which provides cryptographic recipes and primitives to Python developers.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cffi
@@ -567,18 +567,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:craig_citro:google-apitools:0.5.32:*:*
 
 PackageName: google-auth
 SPDXID: SPDXRef-Package-37-google-auth
-PackageVersion: 2.21.0
+PackageVersion: 2.22.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: Google Cloud Platform (googleapis-packages@google.com)
-PackageDownloadLocation: https://pypi.org/project/google-auth/2.21.0
+PackageDownloadLocation: https://pypi.org/project/google-auth/2.22.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>google-auth declares Apache 2.0 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Google Authentication Library</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.21.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.22.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cachetools
@@ -658,62 +658,62 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.3
 
 PackageName: jsonschema
 SPDXID: SPDXRef-Package-43-jsonschema
-PackageVersion: 4.18.0
+PackageVersion: 4.18.4
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.0
+PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.4
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>An implementation of JSON Schema validation for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.4
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*
 ##### 
 
 PackageName: jsonschema-specifications
 SPDXID: SPDXRef-Package-44-jsonschema-specifications
-PackageVersion: 2023.6.1
+PackageVersion: 2023.7.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.6.1
+PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.7.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.6.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.7.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: referencing
 SPDXID: SPDXRef-Package-45-referencing
-PackageVersion: 0.29.1
+PackageVersion: 0.30.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/referencing/0.29.1
+PackageDownloadLocation: https://pypi.org/project/referencing/0.30.0
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>JSON Referencing + Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.29.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.30.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rpds-py
 SPDXID: SPDXRef-Package-46-rpds-py
-PackageVersion: 0.8.10
+PackageVersion: 0.9.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/rpds-py/0.8.10
+PackageDownloadLocation: https://pypi.org/project/rpds-py/0.9.2
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python bindings to Rust's persistent data structures (rpds)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.8.10
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.9.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: lib4sbom
@@ -733,17 +733,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:anthony_harrison:lib4sbom:0.3.1:*:*:*:
 
 PackageName: pyyaml
 SPDXID: SPDXRef-Package-48-pyyaml
-PackageVersion: 6.0
+PackageVersion: 6.0.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kirill Simonov (xi@resolvent.net)
-PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0
+PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>YAML parser and emitter for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: semantic-version
@@ -811,18 +811,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:julien_danjou:tenacity:8.2.2:*:*:*:*:*
 
 PackageName: python-gnupg
 SPDXID: SPDXRef-Package-53-python-gnupg
-PackageVersion: 0.5.0
+PackageVersion: 0.5.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Vinay Sajip (vinay_sajip@yahoo.co.uk)
-PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.0
+PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.1
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: BSD-3-Clause
 PackageLicenseComments: <text>python-gnupg declares BSD which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A wrapper for the Gnu Privacy Guard (GPG or GnuPG)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: requests
@@ -843,17 +843,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:requests:2.31.0:*:*:*:*:
 
 PackageName: certifi
 SPDXID: SPDXRef-Package-55-certifi
-PackageVersion: 2023.5.7
+PackageVersion: 2023.7.22
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kenneth Reitz (me@kennethreitz.com)
-PackageDownloadLocation: https://pypi.org/project/certifi/2023.5.7
+PackageDownloadLocation: https://pypi.org/project/certifi/2023.7.22
 FilesAnalyzed: false
 PackageLicenseDeclared: MPL-2.0
 PackageLicenseConcluded: MPL-2.0
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python package for providing Mozilla's CA Bundle.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.5.7
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.7.22
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rich

--- a/sbom/cve-bin-tool-py3.11.json
+++ b/sbom/cve-bin-tool-py3.11.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
-  "serialNumber": "urn:uuid2ea9459e-edb1-4609-b17d-e0073e90c087",
+  "serialNumber": "urn:uuid5a7b63ab-47f5-4de6-9234-8874c30772fe",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-07-10T00:35:34Z",
+    "timestamp": "2023-07-24T00:29:26Z",
     "tools": [
       {
         "name": "sbom4python",
@@ -55,7 +55,7 @@
       "type": "library",
       "bom-ref": "2-aiohttp",
       "name": "aiohttp",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "description": "Async http client/server framework (asyncio)",
       "licenses": [
         {
@@ -67,12 +67,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/aiohttp/3.8.4",
+          "url": "https://pypi.org/project/aiohttp/3.8.5",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/aiohttp@3.8.4",
+      "purl": "pkg:pypi/aiohttp@3.8.5",
       "properties": [
         {
           "name": "License Comments",
@@ -112,7 +112,7 @@
       "type": "library",
       "bom-ref": "4-frozenlist",
       "name": "frozenlist",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "description": "A list-like structure which implements collections.abc.MutableSequence",
       "licenses": [
         {
@@ -124,12 +124,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/frozenlist/1.3.3",
+          "url": "https://pypi.org/project/frozenlist/1.4.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/frozenlist@1.3.3",
+      "purl": "pkg:pypi/frozenlist@1.4.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1050,7 +1050,7 @@
       "type": "library",
       "bom-ref": "32-cryptography",
       "name": "cryptography",
-      "version": "41.0.1",
+      "version": "41.0.2",
       "supplier": {
         "name": "The Python Cryptographic Authority and individual contributors",
         "contact": [
@@ -1059,7 +1059,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*",
       "description": "cryptography is a package which provides cryptographic recipes and primitives to Python developers.",
       "licenses": [
         {
@@ -1070,12 +1070,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/cryptography/41.0.1",
+          "url": "https://pypi.org/project/cryptography/41.0.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/cryptography@41.0.1"
+      "purl": "pkg:pypi/cryptography@41.0.2"
     },
     {
       "type": "library",
@@ -1221,7 +1221,7 @@
       "type": "library",
       "bom-ref": "37-google-auth",
       "name": "google-auth",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "supplier": {
         "name": "Google Cloud Platform",
         "contact": [
@@ -1230,7 +1230,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*",
       "description": "Google Authentication Library",
       "licenses": [
         {
@@ -1242,12 +1242,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/google-auth/2.21.0",
+          "url": "https://pypi.org/project/google-auth/2.22.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/google-auth@2.21.0",
+      "purl": "pkg:pypi/google-auth@2.22.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1416,11 +1416,11 @@
       "type": "library",
       "bom-ref": "43-jsonschema",
       "name": "jsonschema",
-      "version": "4.18.0",
+      "version": "4.18.4",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*",
       "description": "An implementation of JSON Schema validation for Python",
       "licenses": [
         {
@@ -1432,22 +1432,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema/4.18.0",
+          "url": "https://pypi.org/project/jsonschema/4.18.4",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema@4.18.0"
+      "purl": "pkg:pypi/jsonschema@4.18.4"
     },
     {
       "type": "library",
       "bom-ref": "44-jsonschema-specifications",
       "name": "jsonschema-specifications",
-      "version": "2023.6.1",
+      "version": "2023.7.1",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*",
       "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
       "licenses": [
         {
@@ -1459,22 +1459,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema-specifications/2023.6.1",
+          "url": "https://pypi.org/project/jsonschema-specifications/2023.7.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema-specifications@2023.6.1"
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1"
     },
     {
       "type": "library",
       "bom-ref": "45-referencing",
       "name": "referencing",
-      "version": "0.29.1",
+      "version": "0.30.0",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*",
       "description": "JSON Referencing + Python",
       "licenses": [
         {
@@ -1486,22 +1486,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/referencing/0.29.1",
+          "url": "https://pypi.org/project/referencing/0.30.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/referencing@0.29.1"
+      "purl": "pkg:pypi/referencing@0.30.0"
     },
     {
       "type": "library",
       "bom-ref": "46-rpds-py",
       "name": "rpds-py",
-      "version": "0.8.10",
+      "version": "0.9.2",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*",
       "description": "Python bindings to Rust's persistent data structures (rpds)",
       "licenses": [
         {
@@ -1513,12 +1513,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/rpds-py/0.8.10",
+          "url": "https://pypi.org/project/rpds-py/0.9.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/rpds-py@0.8.10"
+      "purl": "pkg:pypi/rpds-py@0.9.2"
     },
     {
       "type": "library",
@@ -1556,7 +1556,7 @@
       "type": "library",
       "bom-ref": "48-pyyaml",
       "name": "pyyaml",
-      "version": "6.0",
+      "version": "6.0.1",
       "supplier": {
         "name": "Kirill Simonov",
         "contact": [
@@ -1565,7 +1565,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*",
       "description": "YAML parser and emitter for Python",
       "licenses": [
         {
@@ -1577,12 +1577,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/PyYAML/6.0",
+          "url": "https://pypi.org/project/PyYAML/6.0.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/pyyaml@6.0"
+      "purl": "pkg:pypi/pyyaml@6.0.1"
     },
     {
       "type": "library",
@@ -1733,7 +1733,7 @@
       "type": "library",
       "bom-ref": "53-python-gnupg",
       "name": "python-gnupg",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "supplier": {
         "name": "Vinay Sajip",
         "contact": [
@@ -1742,7 +1742,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*",
       "description": "A wrapper for the Gnu Privacy Guard (GPG or GnuPG)",
       "licenses": [
         {
@@ -1754,12 +1754,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/python-gnupg/0.5.0",
+          "url": "https://pypi.org/project/python-gnupg/0.5.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/python-gnupg@0.5.0",
+      "purl": "pkg:pypi/python-gnupg@0.5.1",
       "properties": [
         {
           "name": "License Comments",
@@ -1809,7 +1809,7 @@
       "type": "library",
       "bom-ref": "55-certifi",
       "name": "certifi",
-      "version": "2023.5.7",
+      "version": "2023.7.22",
       "supplier": {
         "name": "Kenneth Reitz",
         "contact": [
@@ -1818,7 +1818,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*",
       "description": "Python package for providing Mozilla's CA Bundle.",
       "licenses": [
         {
@@ -1830,12 +1830,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/certifi/2023.5.7",
+          "url": "https://pypi.org/project/certifi/2023.7.22",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/certifi@2023.5.7"
+      "purl": "pkg:pypi/certifi@2023.7.22"
     },
     {
       "type": "library",

--- a/sbom/cve-bin-tool-py3.11.spdx
+++ b/sbom/cve-bin-tool-py3.11.spdx
@@ -2,10 +2,10 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: Python-cve-bin-tool
-DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-68fdb550-35f5-478c-8d78-495fad3999e8
+DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-80457b80-ae28-4fb8-bb66-68f2bcc10bcd
 LicenseListVersion: 3.20
 Creator: Tool: sbom4python-0.9.2
-Created: 2023-07-10T00:34:20Z
+Created: 2023-07-24T00:28:06Z
 CreatorComment: <text>This document has been automatically generated.</text>
 ##### 
 
@@ -26,17 +26,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:terri_oda:cve-bin-tool:3.2.2.dev0:*:*:
 
 PackageName: aiohttp
 SPDXID: SPDXRef-Package-2-aiohttp
-PackageVersion: 3.8.4
+PackageVersion: 3.8.5
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.4
+PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.5
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>aiohttp declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Async http client/server framework (asyncio)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.4
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.5
 ##### 
 
 PackageName: aiosignal
@@ -55,17 +55,17 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
 
 PackageName: frozenlist
 SPDXID: SPDXRef-Package-4-frozenlist
-PackageVersion: 1.3.3
+PackageVersion: 1.4.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/frozenlist/1.3.3
+PackageDownloadLocation: https://pypi.org/project/frozenlist/1.4.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>frozenlist declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A list-like structure which implements collections.abc.MutableSequence</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.4.0
 ##### 
 
 PackageName: async-timeout
@@ -490,17 +490,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_pyopenssl_developers:pyopenssl:23.
 
 PackageName: cryptography
 SPDXID: SPDXRef-Package-32-cryptography
-PackageVersion: 41.0.1
+PackageVersion: 41.0.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: The Python Cryptographic Authority and individual contributors (cryptography-dev@python.org)
-PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.1
+PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.2
 FilesAnalyzed: false
 PackageLicenseDeclared: Apache-2.0 OR BSD-3-Clause
 PackageLicenseConcluded: Apache-2.0 OR BSD-3-Clause
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>cryptography is a package which provides cryptographic recipes and primitives to Python developers.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cffi
@@ -567,18 +567,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:craig_citro:google-apitools:0.5.32:*:*
 
 PackageName: google-auth
 SPDXID: SPDXRef-Package-37-google-auth
-PackageVersion: 2.21.0
+PackageVersion: 2.22.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: Google Cloud Platform (googleapis-packages@google.com)
-PackageDownloadLocation: https://pypi.org/project/google-auth/2.21.0
+PackageDownloadLocation: https://pypi.org/project/google-auth/2.22.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>google-auth declares Apache 2.0 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Google Authentication Library</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.21.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.22.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cachetools
@@ -658,62 +658,62 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.3
 
 PackageName: jsonschema
 SPDXID: SPDXRef-Package-43-jsonschema
-PackageVersion: 4.18.0
+PackageVersion: 4.18.4
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.0
+PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.4
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>An implementation of JSON Schema validation for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.4
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*
 ##### 
 
 PackageName: jsonschema-specifications
 SPDXID: SPDXRef-Package-44-jsonschema-specifications
-PackageVersion: 2023.6.1
+PackageVersion: 2023.7.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.6.1
+PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.7.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.6.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.7.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: referencing
 SPDXID: SPDXRef-Package-45-referencing
-PackageVersion: 0.29.1
+PackageVersion: 0.30.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/referencing/0.29.1
+PackageDownloadLocation: https://pypi.org/project/referencing/0.30.0
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>JSON Referencing + Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.29.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.30.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rpds-py
 SPDXID: SPDXRef-Package-46-rpds-py
-PackageVersion: 0.8.10
+PackageVersion: 0.9.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/rpds-py/0.8.10
+PackageDownloadLocation: https://pypi.org/project/rpds-py/0.9.2
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python bindings to Rust's persistent data structures (rpds)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.8.10
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.9.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: lib4sbom
@@ -733,17 +733,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:anthony_harrison:lib4sbom:0.3.1:*:*:*:
 
 PackageName: pyyaml
 SPDXID: SPDXRef-Package-48-pyyaml
-PackageVersion: 6.0
+PackageVersion: 6.0.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kirill Simonov (xi@resolvent.net)
-PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0
+PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>YAML parser and emitter for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: semantic-version
@@ -811,18 +811,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:julien_danjou:tenacity:8.2.2:*:*:*:*:*
 
 PackageName: python-gnupg
 SPDXID: SPDXRef-Package-53-python-gnupg
-PackageVersion: 0.5.0
+PackageVersion: 0.5.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Vinay Sajip (vinay_sajip@yahoo.co.uk)
-PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.0
+PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.1
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: BSD-3-Clause
 PackageLicenseComments: <text>python-gnupg declares BSD which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A wrapper for the Gnu Privacy Guard (GPG or GnuPG)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: requests
@@ -843,17 +843,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:requests:2.31.0:*:*:*:*:
 
 PackageName: certifi
 SPDXID: SPDXRef-Package-55-certifi
-PackageVersion: 2023.5.7
+PackageVersion: 2023.7.22
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kenneth Reitz (me@kennethreitz.com)
-PackageDownloadLocation: https://pypi.org/project/certifi/2023.5.7
+PackageDownloadLocation: https://pypi.org/project/certifi/2023.7.22
 FilesAnalyzed: false
 PackageLicenseDeclared: MPL-2.0
 PackageLicenseConcluded: MPL-2.0
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python package for providing Mozilla's CA Bundle.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.5.7
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.7.22
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rich

--- a/sbom/cve-bin-tool-py3.8.json
+++ b/sbom/cve-bin-tool-py3.8.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
-  "serialNumber": "urn:uuid2594a2d8-1a8e-49ce-8155-b6f102ba7513",
+  "serialNumber": "urn:uuidffe289d2-5a99-4a11-95be-bd7acdef29ec",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-07-10T00:39:47Z",
+    "timestamp": "2023-07-24T00:31:06Z",
     "tools": [
       {
         "name": "sbom4python",
@@ -55,7 +55,7 @@
       "type": "library",
       "bom-ref": "2-aiohttp",
       "name": "aiohttp",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "description": "Async http client/server framework (asyncio)",
       "licenses": [
         {
@@ -67,12 +67,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/aiohttp/3.8.4",
+          "url": "https://pypi.org/project/aiohttp/3.8.5",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/aiohttp@3.8.4",
+      "purl": "pkg:pypi/aiohttp@3.8.5",
       "properties": [
         {
           "name": "License Comments",
@@ -112,7 +112,7 @@
       "type": "library",
       "bom-ref": "4-frozenlist",
       "name": "frozenlist",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "description": "A list-like structure which implements collections.abc.MutableSequence",
       "licenses": [
         {
@@ -124,12 +124,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/frozenlist/1.3.3",
+          "url": "https://pypi.org/project/frozenlist/1.4.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/frozenlist@1.3.3",
+      "purl": "pkg:pypi/frozenlist@1.4.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1050,7 +1050,7 @@
       "type": "library",
       "bom-ref": "32-cryptography",
       "name": "cryptography",
-      "version": "41.0.1",
+      "version": "41.0.2",
       "supplier": {
         "name": "The Python Cryptographic Authority and individual contributors",
         "contact": [
@@ -1059,7 +1059,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*",
       "description": "cryptography is a package which provides cryptographic recipes and primitives to Python developers.",
       "licenses": [
         {
@@ -1070,12 +1070,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/cryptography/41.0.1",
+          "url": "https://pypi.org/project/cryptography/41.0.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/cryptography@41.0.1"
+      "purl": "pkg:pypi/cryptography@41.0.2"
     },
     {
       "type": "library",
@@ -1221,7 +1221,7 @@
       "type": "library",
       "bom-ref": "37-google-auth",
       "name": "google-auth",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "supplier": {
         "name": "Google Cloud Platform",
         "contact": [
@@ -1230,7 +1230,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*",
       "description": "Google Authentication Library",
       "licenses": [
         {
@@ -1242,12 +1242,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/google-auth/2.21.0",
+          "url": "https://pypi.org/project/google-auth/2.22.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/google-auth@2.21.0",
+      "purl": "pkg:pypi/google-auth@2.22.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1385,7 +1385,7 @@
       "type": "library",
       "bom-ref": "42-zipp",
       "name": "zipp",
-      "version": "3.16.0",
+      "version": "3.16.2",
       "supplier": {
         "name": "Jason R. Coombs",
         "contact": [
@@ -1394,16 +1394,16 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:jason_r._coombs:zipp:3.16.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:jason_r._coombs:zipp:3.16.2:*:*:*:*:*:*:*",
       "description": "Backport of pathlib-compatible object wrapper for zip files",
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/zipp/3.16.0",
+          "url": "https://pypi.org/project/zipp/3.16.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/zipp@3.16.0"
+      "purl": "pkg:pypi/zipp@3.16.2"
     },
     {
       "type": "library",
@@ -1488,11 +1488,11 @@
       "type": "library",
       "bom-ref": "46-jsonschema",
       "name": "jsonschema",
-      "version": "4.18.0",
+      "version": "4.18.4",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*",
       "description": "An implementation of JSON Schema validation for Python",
       "licenses": [
         {
@@ -1504,22 +1504,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema/4.18.0",
+          "url": "https://pypi.org/project/jsonschema/4.18.4",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema@4.18.0"
+      "purl": "pkg:pypi/jsonschema@4.18.4"
     },
     {
       "type": "library",
       "bom-ref": "47-jsonschema-specifications",
       "name": "jsonschema-specifications",
-      "version": "2023.6.1",
+      "version": "2023.7.1",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*",
       "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
       "licenses": [
         {
@@ -1531,22 +1531,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema-specifications/2023.6.1",
+          "url": "https://pypi.org/project/jsonschema-specifications/2023.7.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema-specifications@2023.6.1"
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1"
     },
     {
       "type": "library",
       "bom-ref": "48-referencing",
       "name": "referencing",
-      "version": "0.29.1",
+      "version": "0.30.0",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*",
       "description": "JSON Referencing + Python",
       "licenses": [
         {
@@ -1558,22 +1558,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/referencing/0.29.1",
+          "url": "https://pypi.org/project/referencing/0.30.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/referencing@0.29.1"
+      "purl": "pkg:pypi/referencing@0.30.0"
     },
     {
       "type": "library",
       "bom-ref": "49-rpds-py",
       "name": "rpds-py",
-      "version": "0.8.10",
+      "version": "0.9.2",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*",
       "description": "Python bindings to Rust's persistent data structures (rpds)",
       "licenses": [
         {
@@ -1585,12 +1585,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/rpds-py/0.8.10",
+          "url": "https://pypi.org/project/rpds-py/0.9.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/rpds-py@0.8.10"
+      "purl": "pkg:pypi/rpds-py@0.9.2"
     },
     {
       "type": "library",
@@ -1652,7 +1652,7 @@
       "type": "library",
       "bom-ref": "52-pyyaml",
       "name": "pyyaml",
-      "version": "6.0",
+      "version": "6.0.1",
       "supplier": {
         "name": "Kirill Simonov",
         "contact": [
@@ -1661,7 +1661,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*",
       "description": "YAML parser and emitter for Python",
       "licenses": [
         {
@@ -1673,12 +1673,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/PyYAML/6.0",
+          "url": "https://pypi.org/project/PyYAML/6.0.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/pyyaml@6.0"
+      "purl": "pkg:pypi/pyyaml@6.0.1"
     },
     {
       "type": "library",
@@ -1829,7 +1829,7 @@
       "type": "library",
       "bom-ref": "57-python-gnupg",
       "name": "python-gnupg",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "supplier": {
         "name": "Vinay Sajip",
         "contact": [
@@ -1838,7 +1838,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*",
       "description": "A wrapper for the Gnu Privacy Guard (GPG or GnuPG)",
       "licenses": [
         {
@@ -1850,12 +1850,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/python-gnupg/0.5.0",
+          "url": "https://pypi.org/project/python-gnupg/0.5.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/python-gnupg@0.5.0",
+      "purl": "pkg:pypi/python-gnupg@0.5.1",
       "properties": [
         {
           "name": "License Comments",
@@ -1905,7 +1905,7 @@
       "type": "library",
       "bom-ref": "59-certifi",
       "name": "certifi",
-      "version": "2023.5.7",
+      "version": "2023.7.22",
       "supplier": {
         "name": "Kenneth Reitz",
         "contact": [
@@ -1914,7 +1914,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*",
       "description": "Python package for providing Mozilla's CA Bundle.",
       "licenses": [
         {
@@ -1926,12 +1926,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/certifi/2023.5.7",
+          "url": "https://pypi.org/project/certifi/2023.7.22",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/certifi@2023.5.7"
+      "purl": "pkg:pypi/certifi@2023.7.22"
     },
     {
       "type": "library",

--- a/sbom/cve-bin-tool-py3.8.spdx
+++ b/sbom/cve-bin-tool-py3.8.spdx
@@ -2,10 +2,10 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: Python-cve-bin-tool
-DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-ad7dbeb4-29be-41b7-9df6-a373cb966694
+DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-8ae13fb1-fa0a-452f-bd4c-eabf41eea69d
 LicenseListVersion: 3.20
 Creator: Tool: sbom4python-0.9.2
-Created: 2023-07-10T00:38:13Z
+Created: 2023-07-24T00:29:07Z
 CreatorComment: <text>This document has been automatically generated.</text>
 ##### 
 
@@ -26,17 +26,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:terri_oda:cve-bin-tool:3.2.2.dev0:*:*:
 
 PackageName: aiohttp
 SPDXID: SPDXRef-Package-2-aiohttp
-PackageVersion: 3.8.4
+PackageVersion: 3.8.5
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.4
+PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.5
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>aiohttp declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Async http client/server framework (asyncio)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.4
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.5
 ##### 
 
 PackageName: aiosignal
@@ -55,17 +55,17 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
 
 PackageName: frozenlist
 SPDXID: SPDXRef-Package-4-frozenlist
-PackageVersion: 1.3.3
+PackageVersion: 1.4.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/frozenlist/1.3.3
+PackageDownloadLocation: https://pypi.org/project/frozenlist/1.4.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>frozenlist declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A list-like structure which implements collections.abc.MutableSequence</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.4.0
 ##### 
 
 PackageName: async-timeout
@@ -490,17 +490,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_pyopenssl_developers:pyopenssl:23.
 
 PackageName: cryptography
 SPDXID: SPDXRef-Package-32-cryptography
-PackageVersion: 41.0.1
+PackageVersion: 41.0.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: The Python Cryptographic Authority and individual contributors (cryptography-dev@python.org)
-PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.1
+PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.2
 FilesAnalyzed: false
 PackageLicenseDeclared: Apache-2.0 OR BSD-3-Clause
 PackageLicenseConcluded: Apache-2.0 OR BSD-3-Clause
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>cryptography is a package which provides cryptographic recipes and primitives to Python developers.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cffi
@@ -567,18 +567,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:craig_citro:google-apitools:0.5.32:*:*
 
 PackageName: google-auth
 SPDXID: SPDXRef-Package-37-google-auth
-PackageVersion: 2.21.0
+PackageVersion: 2.22.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: Google Cloud Platform (googleapis-packages@google.com)
-PackageDownloadLocation: https://pypi.org/project/google-auth/2.21.0
+PackageDownloadLocation: https://pypi.org/project/google-auth/2.22.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>google-auth declares Apache 2.0 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Google Authentication Library</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.21.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.22.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cachetools
@@ -644,17 +644,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:jason_r._coombs:importlib-metadata:6.8
 
 PackageName: zipp
 SPDXID: SPDXRef-Package-42-zipp
-PackageVersion: 3.16.0
+PackageVersion: 3.16.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: Jason R. Coombs (jaraco@jaraco.com)
-PackageDownloadLocation: https://pypi.org/project/zipp/3.16.0
+PackageDownloadLocation: https://pypi.org/project/zipp/3.16.2
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: NOASSERTION
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Backport of pathlib-compatible object wrapper for zip files</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zipp@3.16.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:jason_r._coombs:zipp:3.16.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zipp@3.16.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:jason_r._coombs:zipp:3.16.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: importlib-resources
@@ -703,62 +703,62 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.3
 
 PackageName: jsonschema
 SPDXID: SPDXRef-Package-46-jsonschema
-PackageVersion: 4.18.0
+PackageVersion: 4.18.4
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.0
+PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.4
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>An implementation of JSON Schema validation for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.4
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*
 ##### 
 
 PackageName: jsonschema-specifications
 SPDXID: SPDXRef-Package-47-jsonschema-specifications
-PackageVersion: 2023.6.1
+PackageVersion: 2023.7.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.6.1
+PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.7.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.6.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.7.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: referencing
 SPDXID: SPDXRef-Package-48-referencing
-PackageVersion: 0.29.1
+PackageVersion: 0.30.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/referencing/0.29.1
+PackageDownloadLocation: https://pypi.org/project/referencing/0.30.0
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>JSON Referencing + Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.29.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.30.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rpds-py
 SPDXID: SPDXRef-Package-49-rpds-py
-PackageVersion: 0.8.10
+PackageVersion: 0.9.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/rpds-py/0.8.10
+PackageDownloadLocation: https://pypi.org/project/rpds-py/0.9.2
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python bindings to Rust's persistent data structures (rpds)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.8.10
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.9.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: pkgutil-resolve-name
@@ -793,17 +793,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:anthony_harrison:lib4sbom:0.3.1:*:*:*:
 
 PackageName: pyyaml
 SPDXID: SPDXRef-Package-52-pyyaml
-PackageVersion: 6.0
+PackageVersion: 6.0.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kirill Simonov (xi@resolvent.net)
-PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0
+PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>YAML parser and emitter for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: semantic-version
@@ -871,18 +871,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:julien_danjou:tenacity:8.2.2:*:*:*:*:*
 
 PackageName: python-gnupg
 SPDXID: SPDXRef-Package-57-python-gnupg
-PackageVersion: 0.5.0
+PackageVersion: 0.5.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Vinay Sajip (vinay_sajip@yahoo.co.uk)
-PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.0
+PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.1
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: BSD-3-Clause
 PackageLicenseComments: <text>python-gnupg declares BSD which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A wrapper for the Gnu Privacy Guard (GPG or GnuPG)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: requests
@@ -903,17 +903,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:requests:2.31.0:*:*:*:*:
 
 PackageName: certifi
 SPDXID: SPDXRef-Package-59-certifi
-PackageVersion: 2023.5.7
+PackageVersion: 2023.7.22
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kenneth Reitz (me@kennethreitz.com)
-PackageDownloadLocation: https://pypi.org/project/certifi/2023.5.7
+PackageDownloadLocation: https://pypi.org/project/certifi/2023.7.22
 FilesAnalyzed: false
 PackageLicenseDeclared: MPL-2.0
 PackageLicenseConcluded: MPL-2.0
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python package for providing Mozilla's CA Bundle.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.5.7
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.7.22
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rich

--- a/sbom/cve-bin-tool-py3.9.json
+++ b/sbom/cve-bin-tool-py3.9.json
@@ -2,10 +2,10 @@
   "$schema": "http://cyclonedx.org/schema/bom-1.4.schema.json",
   "bomFormat": "CycloneDX",
   "specVersion": "1.4",
-  "serialNumber": "urn:uuid93f9738b-4ebb-4fb8-9bff-f3b17dc60da2",
+  "serialNumber": "urn:uuide5365fa2-de05-43d0-a018-fda815a5092c",
   "version": 1,
   "metadata": {
-    "timestamp": "2023-07-10T00:43:44Z",
+    "timestamp": "2023-07-24T00:30:14Z",
     "tools": [
       {
         "name": "sbom4python",
@@ -55,7 +55,7 @@
       "type": "library",
       "bom-ref": "2-aiohttp",
       "name": "aiohttp",
-      "version": "3.8.4",
+      "version": "3.8.5",
       "description": "Async http client/server framework (asyncio)",
       "licenses": [
         {
@@ -67,12 +67,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/aiohttp/3.8.4",
+          "url": "https://pypi.org/project/aiohttp/3.8.5",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/aiohttp@3.8.4",
+      "purl": "pkg:pypi/aiohttp@3.8.5",
       "properties": [
         {
           "name": "License Comments",
@@ -112,7 +112,7 @@
       "type": "library",
       "bom-ref": "4-frozenlist",
       "name": "frozenlist",
-      "version": "1.3.3",
+      "version": "1.4.0",
       "description": "A list-like structure which implements collections.abc.MutableSequence",
       "licenses": [
         {
@@ -124,12 +124,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/frozenlist/1.3.3",
+          "url": "https://pypi.org/project/frozenlist/1.4.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/frozenlist@1.3.3",
+      "purl": "pkg:pypi/frozenlist@1.4.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1050,7 +1050,7 @@
       "type": "library",
       "bom-ref": "32-cryptography",
       "name": "cryptography",
-      "version": "41.0.1",
+      "version": "41.0.2",
       "supplier": {
         "name": "The Python Cryptographic Authority and individual contributors",
         "contact": [
@@ -1059,7 +1059,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*",
       "description": "cryptography is a package which provides cryptographic recipes and primitives to Python developers.",
       "licenses": [
         {
@@ -1070,12 +1070,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/cryptography/41.0.1",
+          "url": "https://pypi.org/project/cryptography/41.0.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/cryptography@41.0.1"
+      "purl": "pkg:pypi/cryptography@41.0.2"
     },
     {
       "type": "library",
@@ -1221,7 +1221,7 @@
       "type": "library",
       "bom-ref": "37-google-auth",
       "name": "google-auth",
-      "version": "2.21.0",
+      "version": "2.22.0",
       "supplier": {
         "name": "Google Cloud Platform",
         "contact": [
@@ -1230,7 +1230,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*",
       "description": "Google Authentication Library",
       "licenses": [
         {
@@ -1242,12 +1242,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/google-auth/2.21.0",
+          "url": "https://pypi.org/project/google-auth/2.22.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/google-auth@2.21.0",
+      "purl": "pkg:pypi/google-auth@2.22.0",
       "properties": [
         {
           "name": "License Comments",
@@ -1385,7 +1385,7 @@
       "type": "library",
       "bom-ref": "42-zipp",
       "name": "zipp",
-      "version": "3.16.0",
+      "version": "3.16.2",
       "supplier": {
         "name": "Jason R. Coombs",
         "contact": [
@@ -1394,16 +1394,16 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:jason_r._coombs:zipp:3.16.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:jason_r._coombs:zipp:3.16.2:*:*:*:*:*:*:*",
       "description": "Backport of pathlib-compatible object wrapper for zip files",
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/zipp/3.16.0",
+          "url": "https://pypi.org/project/zipp/3.16.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/zipp@3.16.0"
+      "purl": "pkg:pypi/zipp@3.16.2"
     },
     {
       "type": "library",
@@ -1464,11 +1464,11 @@
       "type": "library",
       "bom-ref": "45-jsonschema",
       "name": "jsonschema",
-      "version": "4.18.0",
+      "version": "4.18.4",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*",
       "description": "An implementation of JSON Schema validation for Python",
       "licenses": [
         {
@@ -1480,22 +1480,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema/4.18.0",
+          "url": "https://pypi.org/project/jsonschema/4.18.4",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema@4.18.0"
+      "purl": "pkg:pypi/jsonschema@4.18.4"
     },
     {
       "type": "library",
       "bom-ref": "46-jsonschema-specifications",
       "name": "jsonschema-specifications",
-      "version": "2023.6.1",
+      "version": "2023.7.1",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*",
       "description": "The JSON Schema meta-schemas and vocabularies, exposed as a Registry",
       "licenses": [
         {
@@ -1507,22 +1507,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/jsonschema-specifications/2023.6.1",
+          "url": "https://pypi.org/project/jsonschema-specifications/2023.7.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/jsonschema-specifications@2023.6.1"
+      "purl": "pkg:pypi/jsonschema-specifications@2023.7.1"
     },
     {
       "type": "library",
       "bom-ref": "47-referencing",
       "name": "referencing",
-      "version": "0.29.1",
+      "version": "0.30.0",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*",
       "description": "JSON Referencing + Python",
       "licenses": [
         {
@@ -1534,22 +1534,22 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/referencing/0.29.1",
+          "url": "https://pypi.org/project/referencing/0.30.0",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/referencing@0.29.1"
+      "purl": "pkg:pypi/referencing@0.30.0"
     },
     {
       "type": "library",
       "bom-ref": "48-rpds-py",
       "name": "rpds-py",
-      "version": "0.8.10",
+      "version": "0.9.2",
       "supplier": {
         "name": "Julian Berman"
       },
-      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*",
       "description": "Python bindings to Rust's persistent data structures (rpds)",
       "licenses": [
         {
@@ -1561,12 +1561,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/rpds-py/0.8.10",
+          "url": "https://pypi.org/project/rpds-py/0.9.2",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/rpds-py@0.8.10"
+      "purl": "pkg:pypi/rpds-py@0.9.2"
     },
     {
       "type": "library",
@@ -1604,7 +1604,7 @@
       "type": "library",
       "bom-ref": "50-pyyaml",
       "name": "pyyaml",
-      "version": "6.0",
+      "version": "6.0.1",
       "supplier": {
         "name": "Kirill Simonov",
         "contact": [
@@ -1613,7 +1613,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*",
       "description": "YAML parser and emitter for Python",
       "licenses": [
         {
@@ -1625,12 +1625,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/PyYAML/6.0",
+          "url": "https://pypi.org/project/PyYAML/6.0.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/pyyaml@6.0"
+      "purl": "pkg:pypi/pyyaml@6.0.1"
     },
     {
       "type": "library",
@@ -1781,7 +1781,7 @@
       "type": "library",
       "bom-ref": "55-python-gnupg",
       "name": "python-gnupg",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "supplier": {
         "name": "Vinay Sajip",
         "contact": [
@@ -1790,7 +1790,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*",
       "description": "A wrapper for the Gnu Privacy Guard (GPG or GnuPG)",
       "licenses": [
         {
@@ -1802,12 +1802,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/python-gnupg/0.5.0",
+          "url": "https://pypi.org/project/python-gnupg/0.5.1",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/python-gnupg@0.5.0",
+      "purl": "pkg:pypi/python-gnupg@0.5.1",
       "properties": [
         {
           "name": "License Comments",
@@ -1857,7 +1857,7 @@
       "type": "library",
       "bom-ref": "57-certifi",
       "name": "certifi",
-      "version": "2023.5.7",
+      "version": "2023.7.22",
       "supplier": {
         "name": "Kenneth Reitz",
         "contact": [
@@ -1866,7 +1866,7 @@
           }
         ]
       },
-      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*",
+      "cpe": "cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*",
       "description": "Python package for providing Mozilla's CA Bundle.",
       "licenses": [
         {
@@ -1878,12 +1878,12 @@
       ],
       "externalReferences": [
         {
-          "url": "https://pypi.org/project/certifi/2023.5.7",
+          "url": "https://pypi.org/project/certifi/2023.7.22",
           "type": "distribution",
           "comment": "Download location for component"
         }
       ],
-      "purl": "pkg:pypi/certifi@2023.5.7"
+      "purl": "pkg:pypi/certifi@2023.7.22"
     },
     {
       "type": "library",

--- a/sbom/cve-bin-tool-py3.9.spdx
+++ b/sbom/cve-bin-tool-py3.9.spdx
@@ -2,10 +2,10 @@ SPDXVersion: SPDX-2.3
 DataLicense: CC0-1.0
 SPDXID: SPDXRef-DOCUMENT
 DocumentName: Python-cve-bin-tool
-DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-2d318abf-e201-4978-8cf4-4ddfde4f43ff
+DocumentNamespace: http://spdx.org/spdxdocs/Python-cve-bin-tool-c6a09f63-8827-481d-a8c1-f9c93bff5c4e
 LicenseListVersion: 3.20
 Creator: Tool: sbom4python-0.9.2
-Created: 2023-07-10T00:42:20Z
+Created: 2023-07-24T00:28:37Z
 CreatorComment: <text>This document has been automatically generated.</text>
 ##### 
 
@@ -26,17 +26,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:terri_oda:cve-bin-tool:3.2.2.dev0:*:*:
 
 PackageName: aiohttp
 SPDXID: SPDXRef-Package-2-aiohttp
-PackageVersion: 3.8.4
+PackageVersion: 3.8.5
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.4
+PackageDownloadLocation: https://pypi.org/project/aiohttp/3.8.5
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>aiohttp declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Async http client/server framework (asyncio)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.4
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiohttp@3.8.5
 ##### 
 
 PackageName: aiosignal
@@ -55,17 +55,17 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/aiosignal@1.3.1
 
 PackageName: frozenlist
 SPDXID: SPDXRef-Package-4-frozenlist
-PackageVersion: 1.3.3
+PackageVersion: 1.4.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: NOASSERTION
-PackageDownloadLocation: https://pypi.org/project/frozenlist/1.3.3
+PackageDownloadLocation: https://pypi.org/project/frozenlist/1.4.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>frozenlist declares Apache 2 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A list-like structure which implements collections.abc.MutableSequence</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.3.3
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/frozenlist@1.4.0
 ##### 
 
 PackageName: async-timeout
@@ -490,17 +490,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_pyopenssl_developers:pyopenssl:23.
 
 PackageName: cryptography
 SPDXID: SPDXRef-Package-32-cryptography
-PackageVersion: 41.0.1
+PackageVersion: 41.0.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: The Python Cryptographic Authority and individual contributors (cryptography-dev@python.org)
-PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.1
+PackageDownloadLocation: https://pypi.org/project/cryptography/41.0.2
 FilesAnalyzed: false
 PackageLicenseDeclared: Apache-2.0 OR BSD-3-Clause
 PackageLicenseConcluded: Apache-2.0 OR BSD-3-Clause
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>cryptography is a package which provides cryptographic recipes and primitives to Python developers.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/cryptography@41.0.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:the_python_cryptographic_authority_and_individual_contributors:cryptography:41.0.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cffi
@@ -567,18 +567,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:craig_citro:google-apitools:0.5.32:*:*
 
 PackageName: google-auth
 SPDXID: SPDXRef-Package-37-google-auth
-PackageVersion: 2.21.0
+PackageVersion: 2.22.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: Google Cloud Platform (googleapis-packages@google.com)
-PackageDownloadLocation: https://pypi.org/project/google-auth/2.21.0
+PackageDownloadLocation: https://pypi.org/project/google-auth/2.22.0
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: Apache-2.0
 PackageLicenseComments: <text>google-auth declares Apache 2.0 which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Google Authentication Library</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.21.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.21.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/google-auth@2.22.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:google_cloud_platform:google-auth:2.22.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: cachetools
@@ -644,17 +644,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:jason_r._coombs:importlib-metadata:6.8
 
 PackageName: zipp
 SPDXID: SPDXRef-Package-42-zipp
-PackageVersion: 3.16.0
+PackageVersion: 3.16.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Organization: Jason R. Coombs (jaraco@jaraco.com)
-PackageDownloadLocation: https://pypi.org/project/zipp/3.16.0
+PackageDownloadLocation: https://pypi.org/project/zipp/3.16.2
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: NOASSERTION
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Backport of pathlib-compatible object wrapper for zip files</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zipp@3.16.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:jason_r._coombs:zipp:3.16.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/zipp@3.16.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:jason_r._coombs:zipp:3.16.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: jinja2
@@ -688,62 +688,62 @@ ExternalRef: PACKAGE-MANAGER purl pkg:pypi/markupsafe@2.1.3
 
 PackageName: jsonschema
 SPDXID: SPDXRef-Package-45-jsonschema
-PackageVersion: 4.18.0
+PackageVersion: 4.18.4
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.0
+PackageDownloadLocation: https://pypi.org/project/jsonschema/4.18.4
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>An implementation of JSON Schema validation for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema@4.18.4
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema:4.18.4:*:*:*:*:*:*:*
 ##### 
 
 PackageName: jsonschema-specifications
 SPDXID: SPDXRef-Package-46-jsonschema-specifications
-PackageVersion: 2023.6.1
+PackageVersion: 2023.7.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.6.1
+PackageDownloadLocation: https://pypi.org/project/jsonschema-specifications/2023.7.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>The JSON Schema meta-schemas and vocabularies, exposed as a Registry</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.6.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.6.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/jsonschema-specifications@2023.7.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:jsonschema-specifications:2023.7.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: referencing
 SPDXID: SPDXRef-Package-47-referencing
-PackageVersion: 0.29.1
+PackageVersion: 0.30.0
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/referencing/0.29.1
+PackageDownloadLocation: https://pypi.org/project/referencing/0.30.0
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>JSON Referencing + Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.29.1
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.29.1:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/referencing@0.30.0
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:referencing:0.30.0:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rpds-py
 SPDXID: SPDXRef-Package-48-rpds-py
-PackageVersion: 0.8.10
+PackageVersion: 0.9.2
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Julian Berman
-PackageDownloadLocation: https://pypi.org/project/rpds-py/0.8.10
+PackageDownloadLocation: https://pypi.org/project/rpds-py/0.9.2
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python bindings to Rust's persistent data structures (rpds)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.8.10
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.8.10:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/rpds-py@0.9.2
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:julian_berman:rpds-py:0.9.2:*:*:*:*:*:*:*
 ##### 
 
 PackageName: lib4sbom
@@ -763,17 +763,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:anthony_harrison:lib4sbom:0.3.1:*:*:*:
 
 PackageName: pyyaml
 SPDXID: SPDXRef-Package-50-pyyaml
-PackageVersion: 6.0
+PackageVersion: 6.0.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kirill Simonov (xi@resolvent.net)
-PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0
+PackageDownloadLocation: https://pypi.org/project/PyYAML/6.0.1
 FilesAnalyzed: false
 PackageLicenseDeclared: MIT
 PackageLicenseConcluded: MIT
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>YAML parser and emitter for Python</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/pyyaml@6.0.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kirill_simonov:pyyaml:6.0.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: semantic-version
@@ -841,18 +841,18 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:julien_danjou:tenacity:8.2.2:*:*:*:*:*
 
 PackageName: python-gnupg
 SPDXID: SPDXRef-Package-55-python-gnupg
-PackageVersion: 0.5.0
+PackageVersion: 0.5.1
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Vinay Sajip (vinay_sajip@yahoo.co.uk)
-PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.0
+PackageDownloadLocation: https://pypi.org/project/python-gnupg/0.5.1
 FilesAnalyzed: false
 PackageLicenseDeclared: NOASSERTION
 PackageLicenseConcluded: BSD-3-Clause
 PackageLicenseComments: <text>python-gnupg declares BSD which is not currently a valid SPDX License identifier or expression.</text>
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>A wrapper for the Gnu Privacy Guard (GPG or GnuPG)</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.0
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.0:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/python-gnupg@0.5.1
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:vinay_sajip:python-gnupg:0.5.1:*:*:*:*:*:*:*
 ##### 
 
 PackageName: requests
@@ -873,17 +873,17 @@ ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:requests:2.31.0:*:*:*:*:
 
 PackageName: certifi
 SPDXID: SPDXRef-Package-57-certifi
-PackageVersion: 2023.5.7
+PackageVersion: 2023.7.22
 PrimaryPackagePurpose: LIBRARY
 PackageSupplier: Person: Kenneth Reitz (me@kennethreitz.com)
-PackageDownloadLocation: https://pypi.org/project/certifi/2023.5.7
+PackageDownloadLocation: https://pypi.org/project/certifi/2023.7.22
 FilesAnalyzed: false
 PackageLicenseDeclared: MPL-2.0
 PackageLicenseConcluded: MPL-2.0
 PackageCopyrightText: NOASSERTION
 PackageSummary: <text>Python package for providing Mozilla's CA Bundle.</text>
-ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.5.7
-ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.5.7:*:*:*:*:*:*:*
+ExternalRef: PACKAGE-MANAGER purl pkg:pypi/certifi@2023.7.22
+ExternalRef: SECURITY cpe23Type cpe:2.3:a:kenneth_reitz:certifi:2023.7.22:*:*:*:*:*:*:*
 ##### 
 
 PackageName: rich


### PR DESCRIPTION
Turning on branch protection has broken my ability to merge our automatic SBOM jobs.  They don't run the tests because they don't need to, but then the branch protection rule won't let me merge until the tests pass and there's no way to force them to run.

This is a workaround where I pull all of the SBOM updates into a personal branch so I can force the tests to run.  I hope this won't be our long-term fix since it's a pain, but it will do for this week until I figure out a better solution.