### PR TITLE
fix: disable nvd_api_key, test disabled sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,8 @@ CVE Data Download:
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-u-nowdailyneverlatest---update-nowdailyneverlatest">-u {now,daily,never,latest}, --update {now,daily,never,latest}</a>
                         update schedule for data sources and exploits database (default: daily)
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#--nvd-api-key-nvd_api_key">--nvd-api-key NVD_API_KEY</a>
-                        specify NVD API key (used to improve NVD rate limit)
+                        Specify NVD API key (used to improve NVD rate limit).
+                        Set to `no` to ignore any keys in the environment.
   <a href="https://github.com/intel/cve-bin-tool/blob/main/doc/MANUAL.md#-d-nvdosvgadcurl-nvdosvgadcurl----disable-data-source-nvdosvgadcurl-nvdosvgadcurl-">-d DISABLE_DATA_SOURCE, --disable-data-source DISABLE_DATA_SOURCE</a>
                         comma-separated list of data sources (CURL, EPSS, GAD, NVD, OSV, REDHAT, RSD) to disable (default: NONE) 
 

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -150,7 +150,12 @@ def main(argv=None):
         "--nvd-api-key",
         action="store",
         default="",
-        help="specify NVD API key (used to improve NVD rate limit)",
+        help=textwrap.dedent(
+            """\
+            Specify NVD API key (used to improve NVD rate limit).
+            Set to `no` to ignore any keys in the environment.
+            """
+        ),
     )
     data_source_disable_help = f'comma-separated list of data sources ({", ".join(DataSourceSupport.available_data_sources())}) to disable (default: NONE)'
     data_sources_group.add_argument(

--- a/cve_bin_tool/data_sources/nvd_source.py
+++ b/cve_bin_tool/data_sources/nvd_source.py
@@ -88,6 +88,13 @@ class NVD_Source(Data_Source):
         # store the nvd api key for use later
         self.nvd_api_key = nvd_api_key
 
+        # if nvd_api_key was set to "No" then unset it
+        # This makes it easier to disable usage from the command line
+        # and over-riding existing environment variables.
+        if self.nvd_api_key.lower() == "no":
+            self.nvd_api_key = ""
+            LOGGER.info("NVD API Key was set to 'no' and will not be used")
+
     async def get_cve_data(self):
         """Retrieves the CVE data from the data source."""
         await self.fetch_cves()

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -125,7 +125,8 @@ which is useful if you're trying the latest code from
       -u {now,daily,never,latest}, --update {now,daily,never,latest}
                             update schedule for data sources and exploits database (default: daily)
       --nvd-api-key NVD_API_KEY
-                            specify NVD API key (used to improve NVD rate limit)
+                            Specify NVD API key (used to improve NVD rate limit).
+                            Set to `no` to ignore any keys in the environment.
       -d {NVD,OSV,GAD,REDHAT,CURL} [{NVD,OSV,GAD,REDHAT,CURL} ...], --disable-data-source {NVD,OSV,GAD,REDHAT,CURL} [{NVD,OSV,GAD,REDHAT,CURL} ...]
                             specify data sources that should be disabled
 
@@ -450,6 +451,8 @@ By stating it in command line interface(cli)
 ```bash
 cve-bin-tool --nvd-api-key your_api_key_here
 ```
+
+You can also set your API Key to be "no" on the command line, which will allow you to ignore any keys set in the environment.  This is occasionally useful for testing purposes or to force cve-bin-tool to use the mirrors only.
 
 Once you have set up your NVD API Key, cve-bin-tool will use it to retrieve vulnerability data from the NVD. This will ensure that you have access to the full database and will reduce the likelihood of encountering errors due to limited access.
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -809,3 +809,32 @@ class TestCLI(TempDirTest):
                 assert expected_content in content
         # Cleanup
         os.remove(expected_files)
+
+    def test_disabled_sources(self, caplog):
+        """Attempts to disable various data sources and makes sure they appear
+        to be disabled correctly.
+
+        This only tests for disabled messages, it doesn't check on the update code
+        because we'd have to actually do updates then and they're slow.
+        """
+
+        # attempt to call with all sources disabled
+        with caplog.at_level(logging.INFO):
+            main(
+                [
+                    "cve-bin-tool",
+                    "--update",
+                    "never",
+                    "--nvd-api-key",
+                    "no",
+                    "-n",
+                    "json-mirror",
+                    "--disable-data-source",
+                    "CURL,EPSS,GAD,OSV,REDHAT,RSD",
+                    self.tempdir,
+                ]
+            )
+            # check that nvd key was disabled as expected
+            assert "NVD API Key was set to 'no' and will not be used" in caplog.text
+            for source in ["CURL", "EPSS", "GAD", "OSV", "REDHAT", "RSD"]:
+                assert f"Disabling data source {source}" in caplog.text


### PR DESCRIPTION
Adding a disabled source test for #4125, and also made it possible to disable the nvd_api_key to make it easier to avoid nvd2 api calls