### PR TITLE
chore: remove dependency on py

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,7 @@ flake8==6.1.0; python_version >= "3.8"
 bandit==1.7.5
 gitlint==v0.19.1
 mypy==v1.4.1
-pytest
+pytest>=7.2.0
 pytest-xdist
 pytest-cov
 pytest-asyncio

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,7 +8,6 @@ flake8==6.1.0; python_version >= "3.8"
 bandit==1.7.5
 gitlint==v0.19.1
 mypy==v1.4.1
-py>=1.10.0
 pytest
 pytest-xdist
 pytest-cov


### PR DESCRIPTION
py used to be a dependency of pytest, and we had it explicitly added to our requirements file as a workaround to avoid an older vulnerable version.  As of pytest 7.2.0 this dependency is no longer required.