### PR TITLE
refactor: tweak format of generated config comments

### DIFF
--- a/cve_bin_tool/config_generator.py
+++ b/cve_bin_tool/config_generator.py
@@ -68,9 +68,11 @@ class ConfigGenerator:
                             if arg_value in [True, False]
                             else arg_value
                         )
-                        f.write(f"  {arg_name} {sign} {arg_val}\n" f"  #{arg_help}\n\n")
+                        f.write(
+                            f"  # {arg_help}\n" f"  {arg_name} {sign} {arg_val}\n\n"
+                        )
                     elif arg_value is not None:
                         f.write(
-                            f"  {arg_name} {sign} {coma}{arg_value}{coma}\n"
-                            f"  #{arg_help}\n\n"
+                            f"  # {arg_help}\n"
+                            f"  {arg_name} {sign} {coma}{arg_value}{coma}\n\n"
                         )


### PR DESCRIPTION
As outlined in issue #3829 I've moved comments above the configuration options and added a space between # and the start of the comment.

Looking at bandit's configuration generator they also use `###` prior to the config header. Is this something you'd also like added?

Resolves #3829