### PR TITLE
ci: Add condition to skip job when PR author is Bot

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,6 +23,15 @@ env:
 jobs:
   docs:
     name: Documentation
+    if: |
+      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
+      ! (
+        startsWith(github.head_ref, 'chore-sbom-py') ||
+        contains(
+          fromJSON('["chore-js-dependencies","chore-precommit-config","chore-spdx-header"]'),
+          github.head_ref
+        )
+      )
     runs-on: ubuntu-22.04
     steps:
       - name: Harden Runner
@@ -49,6 +58,15 @@ jobs:
 
   tests:
     name: Linux tests
+    if: |
+      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
+      ! (
+        startsWith(github.head_ref, 'chore-sbom-py') ||
+        contains(
+          fromJSON('["chore-update-table","chore-precommit-config","chore-spdx-header"]'),
+          github.head_ref
+        )
+      )
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -120,6 +138,15 @@ jobs:
 
   long_tests:
     name: Long tests on Python 3.10
+    if: |
+      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
+      ! (
+        startsWith(github.head_ref, 'chore-sbom-py') ||
+        contains(
+          fromJSON('["chore-update-table","chore-precommit-config","chore-spdx-header"]'),
+          github.head_ref
+        )
+      )
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -217,6 +244,15 @@ jobs:
 
   linux-mayfail:
     name: Tests that may fail due to network or HTML
+    if: |
+      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
+      ! (
+        startsWith(github.head_ref, 'chore-sbom-py') ||
+        contains(
+          fromJSON('["chore-update-table","chore-precommit-config","chore-spdx-header"]'),
+          github.head_ref
+        )
+      )
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     env:
@@ -310,6 +346,15 @@ jobs:
 
   windows_tests:
     name: Windows tests
+    if: |
+      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
+      ! (
+        startsWith(github.head_ref, 'chore-sbom-py') ||
+        contains(
+          fromJSON('["chore-update-table","chore-precommit-config","chore-spdx-header"]'),
+          github.head_ref
+        )
+      )
     runs-on: windows-latest
     timeout-minutes: 90
     env:
@@ -379,6 +424,15 @@ jobs:
 
   windows_long_tests:
     name: Windows long tests
+    if: |
+      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
+      ! (
+        startsWith(github.head_ref, 'chore-sbom-py') ||
+        contains(
+          fromJSON('["chore-update-table","chore-precommit-config","chore-spdx-header"]'),
+          github.head_ref
+        )
+      )
     runs-on: windows-latest
     timeout-minutes: 120
     env:
@@ -478,3 +532,4 @@ jobs:
           flags: win-longtests
           name: codecov-umbrella
           fail_ci_if_error: false
+


### PR DESCRIPTION
Fixes #3415

## Constraint
Job will skip if match this condition:
- The author is github-actions[bot]
- Source branch start with 'chore'

## Description
This approach is different from my comment on the issue because i see there's a pattern on the PR created by `github-actions`. Also, I see several workflow file for automatic update on this repo (sbom, js dependencies, etc). I think this changes has pros and cons described below.

I use [github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) to retrieve information about the PR author and the source branch ref

Pros
- More simple compared to my proposed approach
- Will skip all PR created by `github-actions[bot]`

Cons
- Manually update in the folder `sbom/` will trigger the tests

## Testing
I've test this on my private repo, here's the screenshot
![image](https://github.com/intel/cve-bin-tool/assets/22138274/30113651-b336-4d79-b1d5-fb4514b28eaa)
