### PR TITLE
fix: non-alphanumeric characters as separators

### DIFF
--- a/cve_bin_tool/version_compare.py
+++ b/cve_bin_tool/version_compare.py
@@ -40,14 +40,11 @@ def parse_version(version_string: str):
     versionString = version_string.strip()
     versionArray = []
 
-    # convert - and _ to be treated like . below
+    # convert all non alpha-numeric characters to be treated like . below
     # we could switch to a re split but it seems to leave blanks so this is less hassle
-    versionString = versionString.replace("-", ".")
-    versionString = versionString.replace("_", ".")
-    versionString = versionString.replace("+", ".")
-    # Note: there may be other non-alphanumeric characters we want to add here in the
-    # future, but we'd like to look at those cases before adding them in case the version
-    # logic is very different.
+    versionString = re.sub("[^0-9a-zA-Z]+", ".", versionString)
+
+    # Note: This expression may need improvement if we need to handle unicode
 
     # remove any trailing . then split
     versionString = versionString.strip(".")

--- a/test/test_version_compare.py
+++ b/test/test_version_compare.py
@@ -34,6 +34,8 @@ class TestVersionCompare:
         assert Version("0.0.0.20190813141303.74dc4d7220e7") < Version(
             "0.0.0.20200813141303"
         )
+        assert Version("1.1.0l.1~deb9u2") < Version("2.0.0-1+deb9u1")
+        assert Version("1.1.0l.1~deb9u2") < Version("1.1.0m")
 
     def test_gt(self):
         """Make sure > works between versions, including some with unusual version schemes"""
@@ -50,6 +52,7 @@ class TestVersionCompare:
         assert Version("0.0.0.20200813141303") > Version(
             "0.0.0.20190813141303.74dc4d7220e7"
         )
+        assert Version("1.1.0m") > Version("1.1.0l.1~deb9u2")
 
     def test_error(self):
         """Make sure 'unknown' and blank strings raise appropriate errors"""


### PR DESCRIPTION
This switches the logic so we treat all non-alphanumeric characters as separators equivalent to `.` in version strings.  This should make the code more robust to unusual version strings.

* Fixes #3558 (in that we will be able to handle `~`)