### PR TITLE
feat: convert mismatch utility into a standalone entity

### DIFF
--- a/cve_bin_tool/mismatch_loader.py
+++ b/cve_bin_tool/mismatch_loader.py
@@ -22,6 +22,10 @@ VALUES (?, ?)
 ON CONFLICT DO NOTHING;
 """
 
+db_path = DISK_LOCATION_DEFAULT / DBNAME
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+data_dir = os.path.join(parent_dir, "data")
+
 
 def setup_sqlite(data_dir: str, db_file: str) -> bool:
     """
@@ -72,10 +76,6 @@ def setup_args():
     Setup command line arguments
     """
 
-    db_path = DISK_LOCATION_DEFAULT / DBNAME
-    parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    data_dir = os.path.join(parent_dir, "data")
-
     parser = argparse.ArgumentParser(description="mismatch loader")
     parser.add_argument(
         "--dir",
@@ -95,18 +95,32 @@ def setup_args():
     return args
 
 
+def run_mismatch_loader(dir=data_dir, db_file=db_path):
+    """
+    Runs the mismatch loader to populate the SQLite database with mismatch relationships.
+
+    Args:
+        dir (str): The directory containing the data files to be processed.
+        db_file (str): The file path to the SQLite database file.
+
+    Returns:
+        bool: True if the database setup was successful, False otherwise.
+    """
+    if not os.path.exists(dir) or not os.path.isdir(dir):
+        LOGGER.error(
+            f"Specified data directory does not exist or is not a folder: {dir}"
+        )
+        return False
+    return setup_sqlite(dir, db_file)
+
+
 def main():
     """
-    Run the SQLite loader utility
+    Run the mismatch loader utility
     """
     args = setup_args()
 
-    if not os.path.exists(args.dir) or not os.path.isdir(args.dir):
-        LOGGER.error(
-            f"Specified data directory does not exist or is not a folder: {args.dir}"
-        )
-        exit(1)
-    if not setup_sqlite(args.dir, args.database):
+    if not run_mismatch_loader(args.dir, args.database):
         exit(1)
     exit(0)
 

--- a/mismatch/cli.py
+++ b/mismatch/cli.py
@@ -1,7 +1,6 @@
+import argparse
 import os
 import sqlite3
-
-import click
 
 from cve_bin_tool.cvedb import DBNAME, DISK_LOCATION_DEFAULT
 from cve_bin_tool.mismatch_loader import run_mismatch_loader
@@ -11,16 +10,6 @@ data_dir = os.path.join(parent_dir, "data")
 dbpath = DISK_LOCATION_DEFAULT / DBNAME
 
 
-@click.group(invoke_without_command=True)
-@click.pass_context
-def main(ctx):
-    if ctx.invoked_subcommand is None:
-        ctx.invoke(loader)
-
-
-@main.command()
-@click.argument("purl")
-@click.option("--database", "db_file", default=dbpath, help="SQLite DB file location")
 def lookup(purl, db_file):
     """
     Looks up the vendor information for a given purl in the mismatch database.
@@ -39,33 +28,64 @@ def lookup(purl, db_file):
 
         if result:
             formatted_result = ", ".join([row[0] for row in result])
-            click.echo(formatted_result)
+            print(formatted_result)
         else:
-            click.echo("Error: No data found for the provided purl.")
+            print("Error: No data found for the provided purl.")
     except sqlite3.Error as e:
-        click.echo(f"Database error: {e}")
+        print(f"Database error: {e}")
     finally:
         conn.close()
 
 
-@main.command()
-@click.option("--dir", "data_dir", default=data_dir, help="Data folder location")
-@click.option("--database", "db_file", default=dbpath, help="SQLite DB file location")
-@click.pass_context
-def loader(ctx, data_dir, db_file):
+def loader(data_dir, db_file):
     """
     Sets up or refreshes the mismatch database using data from the specified directory.
 
     Args:
-        ctx (click.Context): Click context object, automatically passed when using @click.pass_context.
         data_dir (str): The directory containing the data files to be loaded into the mismatch database.
         db_file (str): The file path to the SQLite database file.
 
     """
     if run_mismatch_loader(data_dir, db_file):
-        click.echo("Mismatch database setup completed successfully.")
+        print("Mismatch database setup completed successfully.")
     else:
