### PR TITLE
feat: update regex in python checker to match python3.11-3.11.x pattern

### DIFF
--- a/cve_bin_tool/checkers/python.py
+++ b/cve_bin_tool/checkers/python.py
@@ -19,7 +19,7 @@ class PythonChecker(Checker):
     ]
     FILENAME_PATTERNS = [r"python"]
     VERSION_PATTERNS = [
-        r"python(?:[23]+\.[0-9])-([23]+\.[0-9]+\.[0-9]+)",
+        r"python(?:[23]+\.[0-9]+)-([23]+\.[0-9]+\.[0-9]+)",
         r"pymalloc_debug\r?\n([23]+\.[0-9]+\.[0-9]+)",
         r"([23]+\.[0-9]+\.[0-9]+)\r?\nPython %s",
         r"([23]+\.[0-9]+\.[0-9]+)\r?\n%\.80s \(%\.80s\) %\.80s",


### PR DESCRIPTION
Version patterns in python checker right now does not match with a pattern such as `python3.11-3.11.x` so added special character `+` to allow for that.