### PR TITLE
fix: update gawk pattern

### DIFF
--- a/cve_bin_tool/checkers/gawk.py
+++ b/cve_bin_tool/checkers/gawk.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """
-CVE checker for binutils
+CVE checker for gawk
 
 References:
 http://savannah.gnu.org/projects/gawk/
@@ -17,5 +17,5 @@ class GawkChecker(Checker):
     FILENAME_PATTERNS = [
         r"gawk",
     ]
-    VERSION_PATTERNS = [r"GNU Awk (\d+\.\d+\.\d+)"]
+    VERSION_PATTERNS = [r"GNU Awk (\d+\.\d+\.\d+)\r?\n"]
     VENDOR_PRODUCT = [("gnu", "gawk")]


### PR DESCRIPTION
Update gawk pattern to avoid a false positive in `gawk.info` raised by `GNU Awk 4.1.2, API: 1.1`

While at it, fix following typo: binutils -> gawk