### PR TITLE
docs/fixes: add missing docstrings to output_engine/print_mode.py #3457

### DIFF
--- a/cve_bin_tool/output_engine/print_mode.py
+++ b/cve_bin_tool/output_engine/print_mode.py
@@ -15,6 +15,7 @@ from .util import format_version_range
 
 
 def html_print_mode(
+    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
     all_cve_data: CVEData,
     all_cve_version_info: dict[str, VersionInfo] | None,
     directory: str,

--- a/cve_bin_tool/output_engine/print_mode.py
+++ b/cve_bin_tool/output_engine/print_mode.py
@@ -15,7 +15,6 @@ from .util import format_version_range
 
 
 def html_print_mode(
-    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
     all_cve_data: CVEData,
     all_cve_version_info: dict[str, VersionInfo] | None,
     directory: str,
@@ -28,6 +27,7 @@ def html_print_mode(
     full_html: bool = True,
     affected_versions: int = 0,
 ) -> str:
+    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
     root = Path(__file__).absolute().parent
     templates_dir = Path(root / "print_mode")
     templates_env = Environment(

--- a/cve_bin_tool/output_engine/print_mode.py
+++ b/cve_bin_tool/output_engine/print_mode.py
@@ -27,7 +27,7 @@ def html_print_mode(
     full_html: bool = True,
     affected_versions: int = 0,
 ) -> str:
-    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
+    """Generates an HTML report of key CVE Details, including affected vendor/product, version, CVE Number, and severity."""
     root = Path(__file__).absolute().parent
     templates_dir = Path(root / "print_mode")
     templates_env = Environment(


### PR DESCRIPTION
Added the docstring for the `print_mode` function in `output_engine/print_mode.py`.
`interrogate` Verified that the test passes locally (image attached below), so it should be good to merge.
![image](https://github.com/intel/cve-bin-tool/assets/45304559/365b90ae-2f24-4026-aa03-790b35c6cd05)
