### PR TITLE
fix: improve hostapd checker

### DIFF
--- a/cve_bin_tool/checkers/hostapd.py
+++ b/cve_bin_tool/checkers/hostapd.py
@@ -18,7 +18,7 @@ class HostapdChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS = [r"hostapd"]
     VERSION_PATTERNS = [
-        r"hostapd[_a-z]* v([0-9]+\.[0-9]+)",
+        r"\nhostapd[_a-z]* v([0-9]+\.[0-9]+)",
         r"([0-9]+\.[0-9]+)[a-z-]*\r?\nhostapd",
     ]
     VENDOR_PRODUCT = [("w1.fi", "hostapd")]


### PR DESCRIPTION
Improve hostapd checker to avoid the following false positive with a proprietary library: `AP configuration based on hostapd v0.5`