### PR TITLE
fix: use real filenames in language parsers

### DIFF
--- a/cve_bin_tool/parsers/__init__.py
+++ b/cve_bin_tool/parsers/__init__.py
@@ -105,7 +105,6 @@ class Parser:
         It then decodes the CPE data to extract vendor, product, and version information. If the version matches the provided
         version, it constructs a ScanInfo object for each matching entry and returns a list of these objects.
         """
-        
         try:
             purl = purl.to_dict()
             param1 = f"pkg:{purl['type']}/{purl['name']}"

--- a/cve_bin_tool/parsers/__init__.py
+++ b/cve_bin_tool/parsers/__init__.py
@@ -1,10 +1,11 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from __future__ import annotations
+
 import re
 import sqlite3
 from pathlib import Path
-from typing import List, Tuple
 
 from packageurl import PackageURL
 
@@ -73,7 +74,7 @@ class Parser:
             # To handle multiple vendors, return all combinations of product/vendor mappings
             for v in vendor_package_pair:
                 vendor = v["vendor"]
-                location = v.get("location", "/usr/local/bin/product")
+                location = v.get("location", self.filename)
                 self.logger.debug(f"{file_path} {product} {version} by {vendor}")
                 vendorlist.append(
                     ScanInfo(ProductInfo(vendor, product, version, location), file_path)
@@ -96,7 +97,7 @@ class Parser:
         )
         return purl
 
-    def find_vendor_from_purl(self, purl, ver) -> Tuple[List[ScanInfo], bool]:
+    def find_vendor_from_purl(self, purl, ver) -> tuple[list[ScanInfo], bool]:
         """
         Finds the vendor information for a given PackageURL (purl) and version from the database.
 
@@ -126,7 +127,7 @@ class Parser:
                         vendor,
                         product,
                         ver,
-                        "/usr/local/bin/product",
+                        self.filename,
                         purl=purl_with_ver,
                     ),
                     self.filename,
@@ -149,7 +150,7 @@ class Parser:
             raise CVEDBError
         return cursor
 
-    def decode_cpe23(self, cpe23) -> Tuple[str, str, str]:
+    def decode_cpe23(self, cpe23) -> tuple[str, str, str]:
         """
         Decodes a CPE 2.3 formatted string to extract vendor, product, and version information.
 

--- a/cve_bin_tool/parsers/java.py
+++ b/cve_bin_tool/parsers/java.py
@@ -54,7 +54,7 @@ class JavaParser(Parser):
             for pair in vendor_package_pair:
                 vendor = pair["vendor"]
                 file_path = self.filename
-                location = pair.get("location", "/usr/local/bin/product")
+                location = pair.get("location", self.filename)
                 self.logger.debug(f"{file_path} {product} {version} by {vendor}")
                 info.append(
                     ScanInfo(ProductInfo(vendor, product, version, location), file_path)

--- a/cve_bin_tool/parsers/python.py
+++ b/cve_bin_tool/parsers/python.py
@@ -158,7 +158,7 @@ class PythonParser(Parser):
                 if vendor_package_pair != []:
                     for pair in vendor_package_pair:
                         vendor = pair["vendor"]
-                        location = pair.get("location", "/usr/local/bin/product")
+                        location = pair.get("location", self.filename)
                         file_path = self.filename
                         self.logger.debug(
                             f"{file_path} is {vendor}.{product} {version}"

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from cve_bin_tool.cvedb import CVEDB
+from cve_bin_tool.util import ProductInfo
 from cve_bin_tool.version_scanner import VersionScanner
 
 
@@ -251,8 +252,7 @@ class TestLanguageScanner:
         for product in scanner.scan_file(filename):
             if product:
                 product_info, file_path = product
-                assert product_info.vendor == "facebook"
-                assert product_info.product == "zstandard"
-                assert product_info.version == "0.18.0"
-                assert Path(product_info.filename) == Path(filename)
+                assert product_info == ProductInfo(
+                    "facebook", "zstandard", "0.18.0", filename
+                )
         assert file_path == filename

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -254,5 +254,5 @@ class TestLanguageScanner:
                 assert product_info.vendor == "facebook"
                 assert product_info.product == "zstandard"
                 assert product_info.version == "0.18.0"
-                assert product_info.filename.endswith("/test/language_data/PKG-INFO")
+                assert Path(product_info.filename) == Path(filename)
         assert file_path == filename

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 
 from cve_bin_tool.cvedb import CVEDB
-from cve_bin_tool.util import ProductInfo
 from cve_bin_tool.version_scanner import VersionScanner
 
 
@@ -252,7 +251,8 @@ class TestLanguageScanner:
         for product in scanner.scan_file(filename):
             if product:
                 product_info, file_path = product
-        assert product_info == ProductInfo(
-            "facebook", "zstandard", "0.18.0", "/usr/local/bin/product"
-        )
+                assert product_info.vendor == "facebook"
+                assert product_info.product == "zstandard"
+                assert product_info.version == "0.18.0"
+                assert product_info.filename.endswith("/test/language_data/PKG-INFO")
         assert file_path == filename


### PR DESCRIPTION
This was probably my bad during code review, but we were using placeholder filenames in the parsers instead of just using the filename which was part of the class.

This may break some tests but my database is updating locally so I'm uploading this as a draft to take advantage of the cache while I wait.