### PR TITLE
docs: Add tip about python -m pytest #3816

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,7 +171,7 @@ We recommend that you switch to having a local install (e.g. run `pip install --
 
 The CVE Binary Tool has a set of tests that can be run using `pytest` command.  Typically you want to run `pytest` in the cve-bin-tool directory to run the short test suite and make sure tests pass.
 
-After running `pytest`, you may get several test failures relating to `ModuleNotFound` error. The main reason for this error is typically related to Python's module search path. You can run this command instead :
+After running `pytest`, you may get several test failures relating to `ModuleNotFound` error. If you have run `pip install -r dev-requirements.txt` or equivalent and are sure you have the required modules installed, your issue may be related to Python's module search path. You can run this command instead :
 
 ```bash
 python -m pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,13 +171,13 @@ We recommend that you switch to having a local install (e.g. run `pip install --
 
 The CVE Binary Tool has a set of tests that can be run using `pytest` command.  Typically you want to run `pytest` in the cve-bin-tool directory to run the short test suite and make sure tests pass.
 
-After running `pytest`, you may get several test failures relating to ModuleNotFound error. The main reason for this error is typically related to Python's module search path. You can this command instead :
+After running `pytest`, you may get several test failures relating to `ModuleNotFound` error. The main reason for this error is typically related to Python's module search path. You can run this command instead :
 
 ```bash
 python -m pytest
 ```
 
-When running `python -m pytest`, this bypasses potential issues with your system's PATH environment variable, potentially looking in the wrong directory for the dependencies.
+This bypasses potential issues with your system's PATH environment variable, potentially looking in the wrong directory for the dependencies.
 
 [There is a README file in the tests directory](https://github.com/intel/cve-bin-tool/blob/main/test/README.md) which contains more info about how to run specific tests, or how to run the longer tests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,6 +171,14 @@ We recommend that you switch to having a local install (e.g. run `pip install --
 
 The CVE Binary Tool has a set of tests that can be run using `pytest` command.  Typically you want to run `pytest` in the cve-bin-tool directory to run the short test suite and make sure tests pass.
 
+After running `pytest`, you may get several test failures relating to ModuleNotFound error. The main reason for this error is typically related to Python's module search path. You can this command instead :
+
+```bash
+python -m pytest
+```
+
+When running `python -m pytest`, this bypasses potential issues with your system's PATH environment variable, potentially looking in the wrong directory for the dependencies.
+
 [There is a README file in the tests directory](https://github.com/intel/cve-bin-tool/blob/main/test/README.md) which contains more info about how to run specific tests, or how to run the longer tests.
 
 We have done our best to make tests stable and ensure that they pass at all times, but occasionally tests may fail due to factors outside your control (common causes: internet connectivity, rate limiting by NVD or new vulnerability data changing our test expectations). If a test doesn't pass, you should look at it to see if any changes you made caused the failure.  If you're not sure, submit your code as a pull request and mention the issue and someone will try to help you sort it out.


### PR DESCRIPTION
On some systems or misconfigured virtual environment, running `python -m pytest` instead of `pytest` can avoid typical errors related to Python's module search path, issue #3816