### PR TITLE
fix: update squashfs VENDOR_PRODUCT

### DIFF
--- a/cve_bin_tool/checkers/squashfs.py
+++ b/cve_bin_tool/checkers/squashfs.py
@@ -20,5 +20,5 @@ class SquashfsChecker(Checker):
     VERSION_PATTERNS = [r"squashfs version ([0-9]+\.[0-9]+\.?[0-9]*)"]
     VENDOR_PRODUCT = [
         ("squashfs_project", "squashfs"),
-        ("squashfs-tools", "squashfs-tools"),
+        ("squashfs-tools_project", "squashfs-tools"),
     ]


### PR DESCRIPTION
Replace `squashfs-tools` by `squashfs-tools_project` as `squashfs-tools:squashfs-tools` is not a valid CPE ID: https://nvd.nist.gov/products/cpe/search/results?namingFormat=2.3&keyword=cpe%3A2.3%3Aa%3Asquashfs-tools%3Asquashfs-tools