-        click.echo("Mismatch database setup failed.")
+        print("Mismatch database setup failed.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Mismatch Database Management Tool")
+    subparsers = parser.add_subparsers(dest="command")
+
+    # Subparser for the lookup command
+    lookup_parser = subparsers.add_parser(
+        "lookup", help="Look up vendor information for a given purl"
+    )
+    lookup_parser.add_argument(
+        "purl", type=str, help="The package URL to lookup in the mismatch database"
+    )
+    lookup_parser.add_argument(
+        "--database", dest="db_file", default=dbpath, help="SQLite DB file location"
+    )
+
+    # Subparser for the loader command
+    loader_parser = subparsers.add_parser(
+        "loader", help="Set up or refresh the mismatch database"
+    )
+    loader_parser.add_argument(
+        "--dir", dest="data_dir", default=data_dir, help="Data folder location"
+    )
+    loader_parser.add_argument(
+        "--database", dest="db_file", default=dbpath, help="SQLite DB file location"
+    )
+
+    args = parser.parse_args()
+
+    if args.command == "lookup":
+        lookup(args.purl, args.db_file)
+    elif args.command == "loader":
+        loader(args.data_dir, args.db_file)
+    else:
+        loader(data_dir, dbpath)
 
 
 if __name__ == "__main__":

--- a/mismatch/cli.py
+++ b/mismatch/cli.py
@@ -1,0 +1,72 @@
+import os
+import sqlite3
+
+import click
+
+from cve_bin_tool.cvedb import DBNAME, DISK_LOCATION_DEFAULT
+from cve_bin_tool.mismatch_loader import run_mismatch_loader
+
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+data_dir = os.path.join(parent_dir, "data")
+dbpath = DISK_LOCATION_DEFAULT / DBNAME
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def main(ctx):
+    if ctx.invoked_subcommand is None:
+        ctx.invoke(loader)
+
+
+@main.command()
+@click.argument("purl")
+@click.option("--database", "db_file", default=dbpath, help="SQLite DB file location")
+def lookup(purl, db_file):
+    """
+    Looks up the vendor information for a given purl in the mismatch database.
+
+    Args:
+        purl (str): The package URL to lookup in the mismatch database.
+        db_file (str): The file path to the SQLite database file.
+
+    """
+    conn = sqlite3.connect(db_file)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("SELECT vendor FROM mismatch WHERE purl = ?", (purl,))
+        result = cursor.fetchall()
+
+        if result:
+            formatted_result = ", ".join([row[0] for row in result])
+            click.echo(formatted_result)
+        else:
+            click.echo("Error: No data found for the provided purl.")
+    except sqlite3.Error as e:
+        click.echo(f"Database error: {e}")
+    finally:
+        conn.close()
+
+
+@main.command()
+@click.option("--dir", "data_dir", default=data_dir, help="Data folder location")
+@click.option("--database", "db_file", default=dbpath, help="SQLite DB file location")
+@click.pass_context
+def loader(ctx, data_dir, db_file):
+    """
+    Sets up or refreshes the mismatch database using data from the specified directory.
+
+    Args:
+        ctx (click.Context): Click context object, automatically passed when using @click.pass_context.
+        data_dir (str): The directory containing the data files to be loaded into the mismatch database.
+        db_file (str): The file path to the SQLite database file.
+
+    """
+    if run_mismatch_loader(data_dir, db_file):
+        click.echo("Mismatch database setup completed successfully.")
+    else:
+        click.echo("Mismatch database setup failed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,7 @@ setup_kwargs = dict(
         "console_scripts": [
             "cve-bin-tool = cve_bin_tool.cli:main",
             "csv2cve = cve_bin_tool.csv2cve:main",
+            "mismatch = mismatch.cli:main",
         ],
     },
 )


### PR DESCRIPTION
- mismatch -> this command will run the loader and load the default database with default data.
- mismatch loader [--dir] [--database] -> same as previous but with ability to define custom data directory and database file.
- mismatch lookup PURL [--database] -> takes PURL as an argument and returns vendor names associated from database and error if nothing is found.

default values for --dir and --database is tailored for cve-bin-tool, but I think if we were to make it truly standalone, we should make those flags compulsory.

cc @terriko  