### PR TITLE
feat: Enable metrics if epss-{percentile,probability} is set

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -278,14 +278,12 @@ def main(argv=None):
     output_group.add_argument(
         "--epss-percentile",
         action="store",
-        help="minimum epss percentile of CVE range between 0 to 100 to report (default: 0)",
-        default=0,
+        help="minimum epss percentile of CVE range between 0 to 100 to report",
     )
     output_group.add_argument(
         "--epss-probability",
         action="store",
-        help="minimum epss probability of CVE range between 0 to 100 to report (default: 0)",
-        default=0,
+        help="minimum epss probability of CVE range between 0 to 100 to report",
     )
     output_group.add_argument(
         "--no-0-cve-report",
@@ -589,15 +587,35 @@ def main(argv=None):
     if int(args["cvss"]) > 0:
         score = int(args["cvss"])
 
+    metrics = args["metrics"]
+    if args["epss_percentile"] or args["epss_probability"]:
+        metrics = True
+
     epss_percentile = 0
-    if float(args["epss_percentile"]) > 0 or float(args["epss_percentile"]) < 100:
+    if (
+        args["epss_percentile"]
+        and float(args["epss_percentile"]) >= 0
+        and float(args["epss_percentile"]) <= 100
+    ):
         epss_percentile = float(args["epss_percentile"]) / 100
         LOGGER.debug(f"epss percentile stored {epss_percentile}")
+    elif args["epss_percentile"]:
+        LOGGER.debug(
+            f'epss percentile {args["epss_percentile"]} is invalid so set it to 0'
+        )
 
     epss_probability = 0
-    if float(args["epss_probability"]) > 0 or float(args["epss_probability"]) < 100:
+    if (
+        args["epss_probability"]
+        and float(args["epss_probability"]) >= 0
+        and float(args["epss_probability"]) <= 100
+    ):
         epss_probability = float(args["epss_probability"]) / 100
         LOGGER.debug(f"epss probability stored {epss_probability}")
+    elif args["epss_probability"]:
+        LOGGER.debug(
+            f'epss probability {args["epss_probability"]} is invalid so set it to 0'
+        )
 
     config_generate = set(args["generate_config"].split(","))
     config_generate = [config_type.strip() for config_type in config_generate]
@@ -899,7 +917,7 @@ def main(argv=None):
 
     with CVEScanner(
         score=score,
-        check_metrics=args["metrics"],
+        check_metrics=metrics,
         epss_percentile=epss_percentile,
         epss_probability=epss_probability,
         check_exploits=args["exploits"],
@@ -1024,7 +1042,7 @@ def main(argv=None):
             merge_report=merged_reports,
             affected_versions=args["affected_versions"],
             exploits=args["exploits"],
-            metrics=args["metrics"],
+            metrics=metrics,
             detailed=args["detailed"],
             vex_filename=args["vex"],
             sbom_filename=args["sbom_output"],


### PR DESCRIPTION
Enable metrics if epss-percentile or epss-probability is set by the user. This commit also fix this following broken logic which allowed negative epss values:
`
if float(args["epss_percentile"]) > 0 or float(args["epss_percentile"]) < 100:`

replaced by:

`if float(args["epss_percentile"]) >= 0 and float(args["epss_percentile"]) <= 100:`

Tentative fix for #3625