### PR TITLE
ci: Remove dependabot ignores

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,39 +20,39 @@ updates:
 
 # Scanning is disabled for files in /test/ to avoid false positives.
 # These files are used for testing; vulnerable code is never installed or used.
+# These are commented out because they caused problems with other automated checks
 
-  - package-ecosystem: cargo
-    directory: /test/language_data
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: "*"
+#  - package-ecosystem: cargo
+#    directory: /test/language_data
+#    schedule:
+#      interval: monthly
+#    ignore:
+#      - dependency-name: "*"
 
-  - package-ecosystem: bundler
-    directory: /test/language_data
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: "*"
+#  - package-ecosystem: bundler
+#    directory: /test/language_data
+#    schedule:
+#      interval: monthly
+#    ignore:
+#      - dependency-name: "*"
 
-  - package-ecosystem: gomod
-    directory: /test/language_data
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: "*"
+#  - package-ecosystem: gomod
+#    directory: /test/language_data
+#    schedule:
+#      interval: monthly
+#    ignore:
+#      - dependency-name: "*"
 
-  - package-ecosystem: pip
-    directory: /test/language_data
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: "*"
+#  - package-ecosystem: pip
+#    directory: /test/language_data
+#    schedule:
+#      interval: monthly
+#    ignore:
+#      - dependency-name: "*"
 
-  - package-ecosystem: maven
-    directory: /test/language_data
-    schedule:
-      interval: monthly
-    ignore:
-      - dependency-name: "*"
-
+#  - package-ecosystem: maven
+#    directory: /test/language_data
+#    schedule:
+#      interval: monthly
+#    ignore:
+#      - dependency-name: "*"


### PR DESCRIPTION
These were a nice idea, but the auto-ignores are causing a problem with an internal automated script so they'll need to be disabled and I'll need to go back to manually discarding dependabot results in `test/language_data`