### PR TITLE
fix: fix products with no identified vulnerabilities

### DIFF
--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -304,7 +304,11 @@ def _output_console_nowrap(
         table.add_column("Product")
         table.add_column("Version")
 
-        products_with_cves = list(map(lambda x: x[1], all_cve_data))
+        products_with_cves = []
+        for product_info, cve_data in all_cve_data.items():
+            if len(cve_data["cves"]):
+                products_with_cves.append(product_info.product)
+
         for product_data in all_product_data:
             if (
                 all_product_data[product_data] == 0


### PR DESCRIPTION
Products with no identified vulnerabilities are broken since commit 6b0f36e03b74abc76cd2b83a0d3207c4ceaa4d02 because `products_with_cves` will always contain a dictionnary of all products. So replace the broken lamba function with a more clear way of computing products with CVEs (i.e. `len(cve_data["cves"]`))