### PR TITLE
fix: update binutils pattern

### DIFF
--- a/cve_bin_tool/checkers/binutils.py
+++ b/cve_bin_tool/checkers/binutils.py
@@ -79,5 +79,8 @@ class BinutilsChecker(Checker):
         # distro-specific names
         r"ld.bfd",  # as seen on ubuntu
     ]
-    VERSION_PATTERNS = [r"libbfd-((\d+\.)*\d+)[\d\w.-]*so"]
+    VERSION_PATTERNS = [
+        r"GNU Binutils[a-zA-Z ]*\) ((\d+\.)*\d+)",
+        r"BFD header file version %s\r?\nversion ((\d+\.)*\d+)",
+    ]
     VENDOR_PRODUCT = [("gnu", "binutils")]

--- a/test/test_data/binutils.py
+++ b/test/test_data/binutils.py
@@ -7,7 +7,7 @@ mapping_test_data = [
         "version": "2.31.1",
         "version_strings": [
             "Using the --size-sort and --undefined-only options together",
-            "libbfd-2.31.1-system.so",
+            "(GNU Binutils for Ubuntu) 2.31.1",
             "Auxiliary filter for shared object symbol table",
         ],
     }

--- a/test/test_data/gdb.py
+++ b/test/test_data/gdb.py
@@ -29,5 +29,6 @@ package_test_data = [
         "package_name": "gdb_8.3.1-1_x86_64.ipk",
         "product": "gdb",
         "version": "8.3.1",
+        "other_products": ["binutils"],
     },
 ]

--- a/test/test_data/linux_kernel.py
+++ b/test/test_data/linux_kernel.py
@@ -45,5 +45,6 @@ package_test_data = [
         "package_name": "openwrt-22.03.3-archs38-generic-uImage",
         "product": "linux_kernel",
         "version": "5.10.161",
+        "other_products": ["binutils"],
     },
 ]

--- a/test/test_data/u_boot.py
+++ b/test/test_data/u_boot.py
@@ -10,23 +10,27 @@ package_test_data = [
         "package_name": "u-boot-rpi_2016.11+dfsg1-4_arm64.deb",
         "product": "u-boot",
         "version": "2016.11",
+        "other_products": ["binutils"],
     },
     {
         "url": "http://ftp.fr.debian.org/debian/pool/main/u/u-boot/",
         "package_name": "u-boot-tegra_2023.04~rc2+dfsg-1_arm64.deb",
         "product": "u-boot",
         "version": "2023.04",
+        "other_products": ["binutils"],
     },
     {
         "url": "https://downloads.openwrt.org/releases/21.02.0/targets/mediatek/mt7622/u-boot-mt7622/",
         "package_name": "u-boot-mtk.bin",
         "product": "u-boot",
         "version": "2020.10",
+        "other_products": ["binutils"],
     },
     {
         "url": "https://downloads.openwrt.org/releases/22.03.0/targets/tegra/generic/u-boot-trimslice/",
         "package_name": "trimslice-spi.img",
         "product": "u-boot",
         "version": "2020.04",
+        "other_products": ["binutils"],
     },
 ]


### PR DESCRIPTION
Update binutils pattern to avoid a false positive in `libtool.info-1` raised by `libbfd-2.9.0.so`