### PR TITLE
fix: Deprecate NVD API 1.0

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -549,7 +549,7 @@ def main(argv=None):
         args["nvd"] = "json-mirror"
     nvd_type = args["nvd"]
     if nvd_type == "api":
-        LOGGER.warning(f"API 1.0 is deprecated, switching to API 2.0")
+        LOGGER.warning("API 1.0 is deprecated, switching to API 2.0")
         nvd_type = "api2"
 
     # If NVD API key is not set, check for environment variable (e.g. GitHub Secrets)

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -548,6 +548,10 @@ def main(argv=None):
     if args["nvd"] == "json":
         args["nvd"] = "json-mirror"
     nvd_type = args["nvd"]
+    if nvd_type == "api":
+        LOGGER.warning(f"API 1.0 is deprecated, switching to API 2.0")
+        nvd_type = "api2"
+
     # If NVD API key is not set, check for environment variable (e.g. GitHub Secrets)
     if not args["nvd_api_key"] and os.getenv("nvd_api_key"):
         args["nvd_api_key"] = os.getenv("nvd_api_key")
@@ -558,9 +562,10 @@ def main(argv=None):
 
     if args["nvd_api_key"]:
         if nvd_type != "api2":
-            LOGGER.debug(f"{nvd_type} - changing to api. API Key {args['nvd_api_key']}")
-            nvd_type = "api"
-
+            LOGGER.debug(
+                f"{nvd_type} - changing to api2. API Key {args['nvd_api_key']}"
+            )
+            nvd_type = "api2"
     # If you're not using an NVD key, let you know how to get one
     if nvd_type == "json-nvd" and not args["nvd_api_key"] and not args["offline"]:
         LOGGER.info("Not using an NVD API key. Your access may be rate limited by NVD.")

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -545,7 +545,7 @@ This option controls the frequency of updates for the CVE data from the National
 
 ### -n {json-nvd,json-mirror,api,api2}, --nvd {json-nvd,json-mirror,api,api2}
 
-This option selects how CVE data is downloaded from the National Vulnerability Database. The `api` option previously used the NVD CVE Retrieval API version 1.0, which is now deprecated. Using `--nvd api` will automatically failover to the `--nvd api2` option. The `api2` option uses the later NVD CVE Retrieval API version 2.0. The results from this API are updated as quickly as the NVD website.
+This option selects how CVE data is downloaded from the National Vulnerability Database. The `api` option previously used the NVD CVE Retrieval API version 1.0, which is now deprecated. Using `--nvd api` will automatically switch to the `--nvd api2` option. The `api2` option uses the later NVD CVE Retrieval API version 2.0. The results from this API are updated as quickly as the NVD database.
 A major benefit of using this NVD API is incremental updates which basically means you won't have to download the complete feed again in case you want the latest CVE entries from NVD. See the detailed guide on [incremental updates](how_to_guides/use_incremental_updates.md) for more details.
 
 You may also choose to update the data using `json-nvd` option which uses the JSON feeds available on [this page](https://nvd.nist.gov/vuln/data-feeds). These per-year feeds are updated once per day. This mode was the default for CVE Binary Tool prior to the 3.0 release.

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -545,7 +545,7 @@ This option controls the frequency of updates for the CVE data from the National
 
 ### -n {json-nvd,json-mirror,api,api2}, --nvd {json-nvd,json-mirror,api,api2}
 
-This option selects how CVE data is downloaded from the National Vulnerability Database. The default `api` option uses the NVD CVE Retrieval API version 1.0. The `api2` option uses the later NVD CVE Retrieval API version 2.0. The results from this API are updated as quickly as the NVD website.
+This option selects how CVE data is downloaded from the National Vulnerability Database. The `api` option previously used the NVD CVE Retrieval API version 1.0, which is now deprecated. Using `--nvd api` will automatically failover to the `--nvd api2` option. The `api2` option uses the later NVD CVE Retrieval API version 2.0. The results from this API are updated as quickly as the NVD website.
 A major benefit of using this NVD API is incremental updates which basically means you won't have to download the complete feed again in case you want the latest CVE entries from NVD. See the detailed guide on [incremental updates](how_to_guides/use_incremental_updates.md) for more details.
 
 You may also choose to update the data using `json-nvd` option which uses the JSON feeds available on [this page](https://nvd.nist.gov/vuln/data-feeds). These per-year feeds are updated once per day. This mode was the default for CVE Binary Tool prior to the 3.0 release.


### PR DESCRIPTION
- Resolves #3582 
- Updated documentation clarifying the failover to api2