### PR TITLE
Issue #3637. Updated examples in sbom_generation.md 

### DIFF
--- a/doc/how_to_guides/sbom_generation.md
+++ b/doc/how_to_guides/sbom_generation.md
@@ -29,7 +29,7 @@ cve-bin-tool --sbom-type <sbom type> --sbom-format <sbom format> --sbom-output <
 Generate a SPDX SBOM in TagValue format with the name sbom.spdx
 
 ```
-cve-bin-tool --sbom-type spdx --sbom-format tagvalue --sbom-output sbom.spdx
+cve-bin-tool --sbom-type spdx --sbom-format tag --sbom-output sbom.spdx .
 ```
 
 If the `--sbom-type` option is omitted, a SBOM is generated in the SPDX type. If the `--sbom-format` option is omitted, the format is inferred from the extension of the `--sbom-output` filename. The above and below examples are equivalent.


### PR DESCRIPTION
Replaced 'tagvalue' by 'tag' as it was not supported by '--sbom-format' argument.
Added an argument '.' after 'sbom.spdx' to specify directory for scanning. 