### PR TITLE
fix: update tor VENDOR_PRODUCT

### DIFF
--- a/cve_bin_tool/checkers/tor.py
+++ b/cve_bin_tool/checkers/tor.py
@@ -23,5 +23,5 @@ class TorChecker(Checker):
         ("debian", "tor"),
         ("tor", "tor"),
         ("torproject", "tor"),
-        ("tor-project", "tor"),
+        ("tor_project", "tor"),
     ]


### PR DESCRIPTION
Replace `tor-project` by `tor_project` as no CVEs are associated to `tor-project:tor` CPE ID