### PR TITLE
fix: let epss work behind proxy

### DIFF
--- a/cve_bin_tool/data_sources/epss_source.py
+++ b/cve_bin_tool/data_sources/epss_source.py
@@ -69,7 +69,9 @@ class Epss_Source:
             # Check if the file is older than 24 hours
             if time_difference > timedelta(hours=24):
                 try:
-                    async with aiohttp.ClientSession(headers=HTTP_HEADERS) as session:
+                    async with aiohttp.ClientSession(
+                        headers=HTTP_HEADERS, trust_env=True
+                    ) as session:
                         async with session.get(self.DATA_SOURCE_LINK) as response:
                             response.raise_for_status()
                             self.LOGGER.info("Getting EPSS data...")
@@ -89,7 +91,9 @@ class Epss_Source:
 
         else:
             try:
-                async with aiohttp.ClientSession(headers=HTTP_HEADERS) as session:
+                async with aiohttp.ClientSession(
+                    headers=HTTP_HEADERS, trust_env=True
+                ) as session:
                     async with session.get(self.DATA_SOURCE_LINK) as response:
                         response.raise_for_status()
                         self.LOGGER.info("Getting EPSS data...")


### PR DESCRIPTION
Thanks to @alext-w for finding this one.

Needed to add trust_env=True to the aiohttp connections in the epss data source because otherwise it ignores proxy settings (and thus won't work at all for users behind a proxy)

* fixes #4083