### PR TITLE
fix: update libksba CPE ID

### DIFF
--- a/cve_bin_tool/checkers/libksba.py
+++ b/cve_bin_tool/checkers/libksba.py
@@ -5,7 +5,7 @@
 """
 CVE checker for libksba:
 
-https://www.cvedetails.com/product/64485/Libksba-Project-Libksba.html?vendor_id=14973
+https://www.cvedetails.com/product/139830/Gnupg-Libksba.html?vendor_id=4711
 
 """
 from __future__ import annotations
@@ -17,4 +17,4 @@ class LibksbaChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"Libksba ([0-9]+\.[0-9]+\.[0-9]+)"]
-    VENDOR_PRODUCT = [("libksba_project", "libksba")]
+    VENDOR_PRODUCT = [("gnupg", "libksba")]


### PR DESCRIPTION
libksba_project:libksba has been deprecated by NVD [0], gnupg:libksba should be used instead.

[0]: https://nvd.nist.gov/products/cpe/detail/AA709F75-0B9E-4B67-ACEA-C1DCF33E7745?namingFormat=2.3&orderBy=CPEURI&keyword=libksba&status=FINAL