### PR TITLE
docs: add cmd for installing the cve-tool in virtualenv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,8 +144,14 @@ One of the reasons we suggest virtualenv is that it makes it easier to do this s
 
 If you want to run a local copy of cve-bin-tool, the recommended way is to install it locally.  From the cve-bin-tool main directory, run:
 
+### If not in a virtual environment
 ```bash
 python3 -m pip install --user -e .
+```
+
+### If in a virtual environment
+```bash
+python3 -m pip install -e .
 ```
 
 Then you can type `cve-bin-tool` on the command line and it will do the right thing.  This includes some special code intended to deal with adding new checkers to the list on the fly so things should work seamlessly for you while you're building new contributions.


### PR DESCRIPTION
In the contribution guide for running the [local copy of cve-bin-tool](https://github.com/intel/cve-bin-tool/blob/main/CONTRIBUTING.md#running-your-local-copy-of-cve-binary-tool)  ,the mentioned cmd for installing the tool works when a user is not in a virtual env. When present in virtual env , the --user flag isn't needed. 
This PR attempts to clearly mention the cmds for both the cases.