### PR TITLE
feat: added mismatch information for python's zstandard

### DIFF
--- a/data/pypi/zstandard/mismatch_relations.yml
+++ b/data/pypi/zstandard/mismatch_relations.yml
@@ -1,0 +1,4 @@
+purls:
+  - pkg:pypi/zstandard
+invalid_vendors:
+  - facebook


### PR DESCRIPTION
Here, I've added the vendor mismatch information for python's zstandard under `pypi` namespace.
Should be merged after #4236.