### PR TITLE
docs: add docstrings for fuzzing modules

### DIFF
--- a/fuzz/fuzz_cargo_lock.py
+++ b/fuzz/fuzz_cargo_lock.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the RustParser's handling of Cargo.lock files.
+"""
+
 import sys
 import tempfile
 from pathlib import Path
@@ -21,6 +25,12 @@ logger = LOGGER.getChild("Fuzz")
 
 
 def CargoLockBuilder(data):
+    """
+    This function converts the given data into a Cargo.lock file.
+
+    Args:
+        data (protobuf message): The protobuf message to convert to a Cargo.lock file.
+    """
     json_data = MessageToDict(
         data, preserving_proto_field_name=True, including_default_value_fields=True
     )
@@ -56,6 +66,12 @@ def CargoLockBuilder(data):
 
 
 def TestParseData(data):
+    """
+    Fuzz test the RustParser's handling of Cargo.lock files.
+
+    Args:
+        data (protobuf message): The protobuf message to convert to a Cargo.lock file.
+    """
     try:
         CargoLockBuilder(data)
 

--- a/fuzz/fuzz_cpanfile.py
+++ b/fuzz/fuzz_cpanfile.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the PerlParser's handling of cpanfile files.
+"""
+
 import sys
 import tempfile
 from pathlib import Path
@@ -21,6 +25,13 @@ logger = LOGGER.getChild("Fuzz")
 
 
 def cpanfileBuilder(data, file_path):
