### PR TITLE
test: Reduce tests run in short tests jobs

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -171,7 +171,7 @@ jobs:
       - name: Run async tests
         if: env.sbom != 'true'
         run: >
-          pytest -n 4 -v
+          pytest -n 4 -v --durations=50
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
@@ -180,7 +180,7 @@ jobs:
       - name: Run synchronous tests
         if: env.sbom != 'true'
         run: >
-          pytest -v
+          pytest -v --durations=50
           test/test_cli.py
           test/test_cvedb.py
 
@@ -323,7 +323,7 @@ jobs:
         env:
           LONG_TESTS: ${{ steps.git-diff.outputs.value }}
         run: >
-          pytest --cov --cov-append -n 4 -v
+          pytest --cov --cov-append -n 4 -v --durations=50
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
@@ -334,7 +334,7 @@ jobs:
         env:
           LONG_TESTS: ${{ steps.git-diff.outputs.value }}
         run: >
-          pytest -v --cov --cov-append --cov-report=xml
+          pytest -v --cov --cov-append --cov-report=xml --durations=50
           test/test_cli.py
           test/test_cvedb.py
       - name: Upload code coverage to codecov
@@ -463,7 +463,7 @@ jobs:
         env:
           EXTERNAL_SYSTEM: ${{ steps.git-diff.outputs.value }}
         run: >
-          pytest -v
+          pytest -v --durations=0
           test/test_source_osv.py
           test/test_source_gad.py
           test/test_source_nvd.py
@@ -471,10 +471,10 @@ jobs:
           test/test_cvedb.py
           test/test_available_fix.py
       - name: Run HTML tests
-        run: pytest -v -n auto test/test_html.py
+        run: pytest -v -n auto test/test_html.py --durations=0
       - name: Run json tests as they may fail due to NVD data validation issue or download timing
         run: >
-          pytest -v
+          pytest -v --durations=0
           test/test_json.py
 
   windows_long_tests:
@@ -546,7 +546,7 @@ jobs:
           python -m cve_bin_tool.cli test/assets/test-kerberos-5-1.15.1.out
       - name: Run async tests
         run: >
-          pytest --cov --cov-append -n 4 -v
+          pytest --cov --cov-append -n 4 -v --durations=50
           --ignore=test/test_cli.py
           --ignore=test/test_cvedb.py
           --ignore=test/test_requirements.py
@@ -554,7 +554,7 @@ jobs:
           --ignore=test/test_json.py
       - name: Run synchronous tests
         run: >
-          pytest -v --cov --cov-append --cov-report=xml
+          pytest -v --cov --cov-append --cov-report=xml --durations=50
           test/test_cli.py
           test/test_cvedb.py
       - name: Cache conda
@@ -581,7 +581,7 @@ jobs:
           python -m pip install --upgrade -r dev-requirements.txt
           python -m pip install --upgrade .
       - name: Test PDF generation on Windows
-        run: pytest test/test_output_engine.py -k test_output_pdf --cov --cov-append --cov-report=xml
+        run: pytest test/test_output_engine.py -k test_output_pdf --cov --cov-append --cov-report=xml --durations=50
       - name: Upload code coverage to codecov
         uses: codecov/codecov-action@e28ff129e5465c2c0dcc6f003fc735cb6ae0c673 # v4.5.0
         with:

--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -121,7 +121,17 @@ class TestScanner:
     @pytest.mark.parametrize(
         "product, version, version_strings",
         (
-            (d["product"], d["version"], d["version_strings"])
+            pytest.param(
+                d["product"],
+                d["version"],
+                d["version_strings"],
+                marks=[
+                    pytest.mark.skipif(
+                        not LONG_TESTS(),
+                        reason="Test reduction in short tests",
+                    )
+                ],
+            )
             for list_data in mapping_test_data
             for d in list_data
         ),
@@ -275,7 +285,7 @@ class TestScanner:
             for d in list_data
         ),
     )
-    @pytest.mark.skipif(not LONG_TESTS, reason="Skipping long tests")
+    @pytest.mark.skipif(not LONG_TESTS(), reason="Skipping long tests")
     def test_version_in_package(
         self, url, package_name, product, version, other_products
     ):


### PR DESCRIPTION
Our short tests are currently not much shorter than our long tests. Since we've seldom seen only one version of python have a problem with a checker, I'm experimenting to see if running the many MANY mapping tests only in the long_tests jobs will help us reduce the time it takes for short tests to run.

I've also added some pytest insrumentation so we can see which of our tests take the longest to run so that we can hopefully find other places to reduce our usage footprint.

* fixes #4315