### PR TITLE
test: correcting test_scan_multiline with respect to rpm parser

### DIFF
--- a/cve_bin_tool/helper_script.py
+++ b/cve_bin_tool/helper_script.py
@@ -98,7 +98,12 @@ class HelperScript:
 
         # if the file is ELF binary file, don't try to parse its filename or extract it
         if self.version_scanner.is_executable(filename)[0]:
-            return self.parse_execfile(filename)
+            matches = self.parse_execfile(filename)
+            if not self.multiline_pattern:
+                self.version_pattern = [
+                    x for x in self.version_pattern if "\\n" not in x
+                ]
+            return matches
         else:
             self.parse_filename(filename)
 

--- a/test/test_helper_script.py
+++ b/test/test_helper_script.py
@@ -161,7 +161,7 @@ class TestHelperScript:
         scan_files(args)
         out, _ = capfd.readouterr()
         out = out.split("VERSION_PATTERNS")[1]
-        assert "(?:(?:\\r?\\n.*?)*)" in out
+        assert "(?:(?:\\r?\\n.*?)*)" not in out
 
     # @pytest.mark.parametrize("filename", [
     #     "bash-4.2.46-34.el7.x86_64.abc" # unsupported file type


### PR DESCRIPTION
This PR considers that the RPM parser is added based on #2964. (so, first that PR should be merged and then this request)
PR #2964 fails due to inconsistency in the test for testing multiline capability in file `test/test_helper_script.py.` This PR applies changes to extract_and_parse_file functionality in file `cve_bin_tool/helper_script.py` to reuse the multiple tests.
Other details are in #3845 

Close #2916 