### PR TITLE
fix: handle is_symlink PermissionError

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -66,7 +66,10 @@ class BaseExtractor:
     def can_extract(self, filename):
         """Check if the filename is something we know how to extract"""
         # Do not try to extract symlinks
-        if Path(filename).is_symlink():
+        try:
+            if Path(filename).is_symlink():
+                return False
+        except PermissionError:
             return False
         for extension in itertools.chain(*self.file_extractors.values()):
             if filename.endswith(extension):

--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -274,18 +274,24 @@ class DirWalk:
         for root in roots:
             for dirpath, dirnames, filenames in os.walk(root):
                 # Filters
-                filenames[:] = [
-                    filename
-                    for filename in filenames
-                    if self.pattern_match(str(Path(dirpath) / filename), self.pattern)
-                    and not self.pattern_match(
-                        str(Path(dirpath) / filename), self.file_exclude_pattern
-                    )
-                    and not self.pattern_match(
-                        str(Path(dirpath) / filename), self.folder_exclude_pattern
-                    )
-                    and not (Path(dirpath) / filename).is_symlink()
-                ]
+                for filename in filenames:
+                    try:
+                        if (
+                            not self.pattern_match(
+                                str(Path(dirpath) / filename), self.pattern
+                            )
+                            or self.pattern_match(
+                                str(Path(dirpath) / filename), self.file_exclude_pattern
+                            )
+                            or self.pattern_match(
+                                str(Path(dirpath) / filename),
+                                self.folder_exclude_pattern,
+                            )
+                            or (Path(dirpath) / filename).is_symlink()
+                        ):
+                            filenames.remove(filename)
+                    except PermissionError:
+                        filenames.remove(filename)
                 dirnames[:] = [
                     dirname
                     for dirname in dirnames

--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -209,7 +209,10 @@ class VersionScanner:
         self.total_scanned_files += 1
 
         # Do not try to scan symlinks
-        if Path(filename).is_symlink():
+        try:
+            if Path(filename).is_symlink():
+                return None
+        except PermissionError:
             return None
 
         # Ensure filename is a file


### PR DESCRIPTION
`is_symlink` can return `PermissionError` exception so handle those thanks to try/except blocks.