### PR TITLE
ci: Add python 3.12 with fix from @milinddethe15

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -61,8 +61,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python: ['3.8', '3.9', '3.11']
-        # python 3.12 throws aiohttp package install errors
+        python: ['3.8', '3.9', '3.11', '3.12']
     timeout-minutes: 60
     steps:
       - name: Harden Runner
@@ -112,6 +111,9 @@ jobs:
       - name: Install cabextract
         if: env.sbom != 'true'
         run: sudo apt-get update && sudo apt-get install cabextract
+      - name: Install python3.12-dev to fix pip builds
+        if: ${{ matrix.python == '3.12' }}
+        run: sudo apt-get install python3.12-dev
       - name: Install OS dependencies for testing PDF
         if: env.sbom != 'true'
         run: sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python3-dev

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -111,9 +111,6 @@ jobs:
       - name: Install cabextract
         if: env.sbom != 'true'
         run: sudo apt-get update && sudo apt-get install cabextract
-      - name: Install python3.12-dev to fix pip builds
-        if: ${{ matrix.python == '3.12' }}
-        run: sudo apt-get install python3.12-dev
       - name: Install OS dependencies for testing PDF
         if: env.sbom != 'true'
         run: sudo apt-get install build-essential libpoppler-cpp-dev pkg-config python3-dev


### PR DESCRIPTION
* fixes #3495 

@milinddethe15 did some investigation and found that things should work if the -dev package was installed.  Looks like we can't explicitly install python3.12-dev but we already install python3-dev with the pdf testing components so this may work.

(I haven't checked if the tests will pass yet, though)