### PR TITLE
fix: handling of product versions and vendor name guessing

### DIFF
--- a/cve_bin_tool/data_sources/osv_source.py
+++ b/cve_bin_tool/data_sources/osv_source.py
@@ -340,6 +340,7 @@ class OSV_Source(Data_Source):
                             fixed = event.get("fixed")
 
                         if fixed is not None:
+                            affected = affected.copy()
                             affected["versionStartIncluding"] = introduced
                             affected["versionEndExcluding"] = fixed
 

--- a/cve_bin_tool/data_sources/osv_source.py
+++ b/cve_bin_tool/data_sources/osv_source.py
@@ -297,7 +297,9 @@ class OSV_Source(Data_Source):
                 vendor = (
                     "unknown"  # OSV Schema does not provide vendor names for packages
                 )
-                if "/" in product and "github":
+                if (
+                    "github.com/" in product
+                ):  # if package name is of format github.com/xxxx/yyyy  xxxx can be vendor name and yyyy is package name
                     vendor = product.split("/")[-2]  # trying to guess vendor name
                     product = product.split("/")[-1]
 
@@ -314,7 +316,7 @@ class OSV_Source(Data_Source):
 
                 events = None
                 for ranges in package.get("ranges", []):
-                    if ranges["type"] != "GIT":
+                    if ranges["type"] == "SEMVER":
                         events = ranges["events"]
 
                 if events is None:

--- a/cve_bin_tool/data_sources/osv_source.py
+++ b/cve_bin_tool/data_sources/osv_source.py
@@ -325,10 +325,12 @@ class OSV_Source(Data_Source):
                     if versions == []:
                         continue
 
-                    affected["versionStartIncluding"] = versions[0]
-                    affected["versionEndIncluding"] = versions[-1]
+                    version_affected = affected.copy()
 
-                    affected_data.append(affected)
+                    version_affected["versionStartIncluding"] = versions[0]
+                    version_affected["versionEndIncluding"] = versions[-1]
+
+                    affected_data.append(version_affected)
                 else:
                     introduced = None
                     fixed = None
@@ -340,13 +342,14 @@ class OSV_Source(Data_Source):
                             fixed = event.get("fixed")
 
                         if fixed is not None:
-                            affected = affected.copy()
-                            affected["versionStartIncluding"] = introduced
-                            affected["versionEndExcluding"] = fixed
+                            range_affected = affected.copy()
+
+                            range_affected["versionStartIncluding"] = introduced
+                            range_affected["versionEndExcluding"] = fixed
 
                             fixed = None
 
-                            affected_data.append(affected)
+                            affected_data.append(range_affected)
 
         return severity_data, affected_data
 

--- a/test/test_source_osv.py
+++ b/test/test_source_osv.py
@@ -155,7 +155,18 @@ class TestSourceOSV:
                 "CVSS_vector": "unknown",
                 "last_modified": "2021-09-26T23:33:39.795406Z",
             },
-            "affected_data": [],
+            "affected_data": [
+                {
+                    "cve_id": "CVE-2018-20133",
+                    "vendor": "unknown",
+                    "product": "ymlref",
+                    "version": "*",
+                    "versionStartIncluding": "0.1.0",
+                    "versionStartExcluding": "",
+                    "versionEndIncluding": "0.1.1",
+                    "versionEndExcluding": "",
+                }
+            ],
         },
         "CVE-2014-5461": {
             "severity_data": {
@@ -173,10 +184,10 @@ class TestSourceOSV:
                     "vendor": "unknown",
                     "product": "lua5.1",
                     "version": "*",
-                    "versionStartIncluding": "0",
+                    "versionStartIncluding": "5.1.4-5",
                     "versionStartExcluding": "",
-                    "versionEndIncluding": "",
-                    "versionEndExcluding": "5.1.4-5+deb6u1",
+                    "versionEndIncluding": "5.1.4-5",
+                    "versionEndExcluding": "",
                 }
             ],
         },


### PR DESCRIPTION
removed use of `ECOSYSTEM` versions, and corrected vendor name guessing from package name.

fixes #3200 
partial work on #3201 