### PR TITLE
fix: improve gdb pattern

### DIFF
--- a/cve_bin_tool/checkers/gdb.py
+++ b/cve_bin_tool/checkers/gdb.py
@@ -18,6 +18,6 @@ class GdbChecker(Checker):
     FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [
         r"gdb-([0-9]+\.[0-9]+\.?[0-9]*)",
-        r"\r?\n([0-9]+\.[0-9]+\.?[0-9]*)[A-Za-z0-9<>()!,_=|'`+*&^{} \\\.\-\"\r\n\t]*GDB ",
+        r"\r?\n([0-9]+\.[0-9]+\.?[0-9]*)\r?\n[A-Za-z0-9<>()!,_=|'`+*&^{} \\\.\-\"\r\n\t]*GDB ",
     ]
     VENDOR_PRODUCT = [("gnu", "gdb")]


### PR DESCRIPTION
Improve gdb pattern to avoid a false positive with `annotate.info` or `gdb-info.1`