### PR TITLE
docs(README.md): updated options list in README.md

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -473,6 +473,8 @@ p
 pacman
 palletsprojects
 pango
+PASSPHRASE
+passphrase
 patch
 pcre
 pcsc
@@ -483,6 +485,8 @@ pdftotext
 pdxjohnny
 peb
 perl
+PGP
+pgp
 php
 picocom
 pigz
@@ -503,6 +507,7 @@ procps
 proftpd
 protobuf
 pspp
+PUBKEY
 Purvanshsingh
 putty
 pybabel

--- a/README.md
+++ b/README.md
@@ -410,27 +410,27 @@ options:
                         skips checking for a new version
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--disable-validation-check">--disable-validation-check</a>
                         skips checking xml files against schema
-  --offline             operate in offline mode
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--offline">--offline</a>             operate in offline mode
   --detailed            add CVE description in csv or json report (no effect on console, html or pdf)
 
 CVE Data Download:
   Arguments related to data sources and Cache Configuration
 
-  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-n-json-nvdjson-mirrorapiapi2---nvd-json-nvdjson-mirrorapiapi2">-n {api,api2,json-nvd,json-mirror}, --nvd {api,api2,json-nvd,json-mirror}</a>
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-n-json-nvdjson-mirrorapiapi2---nvd-json-nvdjson-mirrorapiapi2">-n {api,api2,json,json-mirror,json-nvd}, --nvd {api,api2,json,json-mirror,json-nvd}</a>
                         choose method for getting CVE lists from NVD
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-u-nowdailyneverlatest---update-nowdailyneverlatest">-u {now,daily,never,latest}, --update {now,daily,never,latest}</a>
                         update schedule for data sources and exploits database (default: daily)
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--nvd-api-key-nvd_api_key">--nvd-api-key NVD_API_KEY</a>
                         specify NVD API key (used to improve NVD rate limit)
-  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-d-nvdosvgad-nvdosvgad----disable-data-source-nvdosvgad-nvdosvgad-">-d {NVD,OSV} [{NVD,OSV} ...], --disable-data-source {NVD,OSV} [{NVD,OSV} ...]</a>
-                        comma-separated list of data sources (GAD, NVD, OSV, REDHAT) to disable (default: NONE)
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-d-nvdosvgadcurl-nvdosvgadcurl----disable-data-source-nvdosvgadcurl-nvdosvgadcurl-">-d DISABLE_DATA_SOURCE, --disable-data-source DISABLE_DATA_SOURCE</a>
+                        comma-separated list of data sources (CURL, EPSS, GAD, NVD, OSV, REDHAT, RSD) to disable (default: NONE) 
 
   --use-mirror USE_MIRROR
                         use an mirror to update the database
 
 Input:
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#directory-positional-argument">directory</a>             directory to scan
-  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-i-input_file---input-file-input_file">-i INPUT_FILE, --input-file</a> INPUT_FILE
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-i-input_file---input-file-input_file">-i INPUT_FILE, --input-file INPUT_FILE</a>
                         provide input filename
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--triage-input-file-input_file">--triage-input-file TRIAGE_INPUT_FILE</a>
                         provide input filename for triage data
@@ -455,15 +455,17 @@ Output:
                         update output format (default: console)
                         specify multiple output formats by using comma (',') as a separator
                         note: don't use spaces between comma (',') and the output formats.
+  --generate-config {yaml,toml,yaml,toml,toml,yaml}
+                        generate config file for cve bin tool in toml and yaml formats.
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-c-cvss---cvss-cvss">-c CVSS, --cvss CVSS</a>  minimum CVSS score (as integer in range 0 to 10) to report (default: 0)
-  <a>--metrics</a>
-  check for metrics (e.g., EPSS) from found cves
-  <a>--epss-percentile</a>
-  minimum EPSS percentile of CVE range between 0 to 100 to report (input value can also be floating point) (default: 0)
-  <a>--epss-probability</a>
-  minimum EPSS probability of CVE range between 0 to 100 to report (input value can also be floating point) (default: 0)
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-s-lowmediumhighcritical---severity-lowmediumhighcritical">-S {low,medium,high,critical}, --severity {low,medium,high,critical}</a>
                         minimum CVE severity to report (default: low)
+  --metrics             
+                        check for metrics (e.g., EPSS) from found cves
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--epss-percentile">--epss-percentile EPSS_PERCENTILE</a>
+                        minimum epss percentile of CVE range between 0 to 100 to report
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--epss-probability">--epss-probability EPSS_PROBABILITY</a>
+                        minimum epss probability of CVE range between 0 to 100 to report
   --no-0-cve-report     only produce report when CVEs are found
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-a-distro_name-distro_version_name---available-fix-distro_name-distro_version_name">-A [<distro_name>-<distro_version_name>], --available-fix [<distro_name>-<distro_version_name>]</a>
                         Lists available fixes of the package from Linux distribution
@@ -495,6 +497,19 @@ Checkers:
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-r-checkers---runs-checkers">-r RUNS, --runs RUNS</a>  comma-separated list of checkers to enable
 
 Database Management:
+  --import-json IMPORT_JSON
+                        import database from json files chopped by years
+  --ignore-sig          do not verify PGP signature while importing json data
+  --log-signature-error
+                        when the signature doesn't match log the error only instead of halting (UNSAFE)
+  --verify PGP_PUBKEY_PATH
+                        verify PGP sign while importing json files
+  --export-json EXPORT_JSON
+                        export database as json files chopped by years
+  --pgp-sign PGP_PRIVATE_KEY_PATH
+                        sign exported json files with PGP
+  --passphrase PASSPHRASE
+                        required passphrase for signing with PGP
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--export-export">--export EXPORT</a>       export database filename
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--import-import">--import IMPORT</a>       import database filename
 
@@ -503,9 +518,7 @@ Exploits:
 
 Deprecated:
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-x---extract">-x, --extract</a>         autoextract compressed files
-   CVE Binary Tool autoextracts all compressed files by default now
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--report">--report</a>              Produces a report even if there are no CVE for the respective output format
-   CVE Binary Tool produces report by default even if there are no CVEs
 </pre>
 
 For further information about all of these options, please see [the CVE Binary Tool user manual](https://cve-bin-tool.readthedocs.io/en/latest/MANUAL.html).

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Exploits:
 
 Deprecated:
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-x---extract">-x, --extract</a>         autoextract compressed files
-  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--report">--report</a>              Produces a report even if there are no CVE for the respective output format
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/dodc/MANUAL.md#--report">--report</a>              Produces a report even if there are no CVE for the respective output format
 </pre>
 
 For further information about all of these options, please see [the CVE Binary Tool user manual](https://cve-bin-tool.readthedocs.io/en/latest/MANUAL.html).

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ Exploits:
 
 Deprecated:
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-x---extract">-x, --extract</a>         autoextract compressed files
-  <a href="https://github.com/intel/cve-bin-tool/blob/main/dodc/MANUAL.md#--report">--report</a>              Produces a report even if there are no CVE for the respective output format
+  <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--report">--report</a>              Produces a report even if there are no CVE for the respective output format
 </pre>
 
 For further information about all of these options, please see [the CVE Binary Tool user manual](https://cve-bin-tool.readthedocs.io/en/latest/MANUAL.html).


### PR DESCRIPTION
I have updated the options list in **README.md** by adding the missing options which I got from `cve-bin-tool --help`  . Also I have added the links to the MANUAL file for the options which were present in the MANUAL file. Few of the options were not present in the MANUAL file, so I couldn't add the links for those options.

fixes #3652