### PR TITLE
docs: updated version of cycloneDX #3272

### DIFF
--- a/doc/how_to_guides/sbom.md
+++ b/doc/how_to_guides/sbom.md
@@ -13,8 +13,8 @@ The cve-bin-tool supports SBOMs in the following formats
 | SPDX      | 2.2       | JSON           |
 | SPDX      | 2.2       | YAML           |
 | SPDX      | 2.2       | XML            |
-| CycloneDX | 1.3       | XML            |
-| CycloneDX | 1.3       | JSON           |
+| CycloneDX | 1.3-1.5   | XML            |
+| CycloneDX | 1.3-1.5   | JSON           |
 | SWID      | See Note  | XML            |
 
 Details of the formats for each of the supported SBOM formats are available for 


### PR DESCRIPTION
fixes #3272
docs : updated the version of cycloneDX in  "doc/how_to_guides/sbom.md"

![Screenshot 2023-08-25 181526](https://github.com/intel/cve-bin-tool/assets/82561880/47ed3bb7-d0a0-4360-96ad-cf2d50ea4fd8)
