### PR TITLE
fix: drop rsync CPE ID without CVEs

### DIFF
--- a/cve_bin_tool/checkers/rsync.py
+++ b/cve_bin_tool/checkers/rsync.py
@@ -7,7 +7,6 @@ CVE checker for rsync
 
 https://www.cvedetails.com/product/396/Andrew-Tridgell-Rsync.html?vendor_id=229
 https://www.cvedetails.com/product/3171/Redhat-Rsync.html?vendor_id=25
-https://www.cvedetails.com/product/3492/GNU-Rsync.html?vendor_id=72
 https://www.cvedetails.com/product/11903/Rsync-Rsync.html?vendor_id=7059
 https://www.cvedetails.com/product/13782/Samba-Rsync.html?vendor_id=102
 
@@ -23,7 +22,6 @@ class RsyncChecker(Checker):
     VERSION_PATTERNS = [r"([0-9]+\.[0-9]+\.[0-9]+)\r?\nrsync"]
     VENDOR_PRODUCT = [
         ("andrew_tridgell", "rsync"),
-        ("gnu", "rsync"),
         ("redhat", "rsync"),
         ("rsync", "rsync"),
         ("samba", "rsync"),


### PR DESCRIPTION
`gnu:rsync` is a CPE ID without any CVEs so drop it: https://www.cvedetails.com/vulnerability-list/vendor_id-72/product_id-3492/GNU-Rsync.html