### PR TITLE
fix: do not hardcode console width

### DIFF
--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -52,11 +52,12 @@ def _output_console_nowrap(
     exploits: bool = False,
     all_product_data=None,
     offline: bool = False,
+    width: int = None,
     console: Console = Console(theme=cve_theme),
 ):
     """Output list of CVEs in a tabular format with color support"""
 
-    console._width = 120
+    console._width = width
     now = datetime.now().strftime("%Y-%m-%d  %H:%M:%S")
     time_of_last_update = time_of_last_update.strftime("%Y-%m-%d  %H:%M:%S")
 

--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -942,6 +942,7 @@ class TestOutputEngine(unittest.TestCase):
             exploits,
             all_product_data,
             True,
+            120,
             console,
             outfile,
         )
@@ -984,6 +985,7 @@ class TestOutputEngine(unittest.TestCase):
             exploits,
             all_product_data,
             True,
+            120,
             console,
             outfile,
         )
@@ -1031,6 +1033,7 @@ class TestOutputEngine(unittest.TestCase):
             exploits,
             all_product_data,
             True,
+            120,
             outfile,
         )
 


### PR DESCRIPTION
Since commit 66e1df391c7598b05a7c3afbbf9808ce1b140648, console width is hardcoded to 120 and so width auto-detection is disabled. Drop this line as most modern screens can display more than 120 characters and a lot of lines are truncated now that EPSS data, latest version, etc. are displayed.