### PR TITLE
fix: improve bandit config #3830

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
     rev: 7.0.0
     hooks:
     - id: flake8
-      exclude: ^fuzz/generated/
+      exclude: ^fuzz/generated/|bandit\.conf$
 
 -   repo: https://github.com/PyCQA/bandit
     rev: 1.7.7

--- a/bandit.conf
+++ b/bandit.conf
@@ -82,14 +82,14 @@
 # B703 : django_mark_safe
 
 # (optional) list included test IDs here, eg '[B101, B406]':
-tests:
+#tests:
 
 # (optional) list skipped test IDs here, eg '[B101, B406]':
-skips: ['B603', 'B607', 'B404', "B608"]
+skips: ['B603', 'B607', 'B404']
 # B603, B607 and B404 are all subprocess-related.
 # B608 should be re-enabled when multi-line issues can be marked with nosec
 
-# Explantion: cve-bin-tool is at heart a shell script that calls other processes.
+# Explanation: cve-bin-tool is at heart a shell script that calls other processes.
 # Switching to pure python has significant performance impacts.
 
 # skips assert rule on tests
@@ -101,4 +101,3 @@ assert_used:
 ### set of sensible defaults and these will be used if no configuration is
 ### provided. It is not necessary to provide settings for every (or any) plugin
 ### if the defaults are acceptable.
-

--- a/cve_bin_tool/cve_scanner.py
+++ b/cve_bin_tool/cve_scanner.py
@@ -200,7 +200,7 @@ class CVEScanner:
                 FROM cve_severity
                 WHERE CVE_number IN ({",".join(["?"] * number_of_cves)}) AND score >= ? and description != "unknown"
                 ORDER BY CVE_number, last_modified DESC
-                """
+                """  # nosec
                 # Add score parameter to tuple listing CVEs to pass to query
                 result = self.cursor.execute(query, cve_list[start:end] + [self.score])
                 start = end

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -253,7 +253,7 @@ class CVEDB:
 
         self.LOGGER.debug("Check database is using latest schema")
         cursor = self.db_open_and_get_cursor()
-        schema_check = f"SELECT * FROM {table_name} WHERE 1=0"
+        schema_check = f"SELECT * FROM {table_name} WHERE 1=0"  # nosec
         result = cursor.execute(schema_check)
         schema_latest = False
 
@@ -865,7 +865,7 @@ class CVEDB:
         """Return JSON of all records in a database table."""
         cursor = self.db_open_and_get_cursor()
         cursor.row_factory = self.dict_factory
-        cursor.execute(f"SELECT * FROM '{table_name}' ")
+        cursor.execute(f"SELECT * FROM '{table_name}' ")  # nosec
         # fetchall as result
         results = cursor.fetchall()
         self.db_close()

--- a/cve_bin_tool/version_signature.py
+++ b/cve_bin_tool/version_signature.py
@@ -77,7 +77,7 @@ class VersionSignatureDb:
         update_required: bool = False
 
         datestamp = self.cursor.execute(
-            f"SELECT * FROM {self.update_table_name}"
+            f"SELECT * FROM {self.update_table_name}"  # nosec
         ).fetchone()  # update_table_name validated in __init__
 
         if datestamp and type(datestamp) is tuple:
@@ -93,18 +93,18 @@ class VersionSignatureDb:
             self.cursor.execute(f"DELETE FROM {self.table_name}")  # nosec
             self.cursor.execute(f"DELETE FROM {self.update_table_name}")  # nosec
             self.cursor.execute(
-                f"INSERT INTO {self.update_table_name} VALUES (?)",
+                f"INSERT INTO {self.update_table_name} VALUES (?)",  # nosec
                 (time.time(),),
             )
 
             for mapping in self.mapping_function():
                 self.cursor.execute(
-                    f"INSERT INTO {self.table_name} (version, sourceId) VALUES (?, ?)",
+                    f"INSERT INTO {self.table_name} (version, sourceId) VALUES (?, ?)",  # nosec
                     (mapping[0], mapping[1]),
                 )
 
         data = self.cursor.execute(
-            f"SELECT * FROM {self.table_name}"
+            f"SELECT * FROM {self.table_name}"  # nosec
         ).fetchall()  # table_name validated in __init__
 
         if self.conn is not None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 profile = black
 
 [flake8]
-exclude = build
+exclude = build, bandit.conf
 max-line-length = 88
 extend-ignore = E203, E501
 

--- a/test/test_cvedb.py
+++ b/test/test_cvedb.py
@@ -80,7 +80,7 @@ class TestCVEDB:
 
         for table in tables_to_check:
             cursor.execute(
-                f"SELECT name FROM sqlite_master WHERE type='table' AND name='{table}'"
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
             )
             result = cursor.fetchone()
             assert result is not None  # Assert that the table exists


### PR DESCRIPTION
fix: improve bandit config #3830

**Checklist:**

1. remove B608 from our skips list - ✅
2. run bandit with the new config file - ✅
3. Review any findings and mark reviewed findings with # nosec as needed (should just be a couple of SQL statements probably all in cvedb.py) - ✅
4. Spelling correction done in line-92 bandit.conf file. ✅

**Regarding the TASK 3:** (Findings of BANDIT in cvedb.py file)

![Bandit Findings](https://github.com/intel/cve-bin-tool/assets/90106559/5d7c6f19-363d-493a-a366-b2f45ed4554b)


**Line 256** - The table name is directly interpolated into the SQL query string, which can lead to SQL injection if the table name comes from an untrusted source. 
Severity: Medium
Confidence: Low

**CURRENT CODE:**

255        cursor = self.db_open_and_get_cursor()
256        schema_check = f"SELECT * FROM {table_name} WHERE 1=0"
257        result = cursor.execute(schema_check)

**PROPOSED SOLUTION:**
To fix this issue, you should use parameterized queries instead of directly interpolating user input into the SQL query string

255       cursor = self.db_open_and_get_cursor()
256       schema_check = "SELECT * FROM {} WHERE 1=0".format(table_name)
257       result = cursor.execute(schema_check)


Here, we are using placeholders `{}` in the SQL query string and use the `.format()` method to insert the `table_name` variable. This approach ensures that the `table_name` is treated as a parameter and properly escaped by the database library, mitigating the risk of SQL injection attacks.


**Line 868** - The issue arises from the interpolation of the `table_name` variable directly into the SQL query string using an f-string. This can potentially lead to SQL injection if the `table_name` variable contains unsanitized user input.
Severity: Medium   
Confidence: Medium

**CURRENT CODE:**

867             cursor.row_factory = self.dict_factory
868             cursor.execute(f"SELECT * FROM '{table_name}' ")
869             # fetchall as result

**PROPOSED CHANGES IN CODE:** 
To address this issue and prevent SQL injection, we need to use parameterized queries or prepared statements. Like the one below:

867             cursor.row_factory = self.dict_factory
868             cursor.execute("SELECT * FROM ?", (table_name,))
869             # fetchall as result
