### PR TITLE
fix: improve windows tarfile extraction

### DIFF
--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -139,9 +139,27 @@ class BaseExtractor:
                 # nosec line because bandit doesn't understand filters yet
 
             elif sys.platform == "win32":
-                # use unsafe extraction for now, fix will come in separate PR
-                with tarfile.open(filename) as tar:
-                    tar.extractall(path=extraction_path)  # nosec - fix in progress
+                # backported path filter (below) doesn't work on windows,
+                # use external tar or 7z if available
+                if await aio_inpath("tar"):
+                    # windows tar (bsdtar) removes / by default
+                    stdout, stderr, _ = await aio_run_command(
+                        ["tar", "-x", "-C", extraction_path, "-f", filename]
+                    )
+                    if stderr:
+                        self.logger.error("**********Extraction failed: {stderr}")
+                elif await aio_inpath("7z"):
+                    # `7z e` is extract without full paths
+                    stdout, stderr, _ = await aio_run_command(
+                        ["7z", "e", filename, f"-o{extraction_path}"]
+                    )
+                    if stderr:
+                        self.logger.error("**********Extraction failed: {stderr}")
+                else:
+                    # Fail and suggest upgrade to python 3.12
+                    self.logger.error(
+                        f"Unable to extract {filename} safely, please upgrade to python 3.12"
+                    )
 
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here


### PR DESCRIPTION
This switches windows to use system tar or 7zip if available for safer tarfile extraction.

My expectation is that this PR will fail to pass tests around 98% same as we saw in #3849 , I just decided it was cleaner to make a PR with only the windows related changes.