### PR TITLE
ci: openSSF scorecard fixes, fix build-wheel

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,5 +1,7 @@
 name: Build pip wheel
 
+permissions: read-all
+
 on:
   push:
     branches: [ "main" ]
@@ -17,7 +19,7 @@ on:
       matrix:
         python-version:
         - "3.12"
-    if: github.repository == 'intel/cve-bin-tool' && github.ref == 'refs/heads/main' # run on origin repo only
+    if: github.repository == 'intel/cve-bin-tool' # run on origin repo only
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,5 +1,7 @@
 name: Testing
 
+permissions: read-all
+
 on:
   push:
   pull_request:


### PR DESCRIPTION
Mostly fixes for openssf scorecard, which doens't like it if there's no explicitly defined top permission.

Put in a small tweak that may solve #4137 as well, I haven't tested it extensively.