### PR TITLE
fix: fix symlink handling

### DIFF
--- a/cve_bin_tool/util.py
+++ b/cve_bin_tool/util.py
@@ -364,7 +364,7 @@ class DirWalk:
         for root in roots:
             for dirpath, dirnames, filenames in os.walk(root):
                 # Filters
-                for filename in filenames:
+                for filename in filenames.copy():
                     try:
                         if (
                             not self.pattern_match(


### PR DESCRIPTION
Fix symlink handling added by commit f13f559b8707cfa62c674ba414aa4b4f0c1888ad: if one of the file is a link, filenames list will be updated resulting in the loop ending before all links are removed. To avoid this issue, loop on a copy of filenames.