### PR TITLE
feat: removed version info from purls in language parsers

### DIFF
--- a/cve_bin_tool/parsers/__init__.py
+++ b/cve_bin_tool/parsers/__init__.py
@@ -79,13 +79,12 @@ class Parser:
             )
         return vendorlist
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generate purl string based on various components."""
         purl = PackageURL(
             type=self.purl_pkg_type,
             namespace=vendor,
             name=product,
-            version=version,
             qualifiers=qualifier,
             subpath=subpath,
         )

--- a/cve_bin_tool/parsers/dart.py
+++ b/cve_bin_tool/parsers/dart.py
@@ -19,21 +19,20 @@ class DartParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "pub"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """
         Generates PURL after normalizing all components.
         pubspec: https://dart.dev/tools/pub/pubspec#name
         purl-spec for pub: https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#pub
         """
-        # Normalize product, version, and vendor for Dart packages
+        # Normalize product and vendor for Dart packages
         product = re.sub(r"[^a-zA-Z0-9_]", "", product).lower()
-        version = re.sub(r"[^a-z0-9.+-]", "", version)
         vendor = "UNKNOWN"  # The vendor is not explicitly defined for pub packages
-        if not product or not version:
+        if not product:
             return None
+
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/go.py
+++ b/cve_bin_tool/parsers/go.py
@@ -29,23 +29,19 @@ class GoParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "golang"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
 
         product = re.sub(r"[^a-zA-Z0-9_-]", "", product)
-        version = re.sub(r"^[^a-zA-Z0-9]|[^a-zA-Z0-9.-]", "", version)
         vendor = re.sub(r"^[^a-zA-Z_]|[^a-zA-Z0-9_-]", "", vendor)
 
         if not re.match(r"^[a-zA-Z0-9_-]", product):
             return
         if vendor == "":
             vendor = "UNKNOWN"
-        if version == "":
-            version = "UNKNOWN"
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,
@@ -79,9 +75,5 @@ class GoParser(Parser):
                         version = line.split(" ")[1][1:].split("-")[0].split("+")[0]
                         vendors = self.find_vendor(product, version)
                         if vendors is not None:
-                            for v in vendors:
-                                self.generate_purl(
-                                    product, version, v.product_info.vendor
-                                )
                             yield from vendors
             self.logger.debug(f"Done scanning file: {self.filename}")

--- a/cve_bin_tool/parsers/java.py
+++ b/cve_bin_tool/parsers/java.py
@@ -18,20 +18,17 @@ class JavaParser(Parser):
         self.validate = validate
         self.purl_pkg_type = "maven"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components of a Maven package."""
-        # Normalize product, version, and vendor
+        # Normalize product and vendor
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
-        version = re.sub(r"[^a-zA-Z0-9.+\-]", "", version)
-
         vendor = re.sub(r"[^a-zA-Z0-9._-]", "", vendor).lower() if vendor else "UNKNOWN"
 
-        if not product or not version:
+        if not product:
             return None
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/javascript.py
+++ b/cve_bin_tool/parsers/javascript.py
@@ -15,18 +15,16 @@ class JavascriptParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "npm"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
-        version = re.sub(r"[^a-zA-Z0-9.+\-]", "", version)
         vendor = "UNKNOWN"  # Typically, the vendor is not explicitly defined for npm packages
 
-        if not product or not version:
+        if not product:
             return None
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/perl.py
+++ b/cve_bin_tool/parsers/perl.py
@@ -13,19 +13,17 @@ class PerlParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "cpan"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
-        # Normalize product, version, and vendor for Perl packages
+        # Normalize product and vendor for Perl packages
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
-        version = re.sub(r"[^a-zA-Z0-9.+-]", "", version)
         vendor = "UNKNOWN"  # Typically, the vendor is not explicitly defined for CPAN packages
 
-        if not product or not version:
+        if not product:
             return None
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/php.py
+++ b/cve_bin_tool/parsers/php.py
@@ -19,18 +19,16 @@ class PhpParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "composer"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
         vendor = re.sub(r"[^a-zA-Z0-9._-]", "", vendor).lower()
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
-        version = re.sub(r"[^a-zA-Z0-9.+-]", "", version)
 
