### PR TITLE
feat: Using tomllib instead of toml in python 3.11 and later deployments

### DIFF
--- a/cve_bin_tool/config.py
+++ b/cve_bin_tool/config.py
@@ -26,9 +26,8 @@ class ConfigParser:
     """
 
     config_data: Mapping[str, dict[str, dict[str, str | bool | int | list[str]]]]
-    """
-    Key-value pairs of config data, e.g., {"extract": True, "directory": "test/assets"}.
-    """
+
+    # Key-value pairs of config data, e.g., {"extract": True, "directory": "test/assets"}.
 
     def __init__(
         self,

--- a/cve_bin_tool/config.py
+++ b/cve_bin_tool/config.py
@@ -66,9 +66,13 @@ class ConfigParser:
             with ErrorHandler(mode=self.error_mode):
                 raise FileNotFoundError(self.filename)
         if self.filename.endswith(".toml"):
-            with open(self.filename) as f:
-                raw_config_data = toml.load(f)
-                self.config_data = ChainMap(*raw_config_data.values())
+            if sys.version_info >= (3, 11):
+                with open(self.filename, "rb") as f:
+                    raw_config_data = toml.load(f)
+            else:
+                with open(self.filename) as f:
+                    raw_config_data = toml.load(f)
+            self.config_data = ChainMap(*raw_config_data.values())
         elif self.filename.endswith(".yaml"):
             with open(self.filename) as f:
                 raw_config_data = yaml.safe_load(f)

--- a/cve_bin_tool/config.py
+++ b/cve_bin_tool/config.py
@@ -3,12 +3,17 @@
 
 from __future__ import annotations
 
+import sys
 from collections import ChainMap
 from logging import Logger
 from pathlib import Path
 from typing import Mapping
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib as toml
+else:
+    import toml
+
 import yaml
 
 from cve_bin_tool.error_handler import ErrorHandler, ErrorMode, UnknownConfigType
@@ -16,8 +21,14 @@ from cve_bin_tool.log import LOGGER
 
 
 class ConfigParser:
-    # Key-value pair of config data ex: {"extract": True, "directory": "test/assets"}
+    """
+    Parses configuration files in either TOML or YAML format.
+    """
+
     config_data: Mapping[str, dict[str, dict[str, str | bool | int | list[str]]]]
+    """
+    Key-value pairs of config data, e.g., {"extract": True, "directory": "test/assets"}.
+    """
 
     def __init__(
         self,
@@ -25,6 +36,14 @@ class ConfigParser:
         logger: Logger | None = None,
         error_mode=ErrorMode.TruncTrace,
     ):
+        """
+        Initializes the ConfigParser instance.
+
+        Args:
+            filename (str): The path to the configuration file.
+            logger (Logger, optional): The logger instance for logging messages.
+            error_mode (ErrorMode, optional): The mode for error handling during parsing.
+        """
         self.filename = str(Path(filename).resolve())
         self.logger = logger or LOGGER.getChild(self.__class__.__name__)
         self.error_mode = error_mode
@@ -33,6 +52,16 @@ class ConfigParser:
     def parse_config(
         self,
     ) -> Mapping[str, dict[str, dict[str, str | bool | int | list[str]]]]:
+        """
+        Parses the configuration file and returns the config data.
+
+        Returns:
+            Mapping[str, dict[str, dict[str, str | bool | int | list[str]]]]:
+                Key-value pairs of config data.
+        Raises:
+            FileNotFoundError: If the specified file is not found.
+            UnknownConfigType: If the file has an unsupported configuration type.
+        """
         if not Path(self.filename).is_file():
             with ErrorHandler(mode=self.error_mode):
                 raise FileNotFoundError(self.filename)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ pyyaml>=5.4
 requests
 rich
 rpmfile>=1.0.6
-toml
+toml; python_version < "3.11"
 urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
 xmlschema
 zstandard; python_version >= "3.4"


### PR DESCRIPTION
Closes #3777
Using the tomllib module for Python 3.11 and later deployments instead of the toml module. Also added some docstrings.