### PR TITLE
fix: handle None for make_http_requests

### DIFF
--- a/cve_bin_tool/output_engine/util.py
+++ b/cve_bin_tool/output_engine/util.py
@@ -77,7 +77,7 @@ def get_latest_upstream_stable_version(product_info: ProductInfo) -> str:
     )
 
     jsonResponse = make_http_requests("json", url=url, timeout=300)
-    if jsonResponse["total_items"] != 0:
+    if jsonResponse is not None and jsonResponse["total_items"] != 0:
         latest_stable_version = jsonResponse["items"][0]["stable_version"]
 
     return latest_stable_version


### PR DESCRIPTION
If network is unavailable, `make_http_requests` will return `None` so it must be checked before calling `jsonResponse["total_items"]`