### PR TITLE
fix: enable gimp tests

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -49,7 +49,7 @@ for i in test_data:
         for i in prod_list:
             all_the_tests.append(i)
 
-DISABLED_TESTS_ACTIONS: list[str] = ["gimp", "ceph"]
+DISABLED_TESTS_ACTIONS: list[str] = ["ceph"]
 DISABLED_TESTS_LOCAL: list[str] = []
 DISABLED_TESTS_WINDOWS: list[str] = ["libsrtp", "p7zip"]
 


### PR DESCRIPTION
gimp tests have been disabled in January 2021 by commit a5d6c25fdf59fedab2da63336328968ef3ada165 but they seem to work perfectly fine nowadays (at least on Linux)