### PR TITLE
docs: add missing docstrings to output_engine/init.py

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -634,7 +634,7 @@ class OutputEngine:
         output_cves: Output a list of CVEs to other formats like CSV or JSON.
         generate_vex: Generate a vex file and create vulnerability entry.
         generate_sbom: Create SBOM package and generate SBOM file.
-        output_file_wrapper: 
+        output_file_wrapper:
         output_file: Generate a file for list of CVE
         check_file_path: Generate a new filename if file already exists.
         check_dir_path: Generate a new filename if filepath is a directory.
@@ -1004,7 +1004,7 @@ class OutputEngine:
                 self.output_cves(f, output_type)
 
     def check_file_path(self, filepath: str, output_type: str, prefix: str = "output"):
-        """Generate a new filename is file already exists."""
+        """Generate a new filename if file already exists."""
         # check if the file already exists
         if Path(filepath).is_file():
             self.logger.warning(f"Failed to write at '{filepath}'. File already exists")

--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -594,10 +594,51 @@ except ModuleNotFoundError:
         exploits: bool = False,
         all_product_data=None,
     ):
+        """Output a PDF of CVEs
+        Required module: Reportlab not found"""
         LOGGER.warning("PDF output requires install of reportlab")
 
 
 class OutputEngine:
+    """
+    Class represention of OutputEngine
+    
+    Attributes:
+        all_cve_data (dict[ProductInfo, CVEData])
+        scanned_dir (str)
+        filename (str)
+        themes_dir (str)
+        time_of_last_update
+        tag (str)
+        logger
+        products_with_cve (int)
+        products_without_cve (int)
+        total_files (int)
+        is_report (bool)
+        no_zero_cve_report (bool)
+        append
+        merge_report
+        affected_versions (int)
+        all_cve_version_info
+        detailed (bool)
+        vex_filename (str)
+        exploits (bool)
+        all_product_data
+        sbom_filename (str)
+        sbom_type (str)
+        sbom_format (str)
+        sbom_root (str)
+        offline (bool)
+
+    Methods:
+        output_cves: Output a list of CVEs to other formats like CSV or JSON.
+        generate_vex: Generate a vex file and create vulnerability entry.
+        generate_sbom: Create SBOM package and generate SBOM file.
+        output_file_wrapper: 
+        output_file: Generate a file for list of CVE
+        check_file_path: Generate a new filename if file already exists.
+        check_dir_path: Generate a new filename if filepath is a directory.
+    """
     def __init__(
         self,
         all_cve_data: dict[ProductInfo, CVEData],
@@ -626,6 +667,7 @@ class OutputEngine:
         sbom_root: str = "CVE_SBOM",
         offline: bool = False,
     ):
+        """Constructor for OutputEngine class."""
         self.logger = logger or LOGGER.getChild(self.__class__.__name__)
         self.all_cve_version_info = all_cve_version_info
         self.scanned_dir = scanned_dir
@@ -735,6 +777,7 @@ class OutputEngine:
             )
 
     def generate_vex(self, all_cve_data: dict[ProductInfo, CVEData], filename: str):
+        """Generate a vex file and create vulnerability entry."""
         analysis_state = {
             Remarks.NewFound: "in_triage",
             Remarks.Unexplored: "in_triage",
@@ -840,6 +883,7 @@ class OutputEngine:
         sbom_format="tag",
         sbom_root="CVE-SCAN",
     ):
+        """Create SBOM package and generate SBOM file."""
         # Create SBOM
         sbom_packages = {}
         sbom_relationships = []
@@ -895,6 +939,7 @@ class OutputEngine:
         my_generator.generate(parent, my_sbom.get_sbom(), filename=filename)
 
     def output_file_wrapper(self, output_types=["console"]):
+        """Call output_file method for all output types."""
         for output_type in output_types:
             self.output_file(output_type)
 
@@ -959,6 +1004,7 @@ class OutputEngine:
                 self.output_cves(f, output_type)
 
     def check_file_path(self, filepath: str, output_type: str, prefix: str = "output"):
+        """Generate a new filename is file already exists."""
         # check if the file already exists
         if Path(filepath).is_file():
             self.logger.warning(f"Failed to write at '{filepath}'. File already exists")
@@ -970,6 +1016,7 @@ class OutputEngine:
     def check_dir_path(
         self, filepath: str, output_type: str, prefix: str = "intermediate"
     ):
+        """Generate a new filename if filepath is a directory."""
         if Path(filepath).is_dir():
             self.logger.info(
                 f"Generating a new filename with Default Naming Convention in directory path {filepath}"

--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -602,7 +602,6 @@ except ModuleNotFoundError:
 class OutputEngine:
     """
     Class represention of OutputEngine
-    
     Attributes:
         all_cve_data (dict[ProductInfo, CVEData])
         scanned_dir (str)

--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -638,6 +638,7 @@ class OutputEngine:
         check_file_path: Generate a new filename if file already exists.
         check_dir_path: Generate a new filename if filepath is a directory.
     """
+
     def __init__(
         self,
         all_cve_data: dict[ProductInfo, CVEData],


### PR DESCRIPTION
## docs:add missing docstrings to output_engine/__init__.py

Added missing docstrings for methods and classes mentioned in issue #3463 
Referred PEP 257 – Docstring Conventions

fixes #3463 