### PR TITLE
fix: ignore non-vulnerable CPEs from NVD CVEs

### DIFF
--- a/cve_bin_tool/data_sources/nvd_source.py
+++ b/cve_bin_tool/data_sources/nvd_source.py
@@ -173,7 +173,8 @@ class NVD_Source(Data_Source):
     def parse_node(self, node: dict[str, list[dict[str, str]]]) -> list[dict[str, str]]:
         affects_list = []
         if "cpe_match" in node:
-            for cpe_match in node["cpe_match"]:
+            vulnerable_matches = (m for m in node["cpe_match"] if m["vulnerable"])
+            for cpe_match in vulnerable_matches:
                 cpe_split = cpe_match["cpe23Uri"].split(":")
                 affects = {
                     "vendor": cpe_split[3],
@@ -277,7 +278,8 @@ class NVD_Source(Data_Source):
     ) -> list[dict[str, str]]:
         affects_list = []
         if "cpeMatch" in node:
-            for cpe_match in node["cpeMatch"]:
+            vulnerable_matches = (m for m in node["cpeMatch"] if m["vulnerable"])
+            for cpe_match in vulnerable_matches:
                 cpe_split = cpe_match["criteria"].split(":")
                 affects = {
                     "vendor": cpe_split[3],


### PR DESCRIPTION
fixes #3136   (at least partially: it excludes the "longer term potential feature" part)

As described in above issue, NVD source provides a list of affected CPE for a given CVE. This list may include non-vulnerable products such as OSes an affected product runs on, e.g. application v3.4 is vulnerable when it runs on Windows. The latter, although being mentioned in a CPE for this CVE, is not vulnerable with regard to that CVE. 

Whether a CPE is vulnerable or not is provided in a `vulnerable` attribute that can be used during data ingestion. See [Response `configuration` JSON sample](https://nvd.nist.gov/developers/vulnerabilities). This PR ignores non-vulnerable CPEs when building/refreshing the CVE DB

Limitations
- On a DB refresh, `vulnerable` will be used, but it won't remove existing entries about non-vulnerable products (ingested from actual cve-bin-tool version). There is no way to figure it out from the current DB.
- It does not address the "missing relations" part of the issue (the "longer term potential feature"), as non-vulnerable products that would take part in such relations are now ignored. 

Note: I could not find unit tests related to NVD source parsing to build upon. I'll welcome suggestions, if any, regarding warranted tests for this PR.