### PR TITLE
docs: Add appropriate docstring to output_engine/print_mode.py (#3457)

### DIFF
--- a/cve_bin_tool/output_engine/print_mode.py
+++ b/cve_bin_tool/output_engine/print_mode.py
@@ -15,6 +15,7 @@ from .util import format_version_range
 
 
 def html_print_mode(
+    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
     all_cve_data: CVEData,
     all_cve_version_info: dict[str, VersionInfo] | None,
     directory: str,

--- a/cve_bin_tool/output_engine/print_mode.py
+++ b/cve_bin_tool/output_engine/print_mode.py
@@ -15,7 +15,6 @@ from .util import format_version_range
 
 
 def html_print_mode(
-    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
     all_cve_data: CVEData,
     all_cve_version_info: dict[str, VersionInfo] | None,
     directory: str,
@@ -28,6 +27,7 @@ def html_print_mode(
     full_html: bool = True,
     affected_versions: int = 0,
 ) -> str:
+    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
     root = Path(__file__).absolute().parent
     templates_dir = Path(root / "print_mode")
     templates_env = Environment(

--- a/cve_bin_tool/output_engine/print_mode.py
+++ b/cve_bin_tool/output_engine/print_mode.py
@@ -27,7 +27,7 @@ def html_print_mode(
     full_html: bool = True,
     affected_versions: int = 0,
 ) -> str:
-    """Generates an HTML report, incorporating a showcase, content, and an intermediate content with an option to include or exclude the full HTML structure."""
+    """Generates an HTML report of key CVE Details, including affected vendor/product, version, CVE Number, and severity."""
     root = Path(__file__).absolute().parent
     templates_dir = Path(root / "print_mode")
     templates_env = Environment(


### PR DESCRIPTION
@terriko 

This docstring should work better for issue #3457 than PR #3675. Interrogate still passes, but then again it is only checking for the presence of a docstring (see attached image below). Please let me know if this works, or if I'm still missing the function description. 

![image](https://github.com/intel/cve-bin-tool/assets/45304559/55733f2a-b8ee-41e1-98c6-252cd3c43bfd)
