### PR TITLE
fix: add additional ppp CPE ID

### DIFF
--- a/cve_bin_tool/checkers/ppp.py
+++ b/cve_bin_tool/checkers/ppp.py
@@ -5,6 +5,7 @@
 """
 CVE checker for point-to-point_protocol
 
+https://www.cvedetails.com/product/2091/Samba-PPP.html?vendor_id=102
 https://www.cvedetails.com/product/61854/Point-to-point-Protocol-Project-Point-to-point-Protocol.html?vendor_id=20961
 
 """
@@ -21,4 +22,7 @@ class PppChecker(Checker):
         r"pppd[a-z, :%\)]*\r?\n([0-9]+\.[0-9]+\.[0-9]+)",
         r"([0-9]+\.[0-9]+\.[0-9]+)\r?\npppd",
     ]
-    VENDOR_PRODUCT = [("point-to-point_protocol_project", "point-to-point_protocol")]
+    VENDOR_PRODUCT = [
+        ("point-to-point_protocol_project", "point-to-point_protocol"),
+        ("samba", "ppp"),
+    ]


### PR DESCRIPTION
samba:ppp is also a valid CPE ID:
https://nvd.nist.gov/products/cpe/search/results?keyword=cpe:2.3:a:samba:ppp