### PR TITLE
fix: update nodejs semver in test files to avoid warning

### DIFF
--- a/test/language_data/package-lock.json
+++ b/test/language_data/package-lock.json
@@ -78,12 +78,12 @@
         "jest-util": "^27.2.5",
         "natural-compare": "^1.4.0",
         "pretty-format": "^27.2.5",
-        "semver": "^7.3.2"
+        "semver": "^7.5.4"
       },
       "dependencies": {
         "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+          "version": "7.5.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
           "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
           "dev": true,
           "requires": {


### PR DESCRIPTION
This is a kind of silly update.

The package-lock.json file we use for language tests has a version of semver that's triggering some CVE warning in one of my dashboards. Normally, I mark these as irrelevant because files in test/language_data are used only for tests of the scanner (the vulnerable code described is never downloaded or used).  But for some reason this particular dashboard isn't giving me the usual way to dismiss the warning.  

Since fixing that particular private dashboard might take a while, I'm going to try updating the one thing that's throwing an error so I don't have to get daily warnings about this component.

It's possible this change will break the tests.  I am running them locally but uploading this PR while I wait so they can happen in parallel.