### PR TITLE
ci: skip running tests on bot-generated sboms

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -74,6 +74,19 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
+
+      - name: "Skip tests if this is an automated sbom job"
+        env:
+          COMMIT_VAR: ${{ startsWith(github.head_ref, 'chore-sbom-py') && github.event.pull_request.user.login == 'github-actions[bot]' }}
+        run: |
+          if ${COMMIT_VAR} == true; then
+            echo "sbom=true" >> $GITHUB_ENV
+            echo "sbom set to true"
+          else
+            echo "sbom=false" >> $GITHUB_ENV
+            echo "sbom set to false"
+          fi
+
       - name: Get date
         id: get-date
         run: |
@@ -96,10 +109,13 @@ jobs:
           path: cache
           key: Linux-cve-bin-tool-${{ steps.get-date.outputs.yesterday }}
       - name: Install cabextract
+        if: env.sbom == false
         run: sudo apt-get update && sudo apt-get install cabextract
       - name: Install OS dependencies for testing PDF
+        if: env.sbom == false
         run: sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python3-dev
       - name: Install pdftotext, reportlab and cve-bin-tool
+        if: env.sbom == false
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
@@ -109,11 +125,13 @@ jobs:
           python -m pip install --upgrade -r dev-requirements.txt
           python -m pip install --upgrade .
       - name: Try single CLI run of tool
+        if: env.sbom == false
         run: |
           [[ -e cache ]] && mkdir -p .cache && mv cache ~/.cache/cve-bin-tool
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out
           cp -r ~/.cache/cve-bin-tool cache
       - name: Run async tests
+        if: env.sbom == false
         run: >
           pytest -n 4 -v
           --ignore=test/test_cli.py
@@ -122,6 +140,7 @@ jobs:
           --ignore=test/test_html.py
           --ignore=test/test_json.py
       - name: Run synchronous tests
+        if: env.sbom == false
         run: >
           pytest -v
           test/test_cli.py
@@ -129,6 +148,15 @@ jobs:
 
   long_tests:
     name: Long tests on Python 3.10
+    if: |
+      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
+      ! (
+        startsWith(github.head_ref, 'chore-sbom-py') ||
+        contains(
+          fromJSON('["chore-update-table","chore-precommit-config","chore-spdx-header"]'),
+          github.head_ref
+        )
+      )
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     env:
@@ -144,6 +172,19 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
+
+      - name: "Skip tests if this is an automated sbom job"
+        env:
+          COMMIT_VAR: ${{ startsWith(github.head_ref, 'chore-sbom-py') && github.event.pull_request.user.login == 'github-actions[bot]' }}
+        run: |
+          if ${COMMIT_VAR} == true; then
+            echo "sbom=true" >> $GITHUB_ENV
+            echo "sbom set to true"
+          else
+            echo "sbom=false" >> $GITHUB_ENV
+            echo "sbom set to false"
+          fi
+
       - name: Get date
         id: get-date
         run: |
@@ -182,10 +223,13 @@ jobs:
           if_true: '1'
           if_false: '0'
       - name: Install cabextract
+        if: env.sbom == false
         run: sudo apt-get update && sudo apt-get install cabextract
       - name: Install OS dependencies for testing PDF
+        if: env.sbom == false
         run: sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python3-dev
       - name: Install pdftotext, reportlab and cve-bin-tool
+        if: env.sbom == false
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools
@@ -195,11 +239,13 @@ jobs:
           python -m pip install --upgrade -r dev-requirements.txt
           python -m pip install --editable .
       - name: Try single CLI run of tool
+        if: env.sbom == false
         run: |
           [[ -e cache ]] && mkdir -p .cache && mv cache ~/.cache/cve-bin-tool
           NO_EXIT_CVE_NUM=1 python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out
           cp -r ~/.cache/cve-bin-tool cache
       - name: Run async tests
+        if: env.sbom == false
         env:
           LONG_TESTS: ${{ steps.git-diff.outputs.value }}
         run: >
@@ -210,6 +256,7 @@ jobs:
           --ignore=test/test_html.py
           --ignore=test/test_json.py
       - name: Run synchronous tests
+        if: env.sbom == false
         env:
           LONG_TESTS: ${{ steps.git-diff.outputs.value }}
         run: >
@@ -217,6 +264,7 @@ jobs:
           test/test_cli.py
           test/test_cvedb.py
       - name: Upload code coverage to codecov
+        if: env.sbom == false
         uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # v3.1.4
         with:
           files: ./coverage.xml


### PR DESCRIPTION
The earlier PR skipping tests caused issues with our branch protection rules and had to be disabled because it blocked merging of pull requests (if the tests were skipped, the PR could never be merged).  This allows part of the job to run (so it'll pass branch protection checks) while skipping the install and running of tests on sbom jobs provided by our automated job.

Note that this is the same code as I had in #3446 but I'm separating it out so it gets a proper code review from someone who is not me.  

It won't do anything interesting when the tests are run here (because this isn't a bot PR for an sbom) but you can see what it's supposed to do on #3446 