### PR TITLE
fix: improve openssl checker

### DIFF
--- a/cve_bin_tool/checkers/openssl.py
+++ b/cve_bin_tool/checkers/openssl.py
@@ -18,7 +18,7 @@ class OpensslChecker(Checker):
     CONTAINS_PATTERNS = [r"part of OpenSSL", r"openssl.cnf", r"-DOPENSSL_"]
     FILENAME_PATTERNS = [r"libssl.so.", r"libcrypto.so"]
     VERSION_PATTERNS = [
-        r"OpenSSL ([0-9]+\.[0-9]+\.[0-9]+[a-z]*) [a-zA-Z0-9 ]+\r?\n(?:%s \(Library: %s\)|[a-zA-Z0-9: \-\r\n]*OPENSSLDIR|ssl)",
+        r"OpenSSL ([0-9]+\.[0-9]+\.[0-9]+[a-z]*) [a-zA-Z0-9 ]+\r?\n(?:%s \(Library: %s\)|[a-zA-Z0-9:, \-\r\n]*OPENSSLDIR|ssl)",
         r"%s \(Library: %s\)\r?\nOpenSSL ([0-9]+\.[0-9]+\.[0-9]+[a-z]*) [a-zA-Z0-9 ]+",
     ]
     VENDOR_PRODUCT = [("openssl", "openssl")]


### PR DESCRIPTION
Update openssl pattern to catch version on 'exotic' library