### PR TITLE
build(deps): Move setuptools to requirements.txt (from dev reqs)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,4 +22,3 @@ types-PyYAML
 types-requests
 types-setuptools
 types-toml
-setuptools>=65.5.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.csv
+++ b/requirements.csv
@@ -24,4 +24,4 @@ anthonyharrison_not_in_db,lib4sbom
 anthonyharrison_not_in_db,lib4vex
 the_purl_authors_not_in_db,packageurl-python
 h2non,filetype
-python_packaging_authority_not_in_db,setuptools
+python,setuptools

--- a/requirements.csv
+++ b/requirements.csv
@@ -24,3 +24,4 @@ anthonyharrison_not_in_db,lib4sbom
 anthonyharrison_not_in_db,lib4vex
 the_purl_authors_not_in_db,packageurl-python
 h2non,filetype
+python_packaging_authority_not_in_db,setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ pyyaml>=5.4
 requests>=2.32.0
 rich
 rpmfile>=1.0.6
+setuptools>=65.5.1 # pinned by Snyk to avoid a vulnerability
 toml; python_version < "3.11"
 urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
 xmlschema


### PR DESCRIPTION
fixes #4282 

* Moved `setuptools>=65.5.1` from `dev-requirements.txt` to `requirements.txt`
* Modified comment as `not directly required` is untrue
* Added a line for setuptools to requirements.csv based on best guess for vendor entry looking at adjacent packages in PyPI