### PR TITLE
fix: update glibc pattern

### DIFF
--- a/cve_bin_tool/checkers/glibc.py
+++ b/cve_bin_tool/checkers/glibc.py
@@ -32,8 +32,8 @@ class GlibcChecker(Checker):
         r"ld-([012](\.[0-9]+){1,2})\.so",
     ]
     VERSION_PATTERNS = [
-        r"GNU C Library \(GNU libc\) stable release version ([012](\.[0-9]+){1,2})",
-        r"(?:glibc|GLIBC) ([012](\.[0-9]+){1,2})",
+        r"GNU C Library \([a-zA-Z0-9 \+\-\.]*\) (?:release|stable) release version ([012](\.[0-9]+){1,2})",
+        r"GLIBC ([012](\.[0-9]+){1,2})[a-z0-9+\-]*\) \r?\n",
         r"libc-([012](\.[0-9]+){1,2})\.so",  # patterns like this aren't ideal (check the end of the file)
         r"ld-([012]\.[0-9]+)\.so",  # patterns like this aren't ideal
         r"libanl-([012](\.[0-9]+){1,2})\.so",  # patterns like this aren't ideal

--- a/test/test_data/glibc.py
+++ b/test/test_data/glibc.py
@@ -6,7 +6,7 @@ mapping_test_data = [
         "product": "glibc",
         "version": "2.31",
         "version_strings": [
-            "GLIBC 2.31",
+            "GLIBC 2.31) ",
             "The following command substitution is needed to make ldd work in SELinux",
             "environments where the RTLD might not have permission to write to the",
         ],

--- a/test/test_data/gnomeshell.py
+++ b/test/test_data/gnomeshell.py
@@ -25,13 +25,11 @@ package_test_data = [
         "package_name": "gnome-shell_3.38.4-1ubuntu2_amd64.deb",
         "product": "gnome-shell",
         "version": "3.38.4",
-        "other_products": ["glibc"],
     },
     {
         "url": "https://download-ib01.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/g/",
         "package_name": "gnome-shell-40.2-1.fc35.x86_64.rpm",
         "product": "gnome-shell",
         "version": "40.2",
-        "other_products": ["glibc"],
     },
 ]


### PR DESCRIPTION
Update glibc pattern to avoid false positives in:
- `libgnome-shell.so` rasied by `the new format specifier introduced in glibc 2.27`
- `gmp-info.1` raised by `is the older GLIBC 2.0.x style.`