### PR TITLE
fix: remove alias mechanism from osv

### DIFF
--- a/cve_bin_tool/data_sources/osv_source.py
+++ b/cve_bin_tool/data_sources/osv_source.py
@@ -251,15 +251,7 @@ class OSV_Source(Data_Source):
         affected_data = []
 
         for cve_item in all_cve_entries:
-            cve_in_alias = None
-
-            for cve in cve_item.get("aliases", []):
-                if "CVE" in cve:
-                    cve_in_alias = cve
-                    break
-
-            # if CVE has alias of the form "CVE-year-xxxx" keep that as CVE ID, will help in checking for duplicates
-            cve_id = cve_in_alias if cve_in_alias is not None else cve_item["id"]
+            cve_id = cve_item["id"]
             severity = cve_item.get("severity", None)
             vector = None
 

--- a/test/test_source_osv.py
+++ b/test/test_source_osv.py
@@ -117,9 +117,9 @@ class TestSourceOSV:
     }
 
     format_data = {
-        "CVE-2018-20133": {
+        "PYSEC-2018-103": {
             "severity_data": {
-                "ID": "CVE-2018-20133",
+                "ID": "PYSEC-2018-103",
                 "severity": "unknown",
                 "description": "unknown",
                 "score": "unknown",
@@ -129,7 +129,7 @@ class TestSourceOSV:
             },
             "affected_data": [
                 {
-                    "cve_id": "CVE-2018-20133",
+                    "cve_id": "PYSEC-2018-103",
                     "vendor": "unknown",
                     "product": "ymlref",
                     "version": "*",
@@ -140,9 +140,9 @@ class TestSourceOSV:
                 }
             ],
         },
-        "CVE-2014-5461": {
+        "DLA-47-1": {
             "severity_data": {
-                "ID": "CVE-2014-5461",
+                "ID": "DLA-47-1",
                 "severity": "unknown",
                 "description": "lua5.1 - security update",
                 "score": "unknown",
@@ -152,7 +152,7 @@ class TestSourceOSV:
             },
             "affected_data": [
                 {
-                    "cve_id": "CVE-2014-5461",
+                    "cve_id": "DLA-47-1",
                     "vendor": "unknown",
                     "product": "lua5.1",
                     "version": "*",


### PR DESCRIPTION
OSV database sometimes as entries such has https://osv.dev/vulnerability/PYSEC-2020-209 with no severity field but an alias to an other OSV entry which has one: https://osv.dev/vulnerability/CVE-2020-14365

Since its addition in commit 09417a2632a2d17b8ad6d93e71aa785648f914f1, cve-bin-tool will create an entry for CVE-2020-14635 but this entry will not contain any score which is obviously wrong so drop this alias mechanism.

Moreover, this alias mechanism combined with the fact that OSV updated many "old" entries (such as https://osv.dev/vulnerability/CVE-2017-1000099 updated in May 2024) raises the following issue with libcurl 7.54.1 with 19 `UNKNOWN` CVEs:

```
╭─────────────────╮
│  NewFound CVEs  │
╰─────────────────╯
┏━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
┃ Vendor ┃ Product ┃ Version ┃ CVE Number       ┃ Source ┃ Severity ┃ Score (CVSS Version) ┃
┡━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000099 │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000100 │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000254 │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000257 │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-8816    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-8817    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2018-1000005 │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2018-14618   │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2018-16890   │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2019-3822    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2019-3823    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2019-5436    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2020-8231    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2020-8285    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2020-8286    │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2021-22876   │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2021-22924   │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-27535   │ NVD    │ MEDIUM   │ 5.9 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-27536   │ NVD    │ MEDIUM   │ 5.9 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-27538   │ OSV    │ UNKNOWN  │ unknown              │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-38546   │ OSV    │ UNKNOWN  │ unknown              │
└────────┴─────────┴─────────┴──────────────────┴────────┴──────────┴──────────────────────┘
```

After this change, the correct result is retrieved from NVD:

```
╭─────────────────╮
│  NewFound CVEs  │
╰─────────────────╯
┏━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━┓
┃ Vendor ┃ Product ┃ Version ┃ CVE Number       ┃ Source ┃ Severity ┃ Score (CVSS Version) ┃
┡━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━┩
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000099 │ NVD    │ MEDIUM   │ 6.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000100 │ NVD    │ MEDIUM   │ 6.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000254 │ NVD    │ HIGH     │ 7.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-1000257 │ NVD    │ CRITICAL │ 9.1 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-8816    │ NVD    │ CRITICAL │ 9.8 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2017-8817    │ NVD    │ CRITICAL │ 9.8 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2018-1000005 │ NVD    │ CRITICAL │ 9.1 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2018-14618   │ NVD    │ CRITICAL │ 9.8 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2018-16890   │ NVD    │ HIGH     │ 7.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2019-3822    │ NVD    │ CRITICAL │ 9.8 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2019-3823    │ NVD    │ HIGH     │ 7.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2019-5436    │ NVD    │ HIGH     │ 7.8 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2020-8231    │ NVD    │ HIGH     │ 7.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2020-8285    │ NVD    │ HIGH     │ 7.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2020-8286    │ NVD    │ HIGH     │ 7.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2021-22876   │ NVD    │ MEDIUM   │ 5.3 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2021-22924   │ NVD    │ LOW      │ 3.7 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-27535   │ NVD    │ MEDIUM   │ 5.9 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-27536   │ NVD    │ MEDIUM   │ 5.9 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-27538   │ NVD    │ MEDIUM   │ 5.5 (v3)             │
│ haxx   │ libcurl │ 7.54.1  │ CVE-2023-38546   │ NVD    │ LOW      │ 3.7 (v3)             │
└────────┴─────────┴─────────┴──────────────────┴────────┴──────────┴──────────────────────┘
```

This alias mechanism is probably the root cause of #3721