### PR TITLE
ci: switch to a faster Black mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     hooks:
     - id: isort
 
--   repo: https://github.com/python/black
-    rev: 23.7.0
+-   repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 23.9.1
     hooks:
     - id: black
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-black==23.7.0
+black==23.9.1
 isort; python_version < "3.8"
 isort==5.12.0; python_version >= "3.8"
 pre-commit; python_version < "3.8"


### PR DESCRIPTION
https://github.com/psf/black/releases/tag/23.9.0 introduced a faster mirror (claimed to be 2x speedup) and https://github.com/psf/black/releases/tag/23.9.1 contained a bugfix to really make it fast