### PR TITLE
docs: Clarifying use of --metrics and epss options

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -272,7 +272,7 @@ def main(argv=None):
     output_group.add_argument(
         "--metrics",
         action="store_true",
-        help="check for metrics (e.g., EPSS) from found cves. `--metrics` gets enabled automatically when  either `--epss-percentile` or `--epss-probability` is set",
+        help="check for metrics (e.g., EPSS) from found cves",
         default=False,
     )
     output_group.add_argument(

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -272,18 +272,18 @@ def main(argv=None):
     output_group.add_argument(
         "--metrics",
         action="store_true",
-        help="check for metrics (e.g., EPSS) from found cves",
+        help="check for metrics (e.g., EPSS) from found cves. `--metrics` gets enabled automatically when  either `--epss-percentile` or `--epss-probability` is set",
         default=False,
     )
     output_group.add_argument(
         "--epss-percentile",
         action="store",
-        help="minimum epss percentile of CVE range between 0 to 100 to report",
+        help="minimum epss percentile of CVE range between 0 to 100 to report. Automatically enables `--metrics`",
     )
     output_group.add_argument(
         "--epss-probability",
         action="store",
-        help="minimum epss probability of CVE range between 0 to 100 to report",
+        help="minimum epss probability of CVE range between 0 to 100 to report. Automatically enables `--metrics`",
     )
     output_group.add_argument(
         "--no-0-cve-report",

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1082,7 +1082,7 @@ This option specifies the minimum EPSS probability of CVE range between o to 100
 
 ### Automatic Metrics Activation
 
-If either `--epss-percentile` or `--epss-probability` is set, the system will automatically enable the `--metrics` option. This eliminates the need for users to explicitly set `--metrics` when utilizing `--epss-percentile` or `--epss-probability`. This streamlines the process for users, eliminating the need for manual `--metrics` configuration.
+If either `--epss-percentile` or `--epss-probability` is set, the system will automatically enable the `--metrics` option so that the epss data will be loaded and displayed.
 
 ### -S {low,medium,high,critical}, --severity {low,medium,high,critical}
 

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1080,6 +1080,10 @@ This option specifies the minimum EPSS percentile of CVE range between 0 to 100 
 
 This option specifies the minimum EPSS probability of CVE range between o to 100 to report. The default value is 0 which result in all CVEs being reported.
 
+### Automatic Metrics Activation
+
+If either `--epss-percentile` or `--epss-probability` is set, the system will automatically enable the `--metrics` option. This eliminates the need for users to explicitly set `--metrics` when utilizing `--epss-percentile` or `--epss-probability`. This streamlines the process for users, eliminating the need for manual `--metrics` configuration.
+
 ### -S {low,medium,high,critical}, --severity {low,medium,high,critical}
 
 This option specifies the minimum CVE severity to report. The default value is low which results in all CVEs being reported.


### PR DESCRIPTION
* resolves #3625 
 - Added documentation clarifying automatic activation of `--metrics`.
 - Updated epss related help