### PR TITLE
docs: add docstrings to cve-bin-tool/util

### DIFF
--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -13,28 +13,74 @@ from typing import DefaultDict, Iterator, List, NamedTuple, Pattern, Set, Union
 
 
 class OrderedEnum(Enum):
+    """
+    An enumeration that supports order comparisons.
+
+    Each member of the enumeration can be compared to others. The comparison is based on the value of the enumeration member.
+    """
+
     def __ge__(self, other: OrderedEnum) -> bool:
+        """
+        Check if this member is greater than or equal to the other member.
+
+        Args:
+            other (OrderedEnum): The other member to compare with.
+
+        Returns:
+            bool: True if this member is greater than or equal to the other member, False otherwise.
+        """
         if self.__class__ is other.__class__:
             return self.value >= other.value
         return NotImplemented
 
     def __gt__(self, other: OrderedEnum) -> bool:
+        """
+        Check if this member is greater than the other member.
+
+        Args:
+            other (OrderedEnum): The other member to compare with.
+
+        Returns:
+            bool: True if this member is greater than the other member, False otherwise.
+        """
         if self.__class__ is other.__class__:
             return self.value > other.value
         return NotImplemented
 
     def __le__(self, other: OrderedEnum) -> bool:
+        """
+        Check if this member is less than or equal to the other member.
+
+        Args:
+            other (OrderedEnum): The other member to compare with.
+
+        Returns:
+            bool: True if this member is greater than or equal to the other member, False otherwise.
+        """
         if self.__class__ is other.__class__:
             return self.value <= other.value
         return NotImplemented
 
     def __lt__(self, other: OrderedEnum) -> bool:
+        """
+        Check if this member is less than the other member.
+        Args:
+            other (OrderedEnum): The other member to compare with.
+        Returns:
+            bool: True if this member is less than the other member, False otherwise.
+        """
         if self.__class__ is other.__class__:
             return self.value < other.value
         return NotImplemented
 
 
 class Remarks(OrderedEnum):
+    """
+    An enumeration of remarks.
+
+    Each member of the enumeration represents a specific remark with a unique value.
+    """
+
     NewFound = 1, "1", "NewFound", "n", "N"
     Unexplored = 2, "2", "Unexplored", "u", "U", ""
     Confirmed = 3, "3", "Confirmed", "c", "C"
@@ -42,6 +88,9 @@ class Remarks(OrderedEnum):
     Ignored = 5, "5", "Ignored", "i", "I"
 
     def __new__(cls, value: int, *aliases: str) -> Remarks:
+        """
+        Return a new instance of the Remarks enumeration.
+        """
         obj = object.__new__(cls)
         obj._value_ = value
         for alias in aliases:
@@ -50,6 +99,22 @@ class Remarks(OrderedEnum):
 
 
 class CVE(NamedTuple):
+    """
+    Class to hold CVE information
+    attributes:
+        cve_number: str
+        severity: str
+        remarks: Remarks
+        description: str
+        comments: str
+        score: float
+        cvss_version: int
+        cvss_vector: str
+        data_source: str
+        last_modified: str
+        metric: dict[str, dict[float, str]]
+    """
+
     cve_number: str
     severity: str
     remarks: Remarks = Remarks.NewFound
@@ -64,17 +129,40 @@ class CVE(NamedTuple):
 
 
 class ProductInfo(NamedTuple):
+    """
+    Class to hold product information
+    attributes:
+        vendor: str
+        product: str
+        version: str
+    """
+
     vendor: str
     product: str
     version: str
 
 
 class ScanInfo(NamedTuple):
+    """
+    Class to hold scan information
+    attributes:
+        product_info: ProductInfo
+        file_path: str
+    """
+
     product_info: ProductInfo
     file_path: str
 
 
 class VersionInfo(NamedTuple):
+    """
+    Class to hold version information of a product
+    attributes:
+        version: str
+        version_patterns: list[Pattern[str]]
+        ignore: list[Pattern[str]]
+    """
+
     start_including: str
     start_excluding: str
     end_including: str
@@ -82,7 +170,24 @@ class VersionInfo(NamedTuple):
 
 
 class CVEData(DefaultDict[str, Union[List[CVE], Set[str]]]):
+    """
+    A Class representing a dictionary of CVEs and paths
+    """
+
     def __missing__(self, key: str) -> list[CVE] | set[str]:
+        """
+        Handle missing keys in the dictionary.
+
+        If the key is "cves", a new list is created and assigned to the key.
+        If the key is "paths", a new set is created and assigned to the key.
+        If the key is neither "cves" nor "paths", NotImplemented is returned.
+
+        Args:
+            key (str): The key that was not found.
+
+        Returns:
+            list[CVE] | set[str]: The value that was created for the missing key.
+        """
         if key == "cves":
             new_list: list[CVE] = []
             self[key] = new_list


### PR DESCRIPTION
closes #3710 

This pr adds docstrings to `cve-bin-tool/util.py` file. 


![image](https://github.com/intel/cve-bin-tool/assets/100200105/079d4bbf-8769-40e0-994f-827825c608f4)
 