### PR TITLE
fix: update detailed description

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ options:
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--disable-validation-check">--disable-validation-check</a>
                         skips checking xml files against schema
   --offline             operate in offline mode
-  --detailed            display detailed report
+  --detailed            add CVE description in csv or json report (no effect on console, html or pdf)
 
 CVE Data Download:
   Arguments related to data sources and Cache Configuration

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -375,7 +375,10 @@ def main(argv=None):
         default=False,
     )
     parser.add_argument(
-        "--detailed", action="store_true", help="display detailed report", default=False
+        "--detailed",
+        action="store_true",
+        help="add CVE description in csv or json report (no effect on console, html or pdf)",
+        default=False,
     )
 
     merge_report_group = parser.add_argument_group(


### PR DESCRIPTION
detailed option was added by commit 4f3538e89d5510d5bfc1c2c288dd96f491485884 with the following description: "display detailed report" which is a bit cryptic so replace it by "add CVE description in csv or json report (no effect on console, html or pdf)".