### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ toml; python_version < "3.11"
 urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
 xmlschema
 zstandard; python_version >= "3.4"
+multidict


### PR DESCRIPTION
I was trying to install cve-bin-tool, and realised one module `multidict` was missing