### PR TITLE
fix: add additional openssh CPE ID

### DIFF
--- a/cve_bin_tool/checkers/openssh.py
+++ b/cve_bin_tool/checkers/openssh.py
@@ -7,6 +7,7 @@ CVE checker for openssh
 
 References:
 https://www.cvedetails.com/product/585/Openbsd-Openssh.html?vendor_id=97
+https://www.cvedetails.com/product/12081/Openssh-Openssh.html?vendor_id=7161
 """
 from __future__ import annotations
 
@@ -29,4 +30,4 @@ class OpensshChecker(Checker):
         r"sshd",
     ]
     VERSION_PATTERNS = [r"\r?\nOpenSSH_([0-9]+\.[0-9]+(\.[0-9]+)?p[0-9]+)(?:\r?\n| )"]
-    VENDOR_PRODUCT = [("openbsd", "openssh")]
+    VENDOR_PRODUCT = [("openbsd", "openssh"), ("openssh", "openssh")]


### PR DESCRIPTION
[CVE-2023-25136](https://nvd.nist.gov/vuln/detail/cve-2023-25136) is registered under openssh:openssh CPE ID