### PR TITLE
feat: add fix to prevent unknown vendor overwrite

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -941,7 +941,7 @@ class OutputEngine:
             my_package.initialise()
             my_package.set_name(product_data.product)
             my_package.set_version(product_data.version)
-            if product_data.vendor != "UNKNOWN" and product_data != "unknown":
+            if product_data.vendor != "UNKNOWN":
                 my_package.set_supplier("Organization", product_data.vendor)
             my_package.set_licensedeclared(license)
             my_package.set_licenseconcluded(license)

--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -945,6 +945,8 @@ class OutputEngine:
                 my_package.set_supplier("Organization", product_data.vendor)
             my_package.set_licensedeclared(license)
             my_package.set_licenseconcluded(license)
+            if (my_package.get_name(), my_package.get_value("version")) in sbom_packages and product_data.vendor == "unknown":
+                continue
             sbom_packages[(my_package.get_name(), my_package.get_value("version"))] = (
                 my_package.get_package()
             )

--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -941,15 +941,18 @@ class OutputEngine:
             my_package.initialise()
             my_package.set_name(product_data.product)
             my_package.set_version(product_data.version)
-            if product_data.vendor != "UNKNOWN":
+            if product_data.vendor != "UNKNOWN" and product_data != "unknown":
                 my_package.set_supplier("Organization", product_data.vendor)
             my_package.set_licensedeclared(license)
             my_package.set_licenseconcluded(license)
-            if (my_package.get_name(), my_package.get_value("version")) in sbom_packages and product_data.vendor == "unknown":
-                continue
-            sbom_packages[(my_package.get_name(), my_package.get_value("version"))] = (
-                my_package.get_package()
-            )
+            if not (
+                (my_package.get_name(), my_package.get_value("version"))
+                in sbom_packages
+                and product_data.vendor == "unknown"
+            ):
+                sbom_packages[
+                    (my_package.get_name(), my_package.get_value("version"))
+                ] = my_package.get_package()
             sbom_relationship.initialise()
             sbom_relationship.set_relationship(
                 root_package, "DEPENDS_ON", product_data.product


### PR DESCRIPTION
add fix in init.py for output_engine to prevent unknown vendor overwrite when sbom is generated for packages with same version and name