### PR TITLE
fix: fix symlink handling

### DIFF
--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -306,6 +306,7 @@ class DirWalk:
         for root in roots:
             for dirpath, dirnames, filenames in os.walk(root):
                 # Filters
+                filtered_filenames = filenames.copy()
                 for filename in filenames:
                     try:
                         if (
@@ -321,9 +322,9 @@ class DirWalk:
                             )
                             or (Path(dirpath) / filename).is_symlink()
                         ):
-                            filenames.remove(filename)
+                            filtered_filenames.remove(filename)
                     except PermissionError:
-                        filenames.remove(filename)
+                        filtered_filenames.remove(filename)
                 dirnames[:] = [
                     dirname
                     for dirname in dirnames
@@ -336,7 +337,7 @@ class DirWalk:
                 ]
                 # Yields
                 if self.yield_files:
-                    for filename in filenames:
+                    for filename in filtered_filenames:
                         yield str((Path(dirpath) / filename).resolve())
                 if self.yield_folders:
                     for dirname in dirnames:


### PR DESCRIPTION
Fix symlink handling added by commit f13f559b8707cfa62c674ba414aa4b4f0c1888ad: if one of the file is a link, `filenames` list will be updated resulting in the loop ending before all links are removed. To avoid this issue, make a copy of `filenames` in `filtered_filenames`.