### PR TITLE
fix: cpe validation and standardize tests data

### DIFF
--- a/cve_bin_tool/sbom_manager/__init__.py
+++ b/cve_bin_tool/sbom_manager/__init__.py
@@ -179,19 +179,29 @@ class SBOMManager:
             vendorlist.append("UNKNOWN")
         return vendorlist
 
-    def is_valid_purl(self, purl_string: str):
+    def is_valid_string(self, string_type: str, ref_string: str) -> bool:
         """
-        Validate the PURL string is the correct form.
+        Validate the PURL, CPE string is the correct form.
 
         Args:
-        - purl_string (str): Package URL string
+        - ref_string (str): PURL, CPE strings
+        - string_type (str): ref_string type. (purl, cpe22 or cpe23)
 
         Returns:
-        - bool: True if the purl_string parameter is a valid purl string, False otherwise.
+        - bool: True if the ref_string parameter is a valid purl or cpe string, False otherwise.
 
         """
-        purl_pattern = r"^(?P<scheme>.+):(?P<type>.+)/(?P<namespace>.+)/(?P<name>.+)@(?P<version>.+)\??(?P<qualifiers>.*)#?(?P<subpath>.*)$"
-        return re.match(purl_pattern, purl_string) is not None
+        string_pattern: str
+        if string_type == "purl":
+            string_pattern = r"^(?P<scheme>.+):(?P<type>.+)/(?P<namespace>.+)/(?P<name>.+)@(?P<version>.+)\??(?P<qualifiers>.*)#?(?P<subpath>.*)$"
+
+        elif string_type == "cpe23":
+            string_pattern = r"^cpe:2\.3:[aho\*\-](:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?\!\"#\$%&'\(\)\+,\-\.\/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){5}(:(([a-zA-Z]{2,3}(-([a-zA-Z]{2}|[0-9]{3}))?)|[\*\-]))(:(((\?*|\*?)([a-zA-Z0-9\-\._]|(\\[\\\*\?\!\"#\$%&'\(\)\+,\-\.\/:;<=>@\[\]\^`\{\|}~]))+(\?*|\*?))|[\*\-])){4}"
+
+        elif string_type == "cpe22":
+            string_pattern = r"^[c][pP][eE]:/[AHOaho]?(:[A-Za-z0-9\._\-~%]*){0,6}"
+
+        return re.match(string_pattern, ref_string) is not None
 
     def parse_sbom(self) -> [(str, str, str)]:
         """
@@ -271,14 +281,16 @@ class SBOMManager:
         """
         decoded = {}
         for ref in ext_ref:
-            if ref[1] == "cpe23Type":
-                decoded["cpe23Type"] = self.decode_cpe23(ref[2])
+            ref_type = ref[1]
+            ref_string = ref[2]
+            if ref_type == "cpe23Type" and self.is_valid_string("cpe23", ref_string):
+                decoded["cpe23Type"] = self.decode_cpe23(ref_string)
 
-            elif ref[1] == "cpe22Type":
-                decoded["cpe22Type"] = self.decode_cpe22(ref[2])
+            elif ref_type == "cpe22Type" and self.is_valid_string("cpe22", ref_string):
+                decoded["cpe22Type"] = self.decode_cpe22(ref_string)
 
