### PR TITLE
fix: set default width for console output

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -768,6 +768,7 @@ class OutputEngine:
                 self.metrics,
                 self.all_product_data,
                 self.offline,
+                None,
                 outfile,
             )
 


### PR DESCRIPTION
Pass `width` parameter when writing console output to a file to avoid the following exception when running `cve-bin-tool -f console -o output` raised since commit ec4f10e4aa9d4bee0dddd8ffc0b896e331bec9a7:

```
│ /home/fabrice/cve-bin-tool/venv/lib/python3.11/site-packages/rich/console.py:1303 in render      │
│                                                                                                  │
│   1300 │   │   """                                                                               │
│   1301 │   │                                                                                     │
│   1302 │   │   _options = options or self.options                                                │
│ ❱ 1303 │   │   if _options.max_width < 1:                                                        │
│   1304 │   │   │   # No space to render anything. This prevents potential recursion errors.      │
│   1305 │   │   │   return                                                                        │
│   1306 │   │   render_iterable: RenderResult                                                     │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
TypeError: '<' not supported between instances of 'Console' and 'int'
```

Fixes: ec4f10e4aa9d4bee0dddd8ffc0b896e331bec9a7