### PR TITLE
refactor: convert ConfigGenerator class to config_generator function

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -39,7 +39,7 @@ from cve_bin_tool.available_fix import (
     get_backport_supported_distros,
 )
 from cve_bin_tool.config import ConfigParser
-from cve_bin_tool.config_generator import ConfigGenerator
+from cve_bin_tool.config_generator import config_generator
 from cve_bin_tool.cve_scanner import CVEScanner
 from cve_bin_tool.cvedb import CVEDB, OLD_CACHE_DIR
 from cve_bin_tool.data_sources import (
@@ -659,7 +659,7 @@ def main(argv=None):
         # current format includes .yaml and .toml
         for config_format in config_formats:
             LOGGER.debug(f"Arguments declared in generating config file {args}")
-            ConfigGenerator.config_generator(config_format, organized_arguments)
+            config_generator(config_format, organized_arguments)
 
         return 0
 

--- a/cve_bin_tool/config_generator.py
+++ b/cve_bin_tool/config_generator.py
@@ -3,7 +3,7 @@
 import json
 
 config_header = """
-# This is a generated configuration file from the CVE Binary Tool ConfigGenerator.
+# This is a generated configuration file from the CVE Binary Tool.
 # Exercise caution when editing. To generate a new config file, use --generate-config option.
 # For more info, refer to the official documentation at: https://cve-bin-tool.readthedocs.io/en/latest/.
 # If you support the project and wish to contribute, check the Contributor Guide:
@@ -12,67 +12,60 @@ config_header = """
 """
 
 
-class ConfigGenerator:
+def config_generator(config_format, organized_arguments):
     """
-    A class for generating configuration files in different formats.
+    Generate a configuration file in the specified format.
+
+    Args:
+        config_format (str): The format of the configuration file (".toml" or ".yaml").
+        organized_arguments (dict): A dictionary containing organized arguments.
+
+    Returns:
+        None
     """
-
-    def config_generator(config_format, organized_arguments):
-        """
-        Generate a configuration file in the specified format.
-
-        Args:
-            config_format (str): The format of the configuration file (".toml" or ".yaml").
-            organized_arguments (dict): A dictionary containing organized arguments.
-
-        Returns:
-            None
-        """
-        if config_format == "toml":
-            first_char = "["
-            last_char = "]"
-            sign = "="
-            coma = '"'
-        elif config_format == "yaml":
-            first_char = ""
-            last_char = ":"
-            sign = ":"
-            coma = ""
-        else:
-            return
-        with open(f"config.{config_format}", "w") as f:
-            f.write(f"{config_header}\n")
-            for group_title, group_args in organized_arguments.items():
-                if group_title == "positional_arguments":
-                    continue
-                group_title = group_title.lower()
-                if group_title == "output":
-                    if group_args["sbom-output"]["arg_value"] == "":
-                        group_args["sbom-type"]["arg_value"] = None
-                        group_args["sbom-format"]["arg_value"] = None
-                        group_args["sbom-output"]["arg_value"] = None
-                    if group_args["vex"]["arg_value"] == "":
-                        group_args["vex"]["arg_value"] = None
-                f.write(f"{first_char}{group_title}{last_char}\n")
-                for arg_name, arg_value_help in group_args.items():
-                    arg_value = arg_value_help["arg_value"]
-                    arg_help = arg_value_help["help"]
-                    arg_name = arg_name.replace("-", "_")
-                    if arg_name in ["config", "generate_config"]:
-                        arg_value = None
-                    if "\n" in arg_help:
-                        arg_help = arg_help.replace("\n", "  ")
-                    if arg_value in [True, False] or isinstance(arg_value, list):
-                        arg_val = (
-                            json.dumps(arg_value).lower()
-                            if arg_value in [True, False]
-                            else arg_value
-                        )
-                        f.write(
-                            f"  # {arg_help}\n" f"  {arg_name} {sign} {arg_val}\n\n"
-                        )
-                    elif arg_value is not None:
-                        f.write(
-                            f"  # {arg_help}\n"
-                            f"  {arg_name} {sign} {coma}{arg_value}{coma}\n\n"
-                        )
+    if config_format == "toml":
+        first_char = "["
+        last_char = "]"
+        sign = "="
+        coma = '"'
+    elif config_format == "yaml":
+        first_char = ""
+        last_char = ":"
+        sign = ":"
+        coma = ""
+    else:
+        return
+    with open(f"config.{config_format}", "w") as f:
+        f.write(f"{config_header}\n")
+        for group_title, group_args in organized_arguments.items():
+            if group_title == "positional_arguments":
+                continue
+            group_title = group_title.lower()
+            if group_title == "output":
+                if group_args["sbom-output"]["arg_value"] == "":
+                    group_args["sbom-type"]["arg_value"] = None
+                    group_args["sbom-format"]["arg_value"] = None
+                    group_args["sbom-output"]["arg_value"] = None
+                if group_args["vex"]["arg_value"] == "":
+                    group_args["vex"]["arg_value"] = None
+            f.write(f"{first_char}{group_title}{last_char}\n")
+            for arg_name, arg_value_help in group_args.items():
+                arg_value = arg_value_help["arg_value"]
+                arg_help = arg_value_help["help"]
+                arg_name = arg_name.replace("-", "_")
+                if arg_name in ["config", "generate_config"]:
+                    arg_value = None
+                if "\n" in arg_help:
+                    arg_help = arg_help.replace("\n", "  ")
+                if arg_value in [True, False] or isinstance(arg_value, list):
+                    arg_val = (
+                        json.dumps(arg_value).lower()
+                        if arg_value in [True, False]
+                        else arg_value
+                    )
+                    f.write(f"  # {arg_help}\n" f"  {arg_name} {sign} {arg_val}\n\n")
+                elif arg_value is not None:
+                    f.write(
+                        f"  # {arg_help}\n"
+                        f"  {arg_name} {sign} {coma}{arg_value}{coma}\n\n"
+                    )


### PR DESCRIPTION
The ConfigGenerator class contains the config_generator method. Currently config_generator isn't decorated as a class or static method and the signature doesn't contain 'self'. This has the potential to create issues in the future if an instance of the ConfigGenerator class is instantiated or the method requires access to class attributes.

This commit refactors the ConfigGenerator class into a function named config_generator. A standalone function was chosen over a method decorator as the ConfigGenerator class maintained no state and contained a single method. This change removes the potential issues highlighted above and simplifies the code structure to meet current requirements.

fixes: #3941