### PR TITLE
ci: reduce dependabot scan frequency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,17 +6,12 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
-  - package-ecosystem: pip
-    directory: /doc
+  - package-ecosystem: "pip"
+    directory: "/"
     schedule:
-      interval: daily
-
-  - package-ecosystem: pip
-    directory: /
-    schedule:
-      interval: daily
+      interval: "weekly"
 
 # Scanning is disabled for files in /test/ to avoid false positives.
 # These files are used for testing; vulnerable code is never installed or used.


### PR DESCRIPTION
This changes our dependabot scan frequency to weekly insead of daily in order to limit the amount of "noise" generated by daily automated PRs. We could consider switching to monthly if weekly isn't enough reduction.

I've also removed the /doc section in hopes of eliminating the duplicate PRs we get on doc requirements.