-        if not vendor or not product or not version:
+        if not vendor or not product:
             return None
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/python.py
+++ b/cve_bin_tool/parsers/python.py
@@ -25,18 +25,16 @@ class PythonRequirementsParser(Parser):
         self.purl_pkg_type = "pypi"
         super().__init__(cve_db, logger)
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
-        version = re.sub(r"[^a-zA-Z0-9.+-]", "", version)
         vendor = "UNKNOWN"
 
-        if not product or not version:
+        if not product:
             return None
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,
@@ -117,18 +115,16 @@ class PythonParser(Parser):
         self.purl_pkg_type = "pypi"
         super().__init__(cve_db, logger)
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
         product = re.sub(r"[^a-zA-Z0-9._-]", "", product).lower()
-        version = re.sub(r"[^a-zA-Z0-9.+-]", "", version)
         vendor = "UNKNOWN"
 
-        if not product or not version:
+        if not product:
             return None
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/r.py
+++ b/cve_bin_tool/parsers/r.py
@@ -30,21 +30,17 @@ class RParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "cran"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
 
         product = re.sub(r"[^a-zA-Z0-9.-]", "", product)
-        version = re.sub(r"^[^a-zA-Z0-9]|[^a-zA-Z0-9.-]", "", version)
         vendor = "UNKNOWN"
 
         if not re.match(r"^[a-zA-Z0-9_-]", product):
             return
-        if version == "":
-            version = "UNKNOWN"
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/ruby.py
+++ b/cve_bin_tool/parsers/ruby.py
@@ -29,23 +29,19 @@ class RubyParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "gem"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
 
         product = re.sub(r"^[^a-z]|[^a-z0-9_-]", "", product)
-        version = re.sub(r"^[^0-9]|[^a-zA-Z0-9.+-]", "", version)
         vendor = re.sub(r"^[^a-z]|[^a-z0-9_-]", "", vendor)
 
         if not re.match(r"^[a-z]|[a-z0-9_-]", product):
             return
         if vendor == "":
             vendor = "UNKNOWN"
-        if version == "":
-            version = "UNKNOWN"
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/rust.py
+++ b/cve_bin_tool/parsers/rust.py
@@ -28,23 +28,19 @@ class RustParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "cargo"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
 
         product = re.sub(r"^[^a-zA-Z_]|[^a-zA-Z0-9_-]", "", product)
         vendor = re.sub(r"^[^a-zA-Z_]|[^a-zA-Z0-9_-]", "", vendor)
-        version = re.sub(r"^[^0-9]|[^a-zA-Z0-9.+-]", "", version)
 
         if not re.match(r"^[a-zA-Z_]|[a-zA-Z0-9_-]", product):
             return
         if vendor == "":
             vendor = "UNKNOWN"
-        if version == "":
-            version = "UNKNOWN"
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,

--- a/cve_bin_tool/parsers/swift.py
+++ b/cve_bin_tool/parsers/swift.py
@@ -32,22 +32,18 @@ class SwiftParser(Parser):
         super().__init__(cve_db, logger)
         self.purl_pkg_type = "swift"
 
-    def generate_purl(self, product, version, vendor, qualifier={}, subpath=None):
+    def generate_purl(self, product, vendor, qualifier={}, subpath=None):
         """Generates PURL after normalizing all components."""
 
         product = re.sub(r"[^a-zA-Z0-9_-]", "", product)
-        version = re.sub(r"[^a-zA-Z0-9.+-]", "", version)
 
         if not re.match(r"[a-zA-Z0-9_-]", product):
             return
         if not vendor:
             vendor = "UNKNOWN"
-        if not version:
-            version = "UNKNOWN"
 
         purl = super().generate_purl(
             product,
-            version,
             vendor,
             qualifier,
             subpath,


### PR DESCRIPTION
Version information isn't particularly useful for queries on the purl2cpe.