### PR TITLE
docs: add PHP launguage specification to docs

### DIFF
--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -1343,6 +1343,11 @@ The `cpanfile` must specify the version data for the vulnerability scanner to wo
 
 Here's an example of what a [`cpanfile`](https://github.com/intel/cve-bin-tool/blob/main/test/language_data/cpanfile) might look like.
 
+### PHP
+
+The scanner examines the `composer.lock` file within a PHP application to identify components. The package names and versions are used to search the database for vulnerabilities. Packages that have a `dev` version are ignored.
+
+Here's an example of what a [`composer.lock`](https://github.com/intel/cve-bin-tool/blob/main/test/language_data/composer.lock) file might look like.
 
 ## Feedback & Contributions
 


### PR DESCRIPTION
closes #3638 
The addition of PHP (#2567) support was not documented in the MANUAL.md file.