### PR TITLE
test: added test for OutputEngine with metrics=False

### DIFF
--- a/test/test_output_engine.py
+++ b/test/test_output_engine.py
@@ -166,6 +166,60 @@ class TestOutputEngine(unittest.TestCase):
         ),
     }
 
+    MOCK_OUTPUT_2 = {
+        ProductInfo("vendor0", "product0", "1.0"): CVEData(
+            cves=[
+                CVE(
+                    "CVE-1234-1234",
+                    "LOW",
+                    score=6.4,
+                    cvss_version=2,
+                    cvss_vector="C:H",
+                    data_source="NVD",
+                    last_modified="25-12-2023",
+                ),
+                CVE(
+                    "CVE-1234-1234",
+                    "MEDIUM",
+                    score=1.2,
+                    cvss_version=2,
+                    cvss_vector="CVSS2.0/C:H",
+                    data_source="NVD",
+                    last_modified="31-10-2021",
+                ),
+            ],
+            paths={""},
+        ),
+        ProductInfo("vendor0", "product0", "2.8.7"): CVEData(
+            cves=[
+                CVE(
+                    "CVE-1234-1234",
+                    "LOW",
+                    score=2.5,
+                    cvss_version=3,
+                    cvss_vector="CVSS3.0/C:H/I:L/A:M",
+                    data_source="NVD",
+                    last_modified="12-12-2020",
+                )
+            ],
+            paths={""},
+        ),
+        ProductInfo("vendor1", "product1", "3.3.1"): CVEData(
+            cves=[
+                CVE(
+                    "CVE-1234-1234",
+                    "HIGH",
+                    score=7.5,
+                    cvss_version=2,
+                    cvss_vector="C:H/I:L/A:M",
+                    data_source="OSV",
+                    last_modified="20-10-2012",
+                )
+            ],
+            paths={""},
+        ),
+    }
+
     MOCK_PDF_OUTPUT = {
         ProductInfo("vendor0", "product0", "1.0"): CVEData(
             cves=[
@@ -1067,6 +1121,43 @@ class TestOutputEngine(unittest.TestCase):
         self.assertIn(expected_output, result)
         self.assertIn(expected_output_2, result)
         Path(tmpf.name).unlink()  # deleting tempfile
+
+    def test_output_console_metrics_false(self):
+        """Test Formatting Output as console with metrics=False"""
+
+        time_of_last_update = datetime.today()
+        affected_versions = 0
+        exploits = False
+        metrics = False
+        console = Console(file=self.mock_file)
+        outfile = None
+        all_product_data = None
+
+        output_console(
+            self.MOCK_OUTPUT_2,
+            self.MOCK_ALL_CVE_VERSION_INFO,
+            time_of_last_update,
+            affected_versions,
+            exploits,
+            metrics,
+            all_product_data,
+            True,
+            120,
+            console,
+            outfile,
+        )
+
+        expected_output = (
+            "│ vendor0 │ product0 │ 1.0     │ CVE-1234-1234 │ NVD    │ LOW      │ 6.4 (v2)             │\n"
+            "│ vendor0 │ product0 │ 1.0     │ CVE-1234-1234 │ NVD    │ MEDIUM   │ 1.2 (v2)             │\n"
+            "│ vendor0 │ product0 │ 2.8.7   │ CVE-1234-1234 │ NVD    │ LOW      │ 2.5 (v3)             │\n"
+            "│ vendor1 │ product1 │ 3.3.1   │ CVE-1234-1234 │ OSV    │ HIGH     │ 7.5 (v2)             │\n"
+            "└─────────┴──────────┴─────────┴───────────────┴────────┴──────────┴──────────────────────┘\n"
+        )
+
+        self.mock_file.seek(0)
+        result = self.mock_file.read()
+        self.assertIn(expected_output, result)
 
     def test_output_file(self):
         """Test file generation logic in output_file"""


### PR DESCRIPTION
fixes: #3626 
Added a test for OutputEngine's output_console with metrics=False.