### PR TITLE
fix: remove resizeGraph function

### DIFF
--- a/cve_bin_tool/output_engine/html_reports/js/main.js
+++ b/cve_bin_tool/output_engine/html_reports/js/main.js
@@ -18,13 +18,6 @@ function analysisShadowToggle(ele) {
     ele.classList.toggle('shadow-lg')
 }
 
-function resizeGraph(ele) {
-    setTimeout(() => {
-        let modalId = ele.getAttribute('data-bs-target').substr(1)
-        eval(document.getElementById(modalId).querySelector('script').innerHTML)
-    }, 240)
-}
-
 function modeInteractive() {
     var div_interactive = document.getElementById('interactive_mode')
     var div_print = document.getElementById('print_mode')

--- a/cve_bin_tool/output_engine/html_reports/templates/base.html
+++ b/cve_bin_tool/output_engine/html_reports/templates/base.html
@@ -176,7 +176,7 @@
                             <li class="list-group-item">
                                 <h5 class="fw-normal">{{path}}</h5>
                                 {% for product in all_paths[path]%}
-                                <a id="vendorProductPill" onclick="resizeGraph(this)"data-bs-toggle="modal" data-bs-target="#modal{{ product }}">
+                                <a id="vendorProductPill" data-bs-toggle="modal" data-bs-target="#modal{{ product }}">
                                     <span class="badge rounded-pill bg-info">{{product}}</span>
                                 </a>
                                 {% endfor %}

--- a/cve_bin_tool/output_engine/html_reports/templates/row_product.html
+++ b/cve_bin_tool/output_engine/html_reports/templates/row_product.html
@@ -1,4 +1,4 @@
-<a onclick="resizeGraph(this)" class="list-group-item list-group-item-action" data-bs-toggle="modal"
+<a class="list-group-item list-group-item-action" data-bs-toggle="modal"
     data-bs-target="#modal{{ fix_id }}" remarks="{{remarks}}">
 
     <div class="row">


### PR DESCRIPTION
Coverity is issuing a warning about this function and it's easier for me to temporarily disable it than fix it this week.