### PR TITLE
feat: added PURL generation to JavaParser

### DIFF
--- a/cve_bin_tool/parsers/java.py
+++ b/cve_bin_tool/parsers/java.py
@@ -1,5 +1,7 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
+"""Script containing all functionalities relating to parsing of Java-based files."""
+import re
 
 import defusedxml.ElementTree as ET
 
@@ -9,9 +11,33 @@ from cve_bin_tool.validator import validate_pom
 
 
 class JavaParser(Parser):
+    """Class to handle parsing Java-based Packages."""
+
     def __init__(self, cve_db, logger, validate=True):
         super().__init__(cve_db, logger)
         self.validate = validate
+        self.purl_pkg_type = "maven"
+
+    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+        """Generates PURL after normalizing all components of a Maven package."""
+        # Normalize product, version, and vendor
+        product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
+        version = re.sub(r"[^a-zA-Z0-9.+\-A-Z]", "", version)
+
+        vendor = re.sub(r"[^a-zA-Z0-9._-]", "", vendor).lower() if vendor else "UNKNOWN"
+
+        if not product or not version:
+            return None
+
+        purl = super().generate_purl(
+            product,
+            version,
+            vendor,
+            qualifier,
+            subpath,
+        )
+
+        return purl
 
     def find_vendor(self, product, version):
         """Find vendor for Java product"""

--- a/cve_bin_tool/parsers/java.py
+++ b/cve_bin_tool/parsers/java.py
@@ -22,7 +22,8 @@ class JavaParser(Parser):
         """Generates PURL after normalizing all components of a Maven package."""
         # Normalize product, version, and vendor
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
-        version = re.sub(r"[^a-zA-Z0-9.+\-A-Z]", "", version)
+        version = re.sub(r"[^a-zA-Z0-9.+\-]", "", version)
+
 
         vendor = re.sub(r"[^a-zA-Z0-9._-]", "", vendor).lower() if vendor else "UNKNOWN"
 

--- a/cve_bin_tool/parsers/java.py
+++ b/cve_bin_tool/parsers/java.py
@@ -24,7 +24,6 @@ class JavaParser(Parser):
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
         version = re.sub(r"[^a-zA-Z0-9.+\-]", "", version)
 
-
         vendor = re.sub(r"[^a-zA-Z0-9._-]", "", vendor).lower() if vendor else "UNKNOWN"
 
         if not product or not version:


### PR DESCRIPTION
Part of #3771 Step-1.

The regular expression used for normalizing `version` is not the standard one we would use for Maven. Instead, I modified it a bit so that it includes also includes some specific characters like `1.0-SNAPSHOT`.

However, I think we would still need to adjust some more edge cases as we work more with PURLs in the future.

cc @terriko @anthonyharrison 