### PR TITLE
fix: drop netatalk CPE ID without CVEs

### DIFF
--- a/cve_bin_tool/checkers/netatalk.py
+++ b/cve_bin_tool/checkers/netatalk.py
@@ -6,7 +6,6 @@
 CVE checker for netatalk
 
 https://www.cvedetails.com/product/15754/Netatalk-Netatalk.html?vendor_id=2680
-https://www.cvedetails.com/product/61360/Netatalk-Project-Netatalk.html?vendor_id=20887
 
 """
 from __future__ import annotations
@@ -25,4 +24,4 @@ class NetatalkChecker(Checker):
         r"([0-9]+\.[0-9]+\.[0-9]+)\r?\ncnid\_metad \(Netatalk",
         r"([0-9]+\.[0-9]+\.[0-9]+)\r?\nnetatalk",
     ]
-    VENDOR_PRODUCT = [("netatalk", "netatalk"), ("netatalk_project", "netatalk")]
+    VENDOR_PRODUCT = [("netatalk", "netatalk")]


### PR DESCRIPTION
`netatalk_project:netatalk` is a CPE ID without any CVEs so drop it: https://www.cvedetails.com/vulnerability-list/vendor_id-20887/product_id-61360/Netatalk-Project-Netatalk.html