### PR TITLE
fix: update darkhttpd VENDOR_PRODUCT

### DIFF
--- a/cve_bin_tool/checkers/darkhttpd.py
+++ b/cve_bin_tool/checkers/darkhttpd.py
@@ -6,6 +6,7 @@
 CVE checker for darkhttpd
 
 https://www.cvedetails.com/product/112161/Darkhttpd-Project-Darkhttpd.html?vendor_id=26797
+https://www.cvedetails.com/product/168196/Unix4lyfe-Darkhttpd.html?vendor_id=34424
 
 Note: darkhttpd is not provided on debian and openWRT. Tests use fedora packages only
 
@@ -19,4 +20,4 @@ class DarkhttpdChecker(Checker):
     CONTAINS_PATTERNS: list[str] = []
     FILENAME_PATTERNS: list[str] = []
     VERSION_PATTERNS = [r"darkhttpd/([0-9]+\.[0-9]+)"]
-    VENDOR_PRODUCT = [("darkhttpd_project", "darkhttpd")]
+    VENDOR_PRODUCT = [("darkhttpd_project", "darkhttpd"), ("unix4lyfe", "darkhttpd")]


### PR DESCRIPTION
Add unix4lyfe:darkhttpd to avoid missing 2 CVEs published in 2024