### PR TITLE
fix: drop gpgme CPE ID without CVEs

### DIFF
--- a/cve_bin_tool/checkers/gpgme.py
+++ b/cve_bin_tool/checkers/gpgme.py
@@ -4,7 +4,6 @@
 """
 CVE checker for gpgme
 
-https://www.cvedetails.com/product/94121/?q=Gpgme
 https://www.cvedetails.com/product/10513/GNU-Gpgme.html?vendor_id=72
 
 """
@@ -20,4 +19,4 @@ class GpgmeChecker(Checker):
         r"This is GPGME ([0-9]+\.[0-9]+\.[0-9]+) \- The GnuPG Made Easy library",
         r"GPGME-Tool ([0-9]+\.[0-9]+\.[0-9]+) ready",
     ]
-    VENDOR_PRODUCT = [("gnupg", "gpgme"), ("gnu", "gpgme")]
+    VENDOR_PRODUCT = [("gnu", "gpgme")]


### PR DESCRIPTION
`gpupg:gpgme` is a CPE ID without any CVEs so drop it: https://www.cvedetails.com/vulnerability-list/vendor_id-4711/product_id-94121/Gnupg-Gpgme.html