+    """
+    This function converts the given data into a cpanfile file.
+
+    Args:
+        data (protobuf message): The protobuf message to convert to a cpanfile file.
+        file_path (str): The path to the file to write the cpanfile data to.
+    """
     # Convert the Protobuf message to a dictionary
     json_data = MessageToDict(
         data, preserving_proto_field_name=True, including_default_value_fields=True
@@ -59,6 +70,9 @@ def cpanfileBuilder(data, file_path):
 
 
 def TestParseData(data):
+    """
+    Fuzz test the PerlParser's handling of cpanfile files.
+    """
     try:
         cpanfileBuilder(data)
 

--- a/fuzz/fuzz_cyclonedx.py
+++ b/fuzz/fuzz_cyclonedx.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the CycloneDXParser's handling of CycloneDX files.
+"""
+
 import json
 import sys
 import tempfile
@@ -17,6 +21,12 @@ with atheris.instrument_imports():
 
 
 def TestParseData(data):
+    """
+    This function converts the given data into a CycloneDX file.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     try:
         json_data = MessageToDict(
             data, preserving_proto_field_name=True, including_default_value_fields=True

--- a/fuzz/fuzz_go.py
+++ b/fuzz/fuzz_go.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the GoParser's handling of go.mod files.
+"""
+
 import sys
 import tempfile
 from pathlib import Path
@@ -21,6 +25,12 @@ logger = LOGGER.getChild("Fuzz")
 
 
 def GoModBuilder(data):
+    """
+    This function converts the given data into a go.mod file.
+
+    Args:
+        data (protobuf message): The protobuf message to convert to a go.mod file.
+    """
     json_data = MessageToDict(
         data, preserving_proto_field_name=True, including_default_value_fields=True
     )
@@ -57,6 +67,12 @@ def GoModBuilder(data):
 
 
 def TestParseData(data):
+    """
+    Fuzz test the GoParser's handling of go.mod files.
+
+    Args:
+        data (protobuf message): The protobuf message to convert to a go.mod file.
+    """
     try:
         GoModBuilder(data)
 

--- a/fuzz/fuzz_intermediate_report_merge.py
+++ b/fuzz/fuzz_intermediate_report_merge.py
@@ -18,6 +18,12 @@ with atheris.instrument_imports():
 
 
 def TestParseData(data):
+    """
+    This function converts the given data into a IntermediateReport file and Fuzz tests the IntermediateReport's handling of IntermediateReport files.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     try:
         json_data = MessageToDict(
             data, preserving_proto_field_name=True, including_default_value_fields=True

--- a/fuzz/fuzz_main.py
+++ b/fuzz/fuzz_main.py
@@ -1,3 +1,10 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+This module contains fuzz testing for the CVE-Bin-CLI.
+"""
+
 import atheris
 
 with atheris.instrument_imports():
@@ -7,6 +14,12 @@ with atheris.instrument_imports():
 
 
 def TestOneInput(data):
+    """
+    Fuzz test the CLI with the given data.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     try:
         # uncomment the one below to run tests where there is a valid filename:
         # cli.main(["test/assets/test-curl-7.34.0.out", data])

--- a/fuzz/fuzz_package_list_parser.py
+++ b/fuzz/fuzz_package_list_parser.py
@@ -1,3 +1,10 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""
+This module contains fuzz testing for the PackageListParser's handling of package lists.
+"""
+
 import sys
 import tempfile
 from pathlib import Path
@@ -13,6 +20,13 @@ with atheris.instrument_imports():
 
 
 def TestListParser(file_name: str, text: str):
+    """
+    Test the PackageListParser for the given file and text.
+
+    Args:
+        file_name (str): The name of the file to write the text to.
+        text (str): The text to write to the file.
+    """
     try:
         with open(file_name, "w") as f:
             f.writelines(text)
@@ -27,6 +41,12 @@ def TestListParser(file_name: str, text: str):
 
 
 def TestPackageData(data):
+    """
+    Fuzz Test the PackageListParser with the given protobuf message.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     with_version = []
     without_version = []
     json_data = MessageToDict(

--- a/fuzz/fuzz_package_lock.py
+++ b/fuzz/fuzz_package_lock.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the JavascriptParser's handling of package-lock.json files.
+"""
+
 import json
 import sys
 import tempfile
@@ -22,6 +26,7 @@ logger = LOGGER.getChild("Fuzz")
 
 
 def array_to_json(json_data):
+    """Converts a list of json objects to a json object with the name as the key"""
     temp = {}
     for item in json_data:
         temp[item.pop("name")] = item
@@ -30,6 +35,15 @@ def array_to_json(json_data):
 
 
 def reformat_dependencies(dependencies):
+    """
+    reformats the 'requires' and 'dependencies' fields of each
+    dependency in a list of dependencies.
+
+    Args:
+        dependencies (list): The list of dependencies to reformat.
+    Returns:
+        dict: The reformatted dependencies.
+    """
     temp = {}
     for dep in dependencies:
         dep["requires"] = array_to_json(dep["requires"])
@@ -46,6 +60,12 @@ def reformat_dependencies(dependencies):
 
 
 def TestParseData(data):
+    """
+    Fuzz testing function for the JavascriptParser's handling of package-lock.json files.
+
+    Args:
+        data (protobuf message): The protobuf message to convert to a dictionary and write to a file.
+    """
     try:
         json_data = MessageToDict(
             data, preserving_proto_field_name=True, including_default_value_fields=True

--- a/fuzz/fuzz_pom_xml.py
+++ b/fuzz/fuzz_pom_xml.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the JavaParser's handling of pom.xml files.
+"""
+
 import sys
 import tempfile
 from pathlib import Path
@@ -26,6 +30,12 @@ logger = LOGGER.getChild("Fuzz")
 
 
 def PomXmlBuilder(data):
+    """
+    This function converts the given data into a pom.xml file.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     json_data = MessageToDict(
         data, preserving_proto_field_name=True, including_default_value_fields=True
     )
@@ -88,6 +98,12 @@ def PomXmlBuilder(data):
 
 
 def TestParseData(data):
+    """
+    Fuzz testing function for the JavaParser's handling of pom.xml files.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     try:
         PomXmlBuilder(data)
 

--- a/fuzz/fuzz_python_requirement_parser.py
+++ b/fuzz/fuzz_python_requirement_parser.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the PythonRequirementsParser's handling of requirements.txt files.
+"""
+
 import sys
 import tempfile
 from pathlib import Path
@@ -21,6 +25,9 @@ logger = LOGGER.getChild("Fuzz")
 
 
 def TestParseData(data):
+    """
+    Fuzz test the PythonRequirementsParser's handling of requirements.txt files.
+    """
     try:
         json_data = MessageToDict(
             data, preserving_proto_field_name=True, including_default_value_fields=True

--- a/fuzz/fuzz_renv_lock.py
+++ b/fuzz/fuzz_renv_lock.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2023 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the RParser's handling of renv.lock files.
+"""
+
 import sys
 import tempfile
 from pathlib import Path
@@ -22,6 +26,12 @@ logger = LOGGER.getChild("Fuzz")
 
 
 def RenvLockBuilder(data):
+    """
+    This function converts the given data into a renv.lock file.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     # Parse the JSON data
     json_data = MessageToDict(
         data, preserving_proto_field_name=True, including_default_value_fields=True
@@ -80,6 +90,12 @@ def RenvLockBuilder(data):
 
 
 def TestParseData(data):
+    """
+    Fuzz testing function for the RParser's handling of renv.lock files.
+
+    Args:
+        data (protobuf message): The protobuf message to convert and process.
+    """
     try:
         RenvLockBuilder(data)
 

--- a/fuzz/fuzz_tuples.py
+++ b/fuzz/fuzz_tuples.py
@@ -1,6 +1,10 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+"""
+This module contains fuzz testing for the InputEngine's handling of product tuples.
+"""
+
 import sys
 
 import atheris
@@ -13,6 +17,9 @@ with atheris.instrument_imports():
 
 
 def TestParseData(data):
+    """
+    Fuzz Test the InputEngine.parse_data function with a product tuple protobuf message.
+    """
     try:
         # data should be a fuzzy product tuple
         InputEngine("").parse_data(


### PR DESCRIPTION
Closes #3682 

This Pr adds docstrings to `cve-bin-tool/fuzz` module. 