### PR TITLE
fix: drop wrong gnutls VENDOR_PRODUCT

### DIFF
--- a/cve_bin_tool/checkers/gnutls.py
+++ b/cve_bin_tool/checkers/gnutls.py
@@ -25,4 +25,4 @@ class GnutlsChecker(Checker):
         r"gnutls-serv ([0-9]+\.[0-9]+\.[0-9]+)",
         r"GnuTLS ([0-9]+\.[0-9]+\.[0-9]+)",
     ]
-    VENDOR_PRODUCT = [("gnutls", "gnutls"), ("gnu", "gnutls")]
+    VENDOR_PRODUCT = [("gnu", "gnutls")]


### PR DESCRIPTION
`gnutls:gnutls` has been added with commit 11b9d7b4d71c9b705ed0dbd3e602d171d399294e but it is not a valid CPE ID: https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Agnutls%3Agnutls