### PR TITLE
fix: blank path gets added when using triage_input_file option

### DIFF
--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -84,7 +84,7 @@ class CVEScanner:
                 f"{product_info} already processed. Update path {triage_data['paths']}"
             )
             # self.products_with_cve += 1
-            self.all_cve_data[product_info]["paths"] |= triage_data["paths"]
+            self.all_cve_data[product_info]["paths"] |= set(triage_data["paths"])
             return
 
         # Check for anything directly marked
@@ -269,7 +269,7 @@ class CVEScanner:
                         f"{len(cves)} CVE(s) in {product_info.vendor}.{product_info.product} version {product_info.version}"
                     )
                 self.all_cve_data[product_info]["cves"] = cves
-                self.all_cve_data[product_info]["paths"] |= triage_data["paths"]
+                self.all_cve_data[product_info]["paths"] |= set(triage_data["paths"])
             else:
                 # No cves found for (product, vendor, version) tuple in the NVD database.
                 self.products_without_cve += 1

--- a/cve_bin_tool/input_engine.py
+++ b/cve_bin_tool/input_engine.py
@@ -151,7 +151,7 @@ class InputEngine:
                                 self.parsed_data[product_info][id.strip() or "default"][
                                     "severity"
                                 ] = severity.strip()
-                            self.parsed_data[product_info]["paths"] = {""}
+                            self.parsed_data[product_info]["paths"] = {}
 
     def parse_data(self, fields: Set[str], data: Iterable) -> None:
         required_fields = {"vendor", "product", "version"}

--- a/test/test_input_engine.py
+++ b/test/test_input_engine.py
@@ -27,11 +27,11 @@ class TestInputEngine:
     PARSED_TRIAGE_DATA = {
         ProductInfo("haxx", "curl", "7.59.0"): {
             "default": {"comments": "", "remarks": Remarks.NewFound, "severity": ""},
-            "paths": {""},
+            "paths": {},
         },
         ProductInfo("haxx", "libcurl", "7.59.0"): {
             "default": {"comments": "", "remarks": Remarks.Unexplored, "severity": ""},
-            "paths": {""},
+            "paths": {},
         },
         ProductInfo("libjpeg-turbo", "libjpeg-turbo", "2.0.1"): {
             "CVE-2018-19664": {
@@ -44,19 +44,19 @@ class TestInputEngine:
                 "remarks": Remarks.Unexplored,
                 "severity": "HIGH",
             },
-            "paths": {""},
+            "paths": {},
         },
         ProductInfo("mit", "kerberos_5", "1.15.1"): {
             "default": {"comments": "", "remarks": Remarks.Confirmed, "severity": ""},
-            "paths": {""},
+            "paths": {},
         },
         ProductInfo("ssh", "ssh2", "2.0"): {
             "default": {"comments": "", "remarks": Remarks.Mitigated, "severity": ""},
-            "paths": {""},
+            "paths": {},
         },
         ProductInfo("sun", "sunos", "5.4"): {
             "default": {"comments": "", "remarks": Remarks.Mitigated, "severity": ""},
-            "paths": {""},
+            "paths": {},
         },
     }
     VEX_TRIAGE_DATA = {

--- a/test/test_input_engine.py
+++ b/test/test_input_engine.py
@@ -27,11 +27,11 @@ class TestInputEngine:
     PARSED_TRIAGE_DATA = {
         ProductInfo("haxx", "curl", "7.59.0"): {
             "default": {"comments": "", "remarks": Remarks.NewFound, "severity": ""},
-            "paths": {},
+            "paths": {""},
         },
         ProductInfo("haxx", "libcurl", "7.59.0"): {
             "default": {"comments": "", "remarks": Remarks.Unexplored, "severity": ""},
-            "paths": {},
+            "paths": {""},
         },
         ProductInfo("libjpeg-turbo", "libjpeg-turbo", "2.0.1"): {
             "CVE-2018-19664": {
@@ -44,19 +44,19 @@ class TestInputEngine:
                 "remarks": Remarks.Unexplored,
                 "severity": "HIGH",
             },
-            "paths": {},
+            "paths": {""},
         },
         ProductInfo("mit", "kerberos_5", "1.15.1"): {
             "default": {"comments": "", "remarks": Remarks.Confirmed, "severity": ""},
-            "paths": {},
+            "paths": {""},
         },
         ProductInfo("ssh", "ssh2", "2.0"): {
             "default": {"comments": "", "remarks": Remarks.Mitigated, "severity": ""},
-            "paths": {},
+            "paths": {""},
         },
         ProductInfo("sun", "sunos", "5.4"): {
             "default": {"comments": "", "remarks": Remarks.Mitigated, "severity": ""},
-            "paths": {},
+            "paths": {""},
         },
     }
     VEX_TRIAGE_DATA = {
@@ -66,7 +66,7 @@ class TestInputEngine:
                 "remarks": Remarks.Confirmed,
                 "severity": "CRITICAL",
             },
-            "paths": {""},
+            "paths": {},
         },
         ProductInfo("gnu", "glibc", "2.33"): {
             "CVE-2021-1234": {
@@ -74,7 +74,7 @@ class TestInputEngine:
                 "remarks": Remarks.Unexplored,
                 "severity": "HIGH",
             },
-            "paths": {""},
+            "paths": {},
         },
     }
     # cyclonedx currently doesn't have vendors
@@ -85,7 +85,7 @@ class TestInputEngine:
                 "remarks": Remarks.Confirmed,
                 "severity": "CRITICAL",
             },
-            "paths": {""},
+            "paths": {},
         },
         ProductInfo("UNKNOWN", "glibc", "2.33"): {
             "CVE-2021-1234": {
@@ -93,7 +93,7 @@ class TestInputEngine:
                 "remarks": Remarks.Unexplored,
                 "severity": "HIGH",
             },
-            "paths": {""},
+            "paths": {},
         },
     }
     MISSING_FIELD_REGEX = re.compile(


### PR DESCRIPTION
before:
![image](https://github.com/intel/cve-bin-tool/assets/64733912/9d305089-5772-438f-9524-962cbf05f10d)

after:
![image](https://github.com/intel/cve-bin-tool/assets/64733912/9ccc91b1-d142-480a-a3a0-29f25d897236)
