### PR TITLE
fix: update bison pattern

### DIFF
--- a/cve_bin_tool/checkers/bison.py
+++ b/cve_bin_tool/checkers/bison.py
@@ -16,5 +16,5 @@ from cve_bin_tool.checkers import Checker
 class BisonChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
-    VERSION_PATTERNS = [r"Bison ([0-9]+\.[0-9]+\.[0-9]+)"]
+    VERSION_PATTERNS = [r"GNU Bison ([0-9]+\.[0-9]+\.[0-9]+)\r?\n"]
     VENDOR_PRODUCT = [("gnu", "bison")]

--- a/test/test_data/bison.py
+++ b/test/test_data/bison.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 mapping_test_data = [
-    {"product": "bison", "version": "3.8.2", "version_strings": ["Bison 3.8.2"]}
+    {"product": "bison", "version": "3.8.2", "version_strings": ["GNU Bison 3.8.2"]}
 ]
 package_test_data = [
     {


### PR DESCRIPTION
Update bison pattern to avoid a false positive in `bison.info` raised by `Introduced in Bison 3.0.3.`