### PR TITLE
docs: added docstring to swid_parser.py

### DIFF
--- a/cve_bin_tool/sbom_manager/swid_parser.py
+++ b/cve_bin_tool/sbom_manager/swid_parser.py
@@ -9,6 +9,10 @@ from cve_bin_tool.validator import validate_swid
 
 
 class SWIDParser:
+    """
+    Class responsible for parsing SWID (Software Identification Tags) XML BOM (Bill of Materials) files.
+    """
+
     def __init__(self, validate: bool = True):
         self.validate = validate
 
@@ -35,6 +39,13 @@ class SWIDParser:
         return modules
 
     def extract(self, swid: str) -> list[str]:
+        """
+        Extracts the product name and version from a SWID entry.
+        args:
+            swid: SWID entry
+        returns:
+            list containing product name and version
+        """
         # Return parsed swid entry as [product, version] list item
         # Format of swid is "URI: <vendor>-<product>-<version>"
         item = swid[swid.find(":") + 1 :].split("-")


### PR DESCRIPTION
closes #3712 

This Pr Adds docstrings to `cve_bin_tool/sbom_manager/swid_parser.py`

![image](https://github.com/intel/cve-bin-tool/assets/100200105/1cabb399-f5bd-4bfe-ab12-2b5943a9ef71)
