### PR TITLE
chore(deps): requests>=2.32.0 due to session bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ packageurl-python
 packaging
 plotly
 pyyaml>=5.4
-requests
+requests>=2.32.0
 rich
 rpmfile>=1.0.6
 toml; python_version < "3.11"


### PR DESCRIPTION
Dependabot is reporting that requests has a session handling bug that could impact security and should be updated to version 2.32.0 or later.