-            elif ref[1] == "purl":
-                decoded["purl"] = self.decode_purl(ref[2])
+            elif ref_type == "purl" and self.is_valid_string("purl", ref_string):
+                decoded["purl"] = self.decode_purl(ref_string)
 
         # No ext-ref matches, return none
         return decoded.get(
@@ -298,6 +310,7 @@ class SBOMManager:
           information extracted from the CPE 2.2 string, or None if the information is incomplete.
 
         """
+
         cpe = cpe22.split(":")
         vendor, product, version = cpe[2], cpe[3], cpe[4]
         # Return available data, convert empty fields to None
@@ -315,6 +328,7 @@ class SBOMManager:
           information extracted from the CPE 2.3 string, or None if the information is incomplete.
 
         """
+
         cpe = cpe23.split(":")
         vendor, product, version = cpe[3], cpe[4], cpe[5]
         # Return available data, convert empty fields to None
@@ -335,10 +349,9 @@ class SBOMManager:
         vendor = None  # Because the vendor and product identifiers in the purl don't always align
         product = None  # with the CVE DB, only the version is parsed.
         version = None
-        if self.is_valid_purl(purl):
-            # Process purl identifier
-            purl_info = PackageURL.from_string(purl).to_dict()
-            version = purl_info.get("version")
+        # Process purl identifier
+        purl_info = PackageURL.from_string(purl).to_dict()
+        version = purl_info.get("version")
 
         return [vendor or None, product or None, version or None]
 

--- a/test/sbom/cyclonedx_bad_cpe22.json
+++ b/test/sbom/cyclonedx_bad_cpe22.json
@@ -35,7 +35,7 @@
       "supplier": {
         "name": "ijg"
       },
-      "cpe": "cpe:/a::libjpeg:8b"
+      "cpe": "cpe:::libjpeg:8b"
     },
     {
       "type": "library",
@@ -45,7 +45,7 @@
       "supplier": {
         "name": "libexpat project"
       },
-      "cpe": "cpe:/a:libexpat_project::2.0.1"
+      "cpe": "cpe::libexpat_project::2.0.1"
     },
     {
       "type": "library",
@@ -55,7 +55,7 @@
       "supplier": {
         "name": "gnu"
       },
-      "cpe": "cpe:/a:gnu:ncurses:"
+      "cpe": "cpe::gnu:ncurses:"
     },
     {
       "type": "library",

--- a/test/sbom/cyclonedx_bad_purl.json
+++ b/test/sbom/cyclonedx_bad_purl.json
@@ -30,7 +30,7 @@
     {
       "type": "library",
       "bom-ref": "2-libjpeg",
-      "name": "libjpeg",
+      "name": "libjpeg-novendor",
       "version": "8b",
       "supplier": {
         "name": "ijg"
@@ -50,7 +50,7 @@
     {
       "type": "library",
       "bom-ref": "4-ncurses",
-      "name": "ncurses",
+      "name": "ncurses-noversion",
       "version": "5.9.noversion",
       "supplier": {
         "name": "gnu"

--- a/test/test_sbom.py
+++ b/test/test_sbom.py
@@ -43,15 +43,12 @@ class TestSBOM:
     ]
 
     PARSED_BAD_SBOM_DATA = [
-        # Unknown vendor has multiple results
-        ProductInfo(vendor="ijg", product="libjpeg", version="8b"),
-        ProductInfo(vendor="unknown", product="libjpeg", version="8b"),
-        ProductInfo(vendor="jpeg", product="libjpeg", version="8b"),
-        ProductInfo(vendor="libjpeg_project", product="libjpeg", version="8b"),
-        # Unknown project pulls the product name from the SBOM
+        ProductInfo(vendor="UNKNOWN", product="libjpeg-novendor", version="8b"),
         ProductInfo(vendor="libexpat_project", product="libexpat", version="2.0.1"),
-        # Unknown version pulls the version number from the SBOM
-        ProductInfo(vendor="gnu", product="ncurses", version="5.9.noversion"),
+        ProductInfo(
+            vendor="UNKNOWN", product="ncurses-noversion", version="5.9.noversion"
+        ),
+        ProductInfo(vendor="zlib", product="zlib", version="1.2.3"),
     ]
     PARSED_EXT_REF_PRIORITY_SBOM_DATA = [
         ProductInfo(vendor="ijg", product="libjpeg", version="8b"),


### PR DESCRIPTION
fixes: #4013

- the cpe22 specification regex is too much flexble so in order to test bad cpe22 test data is tweaked.
- validation is refactored to happen in one function

References:
[cpe2.3 and cpe2.3 schema](https://csrc.nist.gov/schema/cpe/2.3/cpe-naming_2.3.xsd)