### PR TITLE
fix: update binutils pattern

### DIFF
--- a/cve_bin_tool/checkers/binutils.py
+++ b/cve_bin_tool/checkers/binutils.py
@@ -80,7 +80,7 @@ class BinutilsChecker(Checker):
         r"ld.bfd",  # as seen on ubuntu
     ]
     VERSION_PATTERNS = [
-        r"GNU Binutils[a-zA-Z ]*\) ((\d+\.)*\d+)",
-        r"BFD header file version %s\r?\nversion ((\d+\.)*\d+)",
+        r"GNU Binutils[a-zA-Z ]*\) ([0-9]+\.[0-9]+\.?[0-9]*)",
+        r"BFD header file version %s\r?\nversion ([0-9]+\.[0-9]+\.?[0-9]*)",
     ]
     VENDOR_PRODUCT = [("gnu", "binutils")]


### PR DESCRIPTION
Fix binutils pattern to return `2.32.0` instead of `2.32.0.20190204` from the following string:

`Linux version 4.14.206-perf (oe-user@oe-host) (clang version 6.0.9 for Android NDK, GNU ld (GNU Binutils) 2.32.0.20190204) #1 PREEMPT Mon Jan 29 09:57:30 UTC 2024`