### PR TITLE
fix: improve version_compare to drop hashes

### DIFF
--- a/cve_bin_tool/version_compare.py
+++ b/cve_bin_tool/version_compare.py
@@ -49,7 +49,8 @@ def parse_version(version_string: str):
     # future, but we'd like to look at those cases before adding them in case the version
     # logic is very different.
 
-    # Attempt a split
+    # remove any trailing . then split
+    versionString = versionString.strip(".")
     split_version = versionString.split(".")
 
     # if the whole string was numeric then we're done and you can move on
@@ -58,10 +59,10 @@ def parse_version(version_string: str):
         return versionArray
 
     # Go through and split up anything like 6a in to 6 and a
-    number_letter = re.compile("([0-9]+)([a-zA-Z]+)")
-    letter_number = re.compile("([a-zA-Z]+)([0-9]+)")
+    number_letter = re.compile("^([0-9]+)([a-zA-Z]+)$")
+    letter_number = re.compile("^([a-zA-Z]+)([0-9]+)$")
     for section in split_version:
-        # if it's all letters or all nubmers, just add it to the array
+        # if it's all letters or all numbers, just add it to the array
         if section.isnumeric() or section.isalpha():
             versionArray.append(section)
 
@@ -84,9 +85,19 @@ def parse_version(version_string: str):
         elif re.match(letter_number, section):
             versionArray.append(section)
 
-        # If all else fails, complain
+        # It's not a "pure" alpha or number string, it's not something like rc12 or 44g
+
+        # It could be a hash, which we can't string compare without knowledge of the product.
+        # It could also be a distro release string like deb8u5, which we could compare
+        # but the data may not be useful or usable in context.
         else:
-            if versionString != ".":
+            # If it's the last part of the version just drop it silently
+            # we could log these but I suspect it would be very noisy
+            if section == split_version[len(split_version) - 1]:
+                pass
+
+            # if it's not, raise an exception because we should probably examine it
+            elif versionString != ".":
                 raise CannotParseVersionException(f"version string = {versionString}")
 
     return versionArray

--- a/test/test_version_compare.py
+++ b/test/test_version_compare.py
@@ -31,6 +31,9 @@ class TestVersionCompare:
         assert Version("9.10") < Version("9.10.post")
         assert Version("5.3.9") < Version("5.4")
         assert Version("2.0.0") < Version("2.0.0-1+deb9u1")
+        assert Version("0.0.0.20190813141303.74dc4d7220e7") < Version(
+            "0.0.0.20200813141303"
+        )
 
     def test_gt(self):
         """Make sure > works between versions, including some with unusual version schemes"""
@@ -44,6 +47,9 @@ class TestVersionCompare:
         assert Version("9.10.post") > Version("9.10")
         assert Version("5.5") > Version("5.4.1")
         assert Version("2.0.0-1+deb9u1") > Version("2.0.0")
+        assert Version("0.0.0.20200813141303") > Version(
+            "0.0.0.20190813141303.74dc4d7220e7"
+        )
 
     def test_error(self):
         """Make sure 'unknown' and blank strings raise appropriate errors"""


### PR DESCRIPTION
Currently version_compare rasies an error when it gets a hash, since we can't really compare those without more knowledge of the product. This changes the code to silently drop hashes and similar distro markers from the end of versions, which should make our code more robust to real-life cases.  We may also want to put in an error handler to log the versions we can't handle without halting the program, but this doesn't do that yet.

Fixes #3556 