### PR TITLE
fix: update zsh pattern

### DIFF
--- a/cve_bin_tool/checkers/zsh.py
+++ b/cve_bin_tool/checkers/zsh.py
@@ -28,8 +28,5 @@ class ZshChecker(Checker):
         r"newuser.so",
         r"zsh",
     ]
-    VERSION_PATTERNS = [
-        r"zsh/([0-9]+\.[0-9]+(\.[0-9]+)?)",
-        r"zsh-([0-9]+\.[0-9]+(\.[0-9]+)?)",
-    ]
+    VERSION_PATTERNS = [r"zsh/([0-9]+\.[0-9]+(\.[0-9]+)?)"]
     VENDOR_PRODUCT = [("zsh", "zsh"), ("zsh_project", "zsh")]

--- a/test/test_data/zsh.py
+++ b/test/test_data/zsh.py
@@ -2,16 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 mapping_test_data = [
-    {
-        "product": "zsh",
-        "version": "5.8.1",
-        "version_strings": ["zsh-5.8.1"],
-    },
-    {
-        "product": "zsh",
-        "version": "5.8",
-        "version_strings": ["zsh/5.8"],
-    },
+    {"product": "zsh", "version": "5.8", "version_strings": ["zsh/5.8"]},
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Update zsh pattern to avoid a false positive in `autoconf.info` raised by `$ zsh-4.3.4 ./lineo`