### PR TITLE
fix: improve schema validation for bandit

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -156,6 +156,8 @@ class CVEDB:
         "cve_exploited": "SELECT * FROM cve_exploited WHERE 1=0",
         "cve_metrics": "SELECT * FROM cve_metrics WHERE 1=0",
         "metrics": "SELECT * FROM metrics WHERE 1=0",
+        "mismatch": "SELECT * FROM mismatch WHERE 1=0",
+        "purl2cpe": "SELECT * FROM purl2cpe WHERE 1=0",
     }
 
     INSERT_QUERIES = {

--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -344,7 +344,7 @@ class CVEDB:
 
         self.LOGGER.debug("Check database is using latest schema")
         cursor = self.db_open_and_get_cursor()
-        schema_check = f"SELECT * FROM {table_name} WHERE 1=0"  # nosec
+        schema_check = self.EMPTY_SELECT_QUERIES[table_name]
         result = cursor.execute(schema_check)
         schema_latest = False
 


### PR DESCRIPTION
In the course of some other refactoring in cvedb.py, we've got another way to handle schema valiation such that bandit won't complain.

* fixes #3933
* closes #3965