### PR TITLE
test: re-enable failing tests from #3653

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -54,10 +54,10 @@ class CVEDB:
     BACKUPCACHEDIR = DISK_LOCATION_BACKUP
     LOGGER = LOGGER.getChild("CVEDB")
     SOURCES = [
-        nvd_source.NVD_Source,
         curl_source.Curl_Source,
         osv_source.OSV_Source,
         gad_source.GAD_Source,
+        nvd_source.NVD_Source,  # last to avoid data overwrites
     ]
 
     INSERT_QUERIES = {

--- a/test/test_csv2cve.py
+++ b/test/test_csv2cve.py
@@ -11,7 +11,6 @@ from cve_bin_tool.error_handler import ERROR_CODES, InsufficientArgs
 
 
 class TestCSV2CVE:
-    @pytest.mark.skip(reason="Temporarily disabled -- may need data changes")
     @pytest.mark.asyncio
     async def test_csv2cve_valid_file(self, caplog):
         file_path = join(dirname(__file__), "csv", "triage.csv")

--- a/test/test_exploits.py
+++ b/test/test_exploits.py
@@ -8,7 +8,6 @@ from cve_bin_tool.util import ProductInfo
 
 
 class TestExploitScanner:
-    @pytest.mark.skip(reason="Temporarily disabled -- may need data changes")
     @pytest.mark.parametrize(
         "check_exploits, exploits_list, product_info, triage_info, expected_result",
         (

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -163,7 +163,6 @@ class TestLanguageScanner:
         cls.cvedb.get_cvelist_if_stale()
         print("Database setup complete.")
 
-    @pytest.mark.skip(reason="Temporarily disabled -- may need data changes")
     @pytest.mark.parametrize(
         "filename, product_list",
         (((str(TEST_FILE_PATH / "pom.xml")), ["jmeter", "hamcrest"]),),
@@ -235,7 +234,6 @@ class TestLanguageScanner:
             assert p in found_product
         assert file_path == filename
 
-    @pytest.mark.skip(reason="Temporarily disabled -- may need data changes")
     @pytest.mark.parametrize("filename", ((str(TEST_FILE_PATH / "PKG-INFO")),))
     def test_python_package(self, filename: str) -> None:
         scanner = VersionScanner()

--- a/test/test_sbom.py
+++ b/test/test_sbom.py
@@ -68,7 +68,6 @@ class TestSBOM:
         sbom_engine = SBOMManager(filename, sbom_type)
         assert sbom_engine.scan_file() == {}
 
-    @pytest.mark.skip(reason="Temporarily disabled -- may need data changes")
     @pytest.mark.parametrize(
         "filename, spdx_parsed_data",
         (
@@ -89,7 +88,6 @@ class TestSBOM:
         for p in spdx_parsed_data:
             assert p in scan_result
 
-    @pytest.mark.skip(reason="Temporarily disabled -- may need data changes")
     @pytest.mark.parametrize(
         "filename, cyclonedx_parsed_data",
         (
@@ -107,7 +105,6 @@ class TestSBOM:
         for p in cyclonedx_parsed_data:
             assert p in scan_result
 
-    @pytest.mark.skip(reason="Temporarily disabled -- may need data changes")
     @pytest.mark.parametrize(
         "filename, swid_parsed_data",
         ((str(SBOM_PATH / "swid_test.xml"), PARSED_SBOM_DATA),),


### PR DESCRIPTION
Fixes #3653

I was able to get the tests to fail locally, but it looks like my local database was messed up because OSV had over-written the NVD severity data, causing tests to fail.  Refreshing the data *has* fixed it, but it's possibly because we're having other OSV issues and that data isn't getting loaded.  Going to re-enable the tests and make sure nvd is loaded last (so it over-writes any bad data from OSV) but I'll need to keep an eye on this because something bigger is likely wrong with the way our data sources are loading.