### PR TITLE
ci: set default permissions on workflows

### DIFF
--- a/.github/workflows/cve_bin_tool_action.yml
+++ b/.github/workflows/cve_bin_tool_action.yml
@@ -1,4 +1,5 @@
 name: CVE Binary Tool Scanner
+permissions: read-all
 
 on:
   push:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,4 +1,5 @@
 name: Testing
+permissions: read-all
 
 on:
   push:


### PR DESCRIPTION
Looks like we missed a couple of workflows when I last updated the permissions to fit OpenSSF recommendations, so this should fix that.  