### PR TITLE
docs: add missing docstrings to data_sources/curl_source.py #3464

### DIFF
--- a/cve_bin_tool/data_sources/curl_source.py
+++ b/cve_bin_tool/data_sources/curl_source.py
@@ -23,6 +23,9 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 class Curl_Source(Data_Source):
+    """
+    Represents a data source for retrieving information about vulnerabilities in cURL.
+    """
     SOURCE = "Curl"
     CACHEDIR = DISK_LOCATION_DEFAULT
     BACKUPCACHEDIR = DISK_LOCATION_BACKUP
@@ -30,6 +33,12 @@ class Curl_Source(Data_Source):
     DATA_SOURCE_LINK = "https://curl.se/docs/vuln.json"
 
     def __init__(self, error_mode=ErrorMode.TruncTrace):
+        """
+        Initialize a Curl_Source instance.
+
+        Args:
+            error_mode (ErrorMode): The error mode to be used.
+        """
         self.cve_list = None
         self.cachedir = self.CACHEDIR
         self.backup_cachedir = self.BACKUPCACHEDIR
@@ -40,12 +49,23 @@ class Curl_Source(Data_Source):
         self.vulnerability_data = []
 
     async def get_cve_data(self):
+        """
+        Get cURL vulnerability data.
+
+        Fetches the cURL vulnerability data and retrieves a list of affected data.
+
+        Returns:
+            Tuple[Union[None, Any], str]: A tuple containing the affected data and the source name.
+        """
         await self.fetch_cves()
         self.get_cve_list()
 
         return (None, self.affected_data), self.source_name
 
     async def fetch_cves(self):
+         """
+        Fetch cURL vulnerabilities data.
+        """
         if not self.session:
             connector = aiohttp.TCPConnector(limit_per_host=19)
             self.session = RateLimiter(
@@ -57,6 +77,12 @@ class Curl_Source(Data_Source):
         await self.session.close()
 
     async def download_curl_vulnerabilities(self, session: RateLimiter) -> None:
+        """
+        Download cURL vulnerability data and save it to a file.
+
+        Args:
+            session (RateLimiter): The session to use for the HTTP request.
+        """
         async with await session.get(self.DATA_SOURCE_LINK) as response:
             response.raise_for_status()
             self.vulnerability_data = await response.json()
@@ -66,6 +92,9 @@ class Curl_Source(Data_Source):
             await f.write(json.dumps(self.vulnerability_data, indent=4))
 
     def get_cve_list(self):
+        """
+        Get a list of affected cURL vulnerabilities.
+        """
         self.affected_data = []
 
         for cve in self.vulnerability_data:

--- a/cve_bin_tool/data_sources/curl_source.py
+++ b/cve_bin_tool/data_sources/curl_source.py
@@ -23,9 +23,7 @@ logging.basicConfig(level=logging.DEBUG)
 
 
 class Curl_Source(Data_Source):
-    """
-    Represents a data source for retrieving information about vulnerabilities in cURL.
-    """
+    """Represents a data source for retrieving information about vulnerabilities in cURL."""
     SOURCE = "Curl"
     CACHEDIR = DISK_LOCATION_DEFAULT
     BACKUPCACHEDIR = DISK_LOCATION_BACKUP
@@ -33,12 +31,7 @@ class Curl_Source(Data_Source):
     DATA_SOURCE_LINK = "https://curl.se/docs/vuln.json"
 
     def __init__(self, error_mode=ErrorMode.TruncTrace):
-        """
-        Initialize a Curl_Source instance.
-
-        Args:
-            error_mode (ErrorMode): The error mode to be used.
-        """
+        """Initialize a Curl_Source instance. Args: error_mode (ErrorMode): The error mode to be used."""
         self.cve_list = None
         self.cachedir = self.CACHEDIR
         self.backup_cachedir = self.BACKUPCACHEDIR
@@ -49,23 +42,14 @@ class Curl_Source(Data_Source):
         self.vulnerability_data = []
 
     async def get_cve_data(self):
-        """
-        Get cURL vulnerability data.
-
-        Fetches the cURL vulnerability data and retrieves a list of affected data.
-
-        Returns:
-            Tuple[Union[None, Any], str]: A tuple containing the affected data and the source name.
-        """
+        """Get cURL vulnerability data.Fetches the cURL vulnerability data and retrieves a list of affected data. Returns: Tuple[Union[None, Any], str]: A tuple containing the affected data and the source name."""
         await self.fetch_cves()
         self.get_cve_list()
 
         return (None, self.affected_data), self.source_name
 
     async def fetch_cves(self):
-        """
-        Fetch cURL vulnerabilities data.
-        """
+        """Fetch cURL vulnerabilities data."""
         if not self.session:
             connector = aiohttp.TCPConnector(limit_per_host=19)
             self.session = RateLimiter(
@@ -77,12 +61,7 @@ class Curl_Source(Data_Source):
         await self.session.close()
 
     async def download_curl_vulnerabilities(self, session: RateLimiter) -> None:
-        """
-        Download cURL vulnerability data and save it to a file.
-
-        Args:
-            session (RateLimiter): The session to use for the HTTP request.
-        """
+        """Download cURL vulnerability data and save it to a file. Args: session (RateLimiter): The session to use for the HTTP request."""
         async with await session.get(self.DATA_SOURCE_LINK) as response:
             response.raise_for_status()
             self.vulnerability_data = await response.json()
@@ -92,9 +71,7 @@ class Curl_Source(Data_Source):
             await f.write(json.dumps(self.vulnerability_data, indent=4))
 
     def get_cve_list(self):
-        """
-        Get a list of affected cURL vulnerabilities.
-        """
+        """Get a list of affected cURL vulnerabilities."""
         self.affected_data = []
 
         for cve in self.vulnerability_data:

--- a/cve_bin_tool/data_sources/curl_source.py
+++ b/cve_bin_tool/data_sources/curl_source.py
@@ -63,7 +63,7 @@ class Curl_Source(Data_Source):
         return (None, self.affected_data), self.source_name
 
     async def fetch_cves(self):
-         """
+        """
         Fetch cURL vulnerabilities data.
         """
         if not self.session:


### PR DESCRIPTION
Added missing docstrings to data_sources/curl_source.py
I have explained what a function does and have it put at the top of the function in the way that Python expects docstrings to look.
Issue no #3464