### PR TITLE
fix: 0 cve pdf report was not generating

### DIFF
--- a/cve_bin_tool/output_engine/__init__.py
+++ b/cve_bin_tool/output_engine/__init__.py
@@ -179,6 +179,7 @@ try:
                 pdfdoc.tblStyle,
             )
             row = 1
+            star_warn = False
             for product_info, cve_data in all_cve_data.items():
                 star_warn = True if "*" in product_info.vendor else False
                 for cve in cve_data["cves"]:


### PR DESCRIPTION
* partially addresses #4326

This doesn't add regression tests, but it should at least get you a blank report.