### PR TITLE
ci: update Testing workflow with harden-runner recommendations

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,4 @@
 name: Testing
-permissions: read-all
 
 on:
   push:
@@ -24,6 +23,8 @@ env:
 jobs:
   docs:
     name: Documentation
+    permissions:
+      contents: read
     if: |
       ! github.event.pull_request.user.login == 'github-actions[bot]' ||
       ! (
@@ -38,7 +39,12 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            pypi.org:443
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
@@ -59,6 +65,8 @@ jobs:
 
   tests:
     name: Linux tests
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -68,7 +76,34 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            access.redhat.com:443
+            archives.fedoraproject.org:443
+            azure.archive.ubuntu.com:80
+            curl.se:443
+            epss.cyentia.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            ftp.fr.debian.org:80
+            github.com:443
+            gitlab.com:443
+            mirror.cveb.in:443
+            mirror.cveb.in:80
+            motd.ubuntu.com:443
+            nvd.nist.gov:443
+            osv-vulnerabilities.storage.googleapis.com:443
+            packages.microsoft.com:443
+            ppa.launchpadcontent.net:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            release-monitoring.org:443
+            rpmfind.net:443
+            security-tracker.debian.org:443
+            services.nvd.nist.gov:443
+            storage.googleapis.com:443
+            www.cisa.gov:443
+            www.sqlite.org:443
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
@@ -149,6 +184,8 @@ jobs:
 
   long_tests:
     name: Long tests on Python 3.10
+    permissions:
+      contents: read
     if: |
       ! github.event.pull_request.user.login == 'github-actions[bot]' ||
       ! (
@@ -166,7 +203,39 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            access.redhat.com:443
+            api.codecov.io:443
+            api.github.com:443
+            archives.fedoraproject.org:443
+            azure.archive.ubuntu.com:80
+            cli.codecov.io:443
+            codecov.io:443
+            curl.se:443
+            epss.cyentia.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            ftp.fr.debian.org:80
+            github.com:443
+            gitlab.com:443
+            mirror.cveb.in:443
+            mirror.cveb.in:80
+            motd.ubuntu.com:443
+            nvd.nist.gov:443
+            osv-vulnerabilities.storage.googleapis.com:443
+            packages.microsoft.com:443
+            ppa.launchpadcontent.net:443
+            pypi.org:443
+            raw.githubusercontent.com:443
+            release-monitoring.org:443
+            rpmfind.net:443
+            security-tracker.debian.org:443
+            services.nvd.nist.gov:443
+            storage.googleapis.com:443
+            uploader.codecov.io:443
+            www.cisa.gov:443
+            www.sqlite.org:443
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
@@ -277,6 +346,8 @@ jobs:
 
   linux-mayfail:
     name: Tests that may fail due to network or HTML
+    permissions:
+      contents: read
     if: |
       ! github.event.pull_request.user.login == 'github-actions[bot]' ||
       ! (
@@ -294,7 +365,34 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
         with:
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            access.redhat.com:443
+            api.github.com:443
+            azure.archive.ubuntu.com:80
+            csrc.nist.gov:443
+            curl.se:443
+            epss.cyentia.com:443
+            esm.ubuntu.com:443
+            files.pythonhosted.org:443
+            github.com:443
+            gitlab.com:443
+            mirror.cveb.in:443
+            mirror.cveb.in:80
+            motd.ubuntu.com:443
+            nvd.nist.gov:443
+            osv-vulnerabilities.storage.googleapis.com:443
+            packages.microsoft.com:443
+            playwright.azureedge.net:443
+            ppa.launchpadcontent.net:443
+            pypi.org:443
+            release-monitoring.org:443
+            scap.nist.gov:443
+            security-tracker.debian.org:443
+            services.nvd.nist.gov:443
+            storage.googleapis.com:443
+            www.cisa.gov:443
+            www.sqlite.org:443
 
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
@@ -379,6 +477,8 @@ jobs:
 
   windows_long_tests:
     name: Windows long tests
+    permissions:
+      contents: read
     if: |
       ! github.event.pull_request.user.login == 'github-actions[bot]' ||
       ! (


### PR DESCRIPTION
This updates the Testing workflow (testing.yml) using recommendations from Step Security's harden-runner action. Recommendations were taken from the most recent Testing workflow run (6232, see links below) where all jobs ran with only the 'Get Yesterday's cached database if today's is not available' step not running on relevant jobs.

As harden-runner only runs on Ubuntu VMs, a job-level permission was added to the 'Windows long test' job to account for the removal of the top-level workflow permission.

As the Build job has only recently been added, the `egress-policy` key has been left with the value `audit`. The harden-runner recommendations suggest changing the value to `block` after 10+ runs of the job.

@terriko your input on the following would be appreciated:
 - Should I remove the 'Harden Runner' step in the 'Windows long test' job as the harden runner action only runs on Ubuntu VMs?
 - ~~I believe the permissions are set correctly for each job. I followed the harden-runner recommendations and checked the actions and commands within each job to the best of my knowledge. Are we ok to track the logs to see if the permissions are too restrictive and amend from there or would you prefer another approach?~~ From the test logs it seems the workflow is used from my pull request branch.


Reference issue #4111
Testing workflow run 6232: https://github.com/intel/cve-bin-tool/actions/runs/8976788790/job/24654326627
harden-runner recommendations: https://app.stepsecurity.io/github/intel/cve-bin-tool/actions/runs/8976788790?jobid=24654326273&tab=recommendations