### PR TITLE
docs: Added correct pip install command for virtual environments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,19 @@ CVE Binary Tool uses the installed egg file to figure out which checkers are ins
 python setup.py egg_info
 ```
 
-We recommend that you switch to having a local install (e.g. run `pip install --user -e .` in the main cve-bin-tool directory) to avoid this problem in the future.
+We recommend that you switch to having a local install to avoid this problem in the future. 
+
+Run the following in the main `cve-bin-tool` directory:
+
+### If not in a virtual environment
+```bash
+pip install --user -e .
+```
+
+### If in a virtual environment
+```bash
+pip install -e .
+```
 
 ## Running tests
 


### PR DESCRIPTION
So I was going through the dev documentation myself and saw that the command enlisted for the specific purpose of avoiding an eff-file downloading issue was not correctly executing, so according to the context, I fixed it by omitting the --user flag which is supposed to work only in non-virtual-env setups. 