### PR TITLE
feat: Add User-Agent for mirroring

### DIFF
--- a/cve_bin_tool/fetch_json_db.py
+++ b/cve_bin_tool/fetch_json_db.py
@@ -14,6 +14,7 @@ from rich.progress import track
 from cve_bin_tool.async_utils import FileIO
 from cve_bin_tool.error_handler import ERROR_CODES, ErrorMode, SigningError
 from cve_bin_tool.log import LOGGER
+from cve_bin_tool.version import HTTP_HEADERS
 
 
 class Fetch_JSON_DB:
@@ -56,7 +57,7 @@ class Fetch_JSON_DB:
     async def handle_download(self):
         self.connector = aiohttp.TCPConnector(limit_per_host=10)
         async with aiohttp.ClientSession(
-            connector=self.connector, trust_env=True
+            connector=self.connector, headers=HTTP_HEADERS, trust_env=True
         ) as session:
             self.update_directory_structure()
             await self.get_metdata(session)

--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -10,6 +10,10 @@ from cve_bin_tool.log import LOGGER
 
 VERSION: str = "3.2.2dev0"
 
+HTTP_HEADERS: dict = {
+    "User-Agent": f"cve-bin-tool/{VERSION} (https://github.com/intel/cve-bin-tool/)",
+}
+
 
 def check_latest_version():
     """Checks for the latest version available at PyPI."""


### PR DESCRIPTION
This adds a User-Agent header to cve-bin-tool, currently used only when getting data from a mirror (as opposed to downloading directly from other data_sources).  Here's what it looks like trying an experiment on localhost right now:

```console
[terri@cedar ~]$ ls | nc -l -p 4888
GET //metadata.json HTTP/1.1
Host: 127.0.0.1:4888
User-Agent: cve-bin-tool/3.2.2dev0 (https://github.com/intel/cve-bin-tool/)
Accept: */*
Accept-Encoding: gzip, deflate
```