### PR TITLE
test: improve flaky java language scanner test

### DIFF
--- a/test/language_data/pom.xml
+++ b/test/language_data/pom.xml
@@ -28,6 +28,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>jmeter</groupId>
+        <artifactId>jmeter</artifactId>
+        <version>5.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <version>3.8.4</version>
@@ -55,6 +60,11 @@
       <artifactId>reflection-utils</artifactId>
       <version>1.1.0</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>jmeter</groupId>
+        <artifactId>jmeter</artifactId>
+        <version>5.1</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
@@ -496,3 +506,4 @@
   </profiles>
 
 </project>
+

--- a/test/language_data/pom.xml
+++ b/test/language_data/pom.xml
@@ -28,11 +28,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.maven</groupId>
         <artifactId>maven-plugin-api</artifactId>
         <version>3.8.4</version>
@@ -60,11 +55,6 @@
       <artifactId>reflection-utils</artifactId>
       <version>1.1.0</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>2.11.0</version>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -165,7 +165,7 @@ class TestLanguageScanner:
 
     @pytest.mark.parametrize(
         "filename, product_list",
-        (((str(TEST_FILE_PATH / "pom.xml")), ["commons-io", "hamcrest"]),),
+        (((str(TEST_FILE_PATH / "pom.xml")), ["hamcrest"]),),
     )
     def test_java_package(self, filename: str, product_list: set[str]) -> None:
         scanner = VersionScanner()

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -165,7 +165,7 @@ class TestLanguageScanner:
 
     @pytest.mark.parametrize(
         "filename, product_list",
-        (((str(TEST_FILE_PATH / "pom.xml")), ["hamcrest"]),),
+        (((str(TEST_FILE_PATH / "pom.xml")), ["jmeter", "hamcrest"]),),
     )
     def test_java_package(self, filename: str, product_list: set[str]) -> None:
         scanner = VersionScanner()


### PR DESCRIPTION
* Related: #3360
* Fixes: #3361

For some reason we're getting non-deterministic behaviour around commons-io (with a dash) vs commons_io (with an underscore) during detection.  Since the test doesn't really need to detect that partcular library, we're leaving it out for now while the issue is investigated further.