### PR TITLE
Ci: Change workflows to use python 3.11 

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           cache: 'pip'
       - name: Install cve-bin-tool
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           cache: 'pip'
       - name: Install pre-commit
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: '3.x'
+          python-version: '3.11'
           cache: 'pip'
           cache-dependency-path: 'doc/requirements.txt'
       - name: Install doc dependencies

--- a/.github/workflows/update-js-dependencies.yml
+++ b/.github/workflows/update-js-dependencies.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Update JS dependencies
         run: python .github/workflows/update_js_dependencies.py

--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -30,7 +30,7 @@ jobs:
 
       - uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Install pre-commit
         run: |


### PR DESCRIPTION
Fixes #3494 

Replaced "3.x" with "3.11" in exactly 5 workflow files.