### PR TITLE
chore(deps): bump min versions per snyk

### DIFF
--- a/doc/requirements.csv
+++ b/doc/requirements.csv
@@ -6,3 +6,4 @@ anthonyharrison_not_in_db,sbom2doc
 pillow,pillow
 python,requests
 python,urllib3
+jaraco,zipp

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -5,3 +5,4 @@ sbom2doc
 pillow>=10.3.0 # not directly required, pinned by Snyk to avoid a vulnerability
 requests>=2.32.2 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability
+zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/requirements.csv
+++ b/requirements.csv
@@ -25,3 +25,4 @@ anthonyharrison_not_in_db,lib4vex
 the_purl_authors_not_in_db,packageurl-python
 h2non,filetype
 python,setuptools
+jaraco,zipp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp[speedups]>=3.9.2
+aiohttp[speedups]>=3.9.4
 beautifulsoup4
 cvss
 defusedxml
@@ -16,11 +16,12 @@ packageurl-python
 packaging
 plotly
 pyyaml>=5.4
-requests>=2.32.0
+requests>=2.32.2
 rich
 rpmfile>=1.0.6
-setuptools>=65.5.1 # pinned by Snyk to avoid a vulnerability
+setuptools>=70.0.0 # pinned by Snyk to avoid a vulnerability
 toml; python_version < "3.11"
-urllib3>=1.26.5 # dependency of requests added explictly to avoid CVEs
+urllib3>=2.2.2 # dependency of requests added explictly to avoid CVEs
 xmlschema
 zstandard; python_version >= "3.4"
+zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
Snyk recommended bumping a few minimum versions to avoid vulnerabilities.

This replaces the following couple of issues because I didn't think it was worth running tests twice for the different files:
* closes #4296
* closes #4295