### PR TITLE
fix: windows needs python3.12 for tarfile support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -377,84 +377,6 @@ jobs:
           pytest -v
           test/test_json.py
 
-  windows_tests:
-    name: Windows tests
-    if: |
-      ! github.event.pull_request.user.login == 'github-actions[bot]' ||
-      ! (
-        startsWith(github.head_ref, 'chore-sbom-py') ||
-        contains(
-          fromJSON('["chore-update-table","chore-precommit-config","chore-spdx-header"]'),
-          github.head_ref
-        )
-      )
-    runs-on: windows-latest
-    timeout-minutes: 90
-    env:
-      NO_EXIT_CVE_NUM: 1
-      PYTHONIOENCODING: 'utf8'
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
-        with:
-          python-version: '3.10'
-          cache: 'pip'
-      - name: Get date
-        id: get-date
-        run: |
-          echo "DATE=$(get-date -format "yyyyMMdd")" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-          echo "YESTERDAY=$(get-date (get-date).addDays(-1)  -format "yyyyMMdd")" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
-      - name: Print Cache Keys
-        run: |
-          echo "Today's Cache Key: Linux-cve-bin-tool-${{ steps.get-date.outputs.DATE }}"
-          echo "Yesterday's Cache Key: Linux-cve-bin-tool-${{ steps.get-date.outputs.YESTERDAY }}"
-      - name: Get today's cached database
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        id: todays-cache
-        with:
-          path: cache
-          key: Linux-cve-bin-tool-${{ steps.get-date.outputs.DATE }}
-          enableCrossOsArchive: true
-      - name: Get yesterday's cached database if today's is not available
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        if: steps.todays-cache.outputs.cache-hit != 'true'
-        with:
-          path: cache
-          key: Linux-cve-bin-tool-${{ steps.get-date.outputs.YESTERDAY }}
-          enableCrossOsArchive: true
-      - name: Move cache to ~/.cache/cve-bin-tool
-        run: |
-          mkdir '~\.cache'
-          if (Test-Path -Path cache) { mv cache '~\.cache\cve-bin-tool' }
-      - name: Install cve-bin-tool
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools
-          python -m pip install --upgrade wheel
-          python -m pip install --upgrade -r dev-requirements.txt
-          python -m pip install --upgrade .
-      - name: Try single CLI run of tool
-        run: |
-          python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out
-      - name: Run async tests
-        run: >
-          pytest -n 4 -v
-          --ignore=test/test_cli.py
-          --ignore=test/test_cvedb.py
-          --ignore=test/test_requirements.py
-          --ignore=test/test_html.py
-          --ignore=test/test_json.py
-      - name: Run synchronous tests
-        run: >
-          pytest -v
-          test/test_cli.py
-          test/test_cvedb.py
-
   windows_long_tests:
     name: Windows long tests
     if: |
@@ -481,7 +403,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@0a5c61591373683505ea898e09a3ea4f39ef2b9c # v5.0.0
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           cache: 'pip'
       - name: Get date
         id: get-date

--- a/cve_bin_tool/extractor.py
+++ b/cve_bin_tool/extractor.py
@@ -30,7 +30,13 @@ from cve_bin_tool.async_utils import (
     run_coroutine,
 )
 
-from .error_handler import ErrorHandler, ErrorMode, ExtractionFailed, UnknownArchiveType
+from .error_handler import (
+    ErrorHandler,
+    ErrorMode,
+    ExtractionFailed,
+    ExtractionToolNotFound,
+    UnknownArchiveType,
+)
 from .log import LOGGER
 
 # Run rpmfile in a thread
@@ -139,9 +145,13 @@ class BaseExtractor:
                 # nosec line because bandit doesn't understand filters yet
 
             elif sys.platform == "win32":
-                # use unsafe extraction for now, fix will come in separate PR
-                with tarfile.open(filename) as tar:
-                    tar.extractall(path=extraction_path)  # nosec - fix in progress
+                # Windows users must use python 3.12 or later because the
+                # workaround below fails on windows
+                # Patches welcome if you can fix this!
+                self.logger.error(
+                    "Install python 3.12 or later to support tarfile extraction"
+                )
+                return ExtractionToolNotFound
 
             # Some versions may need us to implement a filter to avoid unsafe behaviour
             # we could consider logging a warning here


### PR DESCRIPTION
I have been unable to find a sufficently good safe tar workaround on windows when python < 3.12, so I'm disabling support.

- windows users will get an error message asking them to install python 3.12 if they try to extract a tarfile
- Since most of our tests use tar files, there is no point in running tests on windows on older versions of python.  I have changed windows_longtests to use python 3.12 and have disabled testing on other versions of python
- effectively this means we only support windows users using python 3.12 going forwards, although we aren't going to stop users from trying to use it.  If you're not scanning tarfiles, things will probably still work, we just don't have a way to test reliably.

I don't like this solution, but I haven't been able to find a better workaround.  Help is very much welcome if anyone's got a better idea of how to handle this.

BREAKING CHANGE: windows users must use python 3.12 if they want tarfile support