### PR TITLE
Added 'YAFFS' as valid binary format

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -175,6 +175,7 @@ class VersionScanner:
                     "PE32 executable",
                     "PE32+ executable",
                     "Mach-O",
+                    "YAFFS",
                     ": data",
                     *list(valid_files.keys()),
                 )


### PR DESCRIPTION
Referring to https://github.com/intel/cve-bin-tool/issues/4199.
I've tested some file types and the output of `file <filename>` does not change; so I've added 'YAFFS' flag so these files get scanned anyways.