### PR TITLE
chore: set dev version number

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -8,7 +8,7 @@ from packaging import version
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.util import make_http_requests
 
-VERSION: str = "3.3"
+VERSION: str = "3.3.1dev0"
 
 HTTP_HEADERS: dict = {
     "User-Agent": f"cve-bin-tool/{VERSION} (https://github.com/intel/cve-bin-tool/)",


### PR DESCRIPTION
Setting a dev version number of 3.3.1dev0 just to help people distinguish git main from the released version before we diverge too much in behaviour.