### PR TITLE
feat(console): sort CPE summary by product

### DIFF
--- a/cve_bin_tool/output_engine/console.py
+++ b/cve_bin_tool/output_engine/console.py
@@ -120,7 +120,7 @@ def _output_console_nowrap(
     table.add_column("UNKNWON CVEs Count")
     table.add_column("TOTAL CVEs Count")
     if all_product_data is not None:
-        for product_data in sorted(all_product_data):
+        for product_data in sorted(all_product_data, key=lambda item: item.product):
             color = None
             summary = get_cve_summary(
                 {product_data: all_cve_data[product_data]}, exploits


### PR DESCRIPTION
Sort CPE summary by product instead of vendor, this is especially useful for product with multiple vendors (e.g. dnsmasq).