### PR TITLE
feat: add fix to allow detection of python3.11 on DLL file

### DIFF
--- a/cve_bin_tool/checkers/python.py
+++ b/cve_bin_tool/checkers/python.py
@@ -23,5 +23,6 @@ class PythonChecker(Checker):
         r"pymalloc_debug\r?\n([23]+\.[0-9]+\.[0-9]+)",
         r"([23]+\.[0-9]+\.[0-9]+)\r?\nPython %s",
         r"([23]+\.[0-9]+\.[0-9]+)\r?\n%\.80s \(%\.80s\) %\.80s",
+        r"tags/v([23]+\.[0-9]+\.[0-9]+)\r?\nversion_info",
     ]
     VENDOR_PRODUCT = [("python_software_foundation", "python"), ("python", "python")]


### PR DESCRIPTION
Fixes this issue: https://github.com/intel/cve-bin-tool/issues/4003

The current tool is not able to detect python3.11 on a python3 DLL file due to the fact that its version pattern does not match any existing pattern in `checkers/python.py`. I added `r"tags/v([23]+\.[0-9]+\.[0-9]+)\r?\nversion_info"` as a version pattern since this is the unique way that the DLL displays the python version.