### PR TITLE
feat: upload slsa to github on testing ci build job

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -489,6 +489,7 @@ jobs:
           fail_ci_if_error: false
 
   build:
+    name: Build wheel
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -501,6 +501,9 @@ jobs:
         python-version:
         - "3.12"
     steps:
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel build
     - name: Build
       run: |
         python -m build .

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -503,13 +503,6 @@ jobs:
     - name: Build
       run: |
         python -m build .
-    - name: Generate SBOM
-      id: generate-sbom
-      uses: anthonyharrison/sbom4python@5b458354df89357bf0253e62ea4567b1807120e2
-      with:
-        python-version: ${{ matrix.python-version }}
-        module-name: dffml
-        output-directory: sbom
     - name: Get built filenames
       id: filename
       run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -488,3 +488,39 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+        - "3.12"
+    steps:
+    - name: Build
+      run: |
+        python -m build .
+    - name: Generate SBOM
+      id: generate-sbom
+      uses: anthonyharrison/sbom4python@5b458354df89357bf0253e62ea4567b1807120e2
+      with:
+        python-version: ${{ matrix.python-version }}
+        module-name: dffml
+        output-directory: sbom
+    - name: Get built filenames
+      id: filename
+      run: |
+        echo "tar=$(cd dist/ && echo *.tar.gz)" >> $GITHUB_OUTPUT
+        echo "whl=$(cd dist/ && echo *.tar.gz)" >> $GITHUB_OUTPUT
+    - name: Attest Build Provenance for tar
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-path: "dist/${{ steps.filename.outputs.tar }}"
+    - name: Attest Build Provenance for whl
+      uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+      with:
+        subject-path: "dist/${{ steps.filename.outputs.whl }}"
+    # TODO Upload to pypi on release creation

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -501,6 +501,16 @@ jobs:
         python-version:
         - "3.12"
     steps:
+    - name: Harden Runner
+      uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+      with:
+        egress-policy: audit
+
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel build


### PR DESCRIPTION
GitHub recently made generating and uploading SLSA evidence easier!

Related: https://github.blog/2024-05-02-introducing-artifact-attestations-now-in-public-beta/
Attestations: https://github.com/intel/cve-bin-tool/attestations/