### PR TITLE
fix: use tarfile extract filters to open tarfiles more safely

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -210,6 +210,8 @@ jobs:
       - uses: technote-space/get-diff-action@f27caffdd0fb9b13f4fc191c016bb4e0632844af # v6.1.2
         with:
           PATTERNS: |
+            cve_bin_tool/*.py
+            cve_bin_tool/data_sources/*.py
             cve_bin_tool/checkers/*.py
             test/condensed-downloads/*
           FILES: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,12 @@
 repos:
+-   repo: https://github.com/econchick/interrogate
+    rev: 1.5.0
+    hooks:
+      - id: interrogate
+        verbose: True
+        exclude: ^(locales|presentation|fuzz|test|cve_bin_tool/checkers|build)
+        args: ["-vv", "-i", "-I", "-M", "-C", "-n", "-p", "-f", "60.0"]
+
 -   repo: https://github.com/pycqa/isort
     rev: 5.13.2
     hooks:
@@ -71,11 +79,4 @@ repos:
             test/utils.py|
         )$
 
--   repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
-    hooks:
-      - id: interrogate
-        verbose: True
-        exclude: ^(locales|presentation|fuzz|test|cve_bin_tool/checkers|build)
-        args: ["-vv", "-i", "-I", "-M", "-C", "-n", "-p", "-f", "60.0"]
 

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -83,6 +83,18 @@ class BaseExtractor:
             if hasattr(tarfile, "data_filter"):
                 await aio_unpack_archive(filename, extraction_path, filter="data")
 
+            # FIXME: filter solution below doesn't work with windows paths
+            # This is a temporary and unsafe measure so we can merge a partial fix
+            elif sys.platform == "win32":
+                extraction_path_abs = PurePath(extraction_path).absolute()
+                tarchive = tarfile.open(filename)
+                to_extract = []
+                for member in tarchive.getmembers():
+                    # Check that file is a regular file (not a link, block device, etc.)
+                    if member.isfile():
+                        to_extract.append(member)
+                await aio_unpack_archive(filename, extraction_path, members=to_extract)
+
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here
             else:

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -81,19 +81,13 @@ class BaseExtractor:
             # Python 3.12 has a data filter we can use in extract
             # tarfile has this available in older versions as well
             if hasattr(tarfile, "data_filter"):
-                await aio_unpack_archive(filename, extraction_path, filter="data")
+                tarfile.extractall(filename, extraction_path, filter="data")  # nosec
+                # nosec line because bandit doesn't understand filters yet
 
             # FIXME: filter solution below doesn't work with windows paths
             # This is a temporary and unsafe measure so we can merge a partial fix
             elif sys.platform == "win32":
-                extraction_path_abs = PurePath(extraction_path).absolute()
-                tarchive = tarfile.open(filename)
-                to_extract = []
-                for member in tarchive.getmembers():
-                    # Check that file is a regular file (not a link, block device, etc.)
-                    if member.isfile():
-                        to_extract.append(member)
-                await aio_unpack_archive(filename, extraction_path, members=to_extract)
+                await aio_unpack_archive(filename, extraction_path)
 
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here
@@ -110,7 +104,7 @@ class BaseExtractor:
                     ).absolute().startswith(extraction_path_abs):
                         to_extract.append(member)
 
-                await aio_unpack_archive(filename, extraction_path, members=to_extract)
+                tarfile.extractal(filename, extraction_path, members=to_extract)
 
         return e.exit_code
 

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -99,7 +99,7 @@ class BaseExtractor:
 
             # FIXME: the backported fix is not working on windows.
             # this leaves the current (unsafe) behaviour so we can fix at least one OS for now
-            if sys.info == "win32":
+            if sys.platform == "win32":
                 tar.extractall(path=extraction_path)  # nosec
                 tar.close()
 

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -8,6 +8,7 @@ import itertools
 import re
 import shutil
 import sys
+import tarfile
 import tempfile
 from pathlib import Path
 
@@ -77,7 +78,28 @@ class BaseExtractor:
     async def extract_file_tar(filename, extraction_path):
         """Extract tar files"""
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
-            await aio_unpack_archive(filename, extraction_path, filter='data')
+            # Python 3.12 has a data filter we can use in extract
+            if sys.version_info >= (3, 12):
+                await aio_unpack_archive(filename, extraction_path, filter="data")
+
+            # Older versions need us to implement a filter
+            else:
+                tarchive = tarfile.open(filename)
+                to_extract = []
+                for member in tarchive.getmembers():
+                    # Skip links/symlinks entirely, make sure file will be exracted into expected path
+                    # (i.e. no absolute paths, no ../)
+                    if (
+                        not member.islink()
+                        and not member.issym()
+                        and (Path(extraction_path) / member.name).startswith(
+                            extraction_path
+                        )
+                    ):
+                        to_extract.append(member)
+
+                await aio_unpack_archive(filename, extraction_path, members=to_extract)
+
         return e.exit_code
 
     async def extract_file_rpm(self, filename, extraction_path):

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -97,6 +97,12 @@ class BaseExtractor:
                 tar.extractall(path=extraction_path, filter="data")  # nosec
                 # nosec line because bandit doesn't understand filters yet
 
+            # FIXME: the backported fix is not working on windows.
+            # this leaves the current (unsafe) behaviour so we can fix at least one OS for now
+            if sys.info == "win32":
+                tar.extractall(path=extraction_path)  # nosec
+                tar.close()
+
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here
             else:

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -77,7 +77,7 @@ class BaseExtractor:
     async def extract_file_tar(filename, extraction_path):
         """Extract tar files"""
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
-            await aio_unpack_archive(filename, extraction_path)
+            await aio_unpack_archive(filename, extraction_path, filter='data')
         return e.exit_code
 
     async def extract_file_rpm(self, filename, extraction_path):

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -108,7 +108,8 @@ class BaseExtractor:
                                 extraction_path,
                                 str(Path(member.name).resolve()).strip("/"),
                             )
-                        to_extract.append(member)
+
+                    to_extract.append(member)
 
                 tarfile.extractal(filename, extraction_path, members=to_extract)
 

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -90,15 +90,12 @@ class BaseExtractor:
                 tarchive = tarfile.open(filename)
                 to_extract = []
                 for member in tarchive.getmembers():
-                    # Skip links/symlinks entirely, make sure file will be exracted into expected path
+                    # Check that file is a regular file (not a link, block device, etc.)
+                    # and make sure file will be exracted into expected path
                     # (i.e. no absolute paths, no ../)
-                    if (
-                        not member.islink()
-                        and not member.issym()
-                        and PurePath(extraction_path, member.name)
-                        .absolute()
-                        .startswith(extraction_path_abs)
-                    ):
+                    if member.isfile() and PurePath(
+                        extraction_path, member.name
+                    ).absolute().startswith(extraction_path_abs):
                         to_extract.append(member)
 
                 await aio_unpack_archive(filename, extraction_path, members=to_extract)

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -99,9 +99,8 @@ class BaseExtractor:
 
             # FIXME: the backported fix is not working on windows.
             # this leaves the current (unsafe) behaviour so we can fix at least one OS for now
-            if sys.platform == "win32":
+            elif sys.platform == "win32":
                 tar.extractall(path=extraction_path)  # nosec
-                tar.close()
 
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
-from pathlib import Path
+from pathlib import Path, PurePath
 
 import zstandard
 from rpmfile.cli import main as rpmextract
@@ -94,7 +94,7 @@ class BaseExtractor:
                     if (
                         not member.islink()
                         and not member.issym()
-                        and (Path(extraction_path) / member.name).startswith(
+                        and PurePath(extraction_path, member.name).startswith(
                             extraction_path
                         )
                     ):

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -84,20 +84,21 @@ class BaseExtractor:
     async def extract_file_tar(self, filename, extraction_path):
         """Extract tar files"""
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
+            tar = tarfile.open(filename)
             # Python 3.12 has a data filter we can use in extract
             # tarfile has this available in older versions as well
             if hasattr(tarfile, "data_filter"):
-                tarfile.extractall(path=extraction_path, filter="data")  # nosec
+                tar.extractall(path=extraction_path, filter="data")  # nosec
                 # nosec line because bandit doesn't understand filters yet
 
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here
             else:
-                tarchive = tarfile.open(filename)
-                tarchive.extractall(
+                tar.extractall(
                     path=extraction_path,
-                    members=self.can_extract_tar(tarchive, extraction_path),
+                    members=self.can_extract_tar(tar, extraction_path),
                 )  # nosec
+            tar.close()
         return e.exit_code
 
     async def extract_file_rpm(self, filename, extraction_path):

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -86,6 +86,7 @@ class BaseExtractor:
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here
             else:
+                extraction_path_abs = PurePath(extraction_path).absolute()
                 tarchive = tarfile.open(filename)
                 to_extract = []
                 for member in tarchive.getmembers():
@@ -94,9 +95,9 @@ class BaseExtractor:
                     if (
                         not member.islink()
                         and not member.issym()
-                        and PurePath(extraction_path, member.name).startswith(
-                            extraction_path
-                        )
+                        and PurePath(extraction_path, member.name)
+                        .absolute()
+                        .startswith(extraction_path_abs)
                     ):
                         to_extract.append(member)
 

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -74,7 +74,10 @@ class BaseExtractor:
                 return True
         return False
 
-    async def can_extract_tar(self, members, extraction_path):
+    def tar_member_filter(self, members, extraction_path):
+        """Generator function to serve as a backported filter for tarfile extraction
+        based on https://docs.python.org/3/library/tarfile.html#examples
+        """
         for tarmember in members:
             if tarmember.isfile() and str(
                 Path(extraction_path, tarmember.name).resolve()
@@ -83,6 +86,9 @@ class BaseExtractor:
 
     async def extract_file_tar(self, filename, extraction_path):
         """Extract tar files"""
+
+        # make sure we have full path for later checks
+        extraction_path = str(Path(extraction_path).resolve())
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
             tar = tarfile.open(filename)
             # Python 3.12 has a data filter we can use in extract
@@ -96,7 +102,7 @@ class BaseExtractor:
             else:
                 tar.extractall(
                     path=extraction_path,
-                    members=self.can_extract_tar(tar, extraction_path),
+                    members=self.tar_member_filter(tar, extraction_path),
                 )  # nosec
             tar.close()
         return e.exit_code

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -92,16 +92,22 @@ class BaseExtractor:
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here
             else:
-                extraction_path_abs = PurePath(extraction_path).absolute()
+                extraction_path_abs = PurePath(extraction_path).resolve()
                 tarchive = tarfile.open(filename)
                 to_extract = []
                 for member in tarchive.getmembers():
                     # Check that file is a regular file (not a link, block device, etc.)
                     # and make sure file will be exracted into expected path
                     # (i.e. no absolute paths, no ../)
-                    if member.isfile() and PurePath(
-                        extraction_path, member.name
-                    ).absolute().startswith(extraction_path_abs):
+                    if member.isfile():
+                        if not Path(extraction_path, member.name).resolve.startsWith(
+                            extraction_path_abs
+                        ):
+                            # there was something problematic in that path so let's fix it
+                            member.name = Path(
+                                extraction_path,
+                                str(Path(member.name).resolve()).strip("/"),
+                            )
                         to_extract.append(member)
 
                 tarfile.extractal(filename, extraction_path, members=to_extract)

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -79,10 +79,12 @@ class BaseExtractor:
         """Extract tar files"""
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
             # Python 3.12 has a data filter we can use in extract
-            if sys.version_info >= (3, 12):
+            # tarfile has this available in older versions as well
+            if hasattr(tarfile, "data_filter"):
                 await aio_unpack_archive(filename, extraction_path, filter="data")
 
-            # Older versions need us to implement a filter
+            # Some versions may need us to implement a filter to avoid unsafe behaviour
+            # we could consider logging a warning here
             else:
                 tarchive = tarfile.open(filename)
                 to_extract = []

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -80,8 +80,8 @@ class BaseExtractor:
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
             # Python 3.12 has a data filter we can use in extract
             # tarfile has this available in older versions as well
-            if hasattr(tarfile, "data_filter"):
-                tarfile.extractall(filename, extraction_path, filter="data")  # nosec
+            if hasattr(tarfile, "tar_filter"):
+                tarfile.extractall(filename, extraction_path, filter="tar")  # nosec
                 # nosec line because bandit doesn't understand filters yet
 
             # FIXME: filter solution below doesn't work with windows paths

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -10,7 +10,7 @@ import shutil
 import sys
 import tarfile
 import tempfile
-from pathlib import Path, PurePath
+from pathlib import Path
 
 import zstandard
 from rpmfile.cli import main as rpmextract
@@ -74,45 +74,30 @@ class BaseExtractor:
                 return True
         return False
 
-    @staticmethod
-    async def extract_file_tar(filename, extraction_path):
+    async def can_extract_tar(self, members, extraction_path):
+        for tarmember in members:
+            if tarmember.isfile() and str(
+                Path(extraction_path, tarmember.name).resolve()
+            ).startsWith(extraction_path):
+                yield tarmember
+
+    async def extract_file_tar(self, filename, extraction_path):
         """Extract tar files"""
         with ErrorHandler(mode=ErrorMode.Ignore) as e:
             # Python 3.12 has a data filter we can use in extract
             # tarfile has this available in older versions as well
-            if hasattr(tarfile, "tar_filter"):
-                tarfile.extractall(filename, extraction_path, filter="tar")  # nosec
+            if hasattr(tarfile, "data_filter"):
+                tarfile.extractall(path=extraction_path, filter="data")  # nosec
                 # nosec line because bandit doesn't understand filters yet
-
-            # FIXME: filter solution below doesn't work with windows paths
-            # This is a temporary and unsafe measure so we can merge a partial fix
-            elif sys.platform == "win32":
-                await aio_unpack_archive(filename, extraction_path)
 
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here
             else:
-                extraction_path_abs = PurePath(extraction_path).resolve()
                 tarchive = tarfile.open(filename)
-                to_extract = []
-                for member in tarchive.getmembers():
-                    # Check that file is a regular file (not a link, block device, etc.)
-                    # and make sure file will be exracted into expected path
-                    # (i.e. no absolute paths, no ../)
-                    if member.isfile():
-                        if not Path(extraction_path, member.name).resolve.startsWith(
-                            extraction_path_abs
-                        ):
-                            # there was something problematic in that path so let's fix it
-                            member.name = Path(
-                                extraction_path,
-                                str(Path(member.name).resolve()).strip("/"),
-                            )
-
-                    to_extract.append(member)
-
-                tarfile.extractal(filename, extraction_path, members=to_extract)
-
+                tarchive.extractall(
+                    path=extraction_path,
+                    members=self.can_extract_tar(tarchive, extraction_path),
+                )  # nosec
         return e.exit_code
 
     async def extract_file_rpm(self, filename, extraction_path):


### PR DESCRIPTION
Had an external report that we weren't sufficiently careful when opening tarfiles because we're using Python's (insecure) default behaviour here.  That default *is* changed in python 3.12 but since we support 3.8-3.11 as well then we need a fix.  

This uses the file filters if available as recommended by the tarfile docs (it's not quite a `from __future__` but similar idea I think) and does a simple "skip symlinks and absolute paths" check if filters are not available.

Edit:
This is still missing
- test
- a fix that works in windows

I'm hoping we can merge what I have so we have mitigation on Linux in main, but those will definitely be coming in future PRs.  (The test would have been in this one but I'm feeling unwell so I'm sending it for code review while I won't be touching it for a bit.)