### PR TITLE
fix: TypeError in fuzz_python_requirement_ parser in fuzzing reports

### DIFF
--- a/fuzz/fuzz_package_list_parser.py
+++ b/fuzz/fuzz_package_list_parser.py
@@ -50,7 +50,7 @@ def TestPackageData(data):
     with_version = []
     without_version = []
     json_data = MessageToDict(
-        data, preserving_proto_field_name=True, including_default_value_fields=True
+        data, preserving_proto_field_name=True, always_print_fields_with_no_presence=True
     )
 
     print(json_data)

--- a/fuzz/fuzz_python_requirement_parser.py
+++ b/fuzz/fuzz_python_requirement_parser.py
@@ -36,7 +36,7 @@ def TestParseData(data, cve_db, logger, tmpdir):
     """
     try:
         json_data = MessageToDict(
-            data, preserving_proto_field_name=True, always_print_fields_with_no_presence=True #Fixed Issue #4053: including_default_value_fields is deprecated
+            data, preserving_proto_field_name=True, always_print_fields_with_no_presence=True 
         )
         file_path = os.path.join(tmpdir, "requirements.txt")
         with open(file_path, "w") as f:

--- a/fuzz/fuzz_python_requirement_parser.py
+++ b/fuzz/fuzz_python_requirement_parser.py
@@ -36,7 +36,7 @@ def TestParseData(data, cve_db, logger, tmpdir):
     """
     try:
         json_data = MessageToDict(
-            data, preserving_proto_field_name=True, including_default_value_fields=True
+            data, preserving_proto_field_name=True, always_print_fields_with_no_presence=True #Fixed Issue #4053: including_default_value_fields is deprecated
         )
         file_path = os.path.join(tmpdir, "requirements.txt")
         with open(file_path, "w") as f:


### PR DESCRIPTION
_./fuzz/fuzz_python_requirement_parser.py_
_./fuzz/fuzz_package_list_parser.py_

**MessageToDict()** **including_default_value_fields** argument has been deprecated and you'll need to use **always_print_fields_with_no_presence**.

`json_data = MessageToDict(
            data, preserving_proto_field_name=True, always_print_fields_with_no_presence=True)`


source: 
[15703](https://github.com/protocolbuffers/protobuf/pull/15703)

