### PR TITLE
fix: improve display of language checkers in output (#4328)

### DIFF
--- a/cve_bin_tool/version_scanner.py
+++ b/cve_bin_tool/version_scanner.py
@@ -134,10 +134,21 @@ class VersionScanner:
     # Language Checkers
     LANGUAGE_CHECKER_ENTRYPOINT = "cve_bin_tool.parsers"
 
+    @staticmethod
+    def _get_parser_name(parser_class):
+        """Extract the parser name from the class"""
+        return parser_class.__name__.lower().replace("parser", "")
+
     @classmethod
-    def available_language_checkers(cls) -> list[str]:
+    def available_language_checkers(cls):
         """Find Language checkers"""
-        return list(sorted(map(str, set(itertools.chain(*valid_files.values())))))
+        return sorted(
+            set(
+                cls._get_parser_name(parser)
+                for parsers in valid_files.values()
+                for parser in parsers
+            )
+        )
 
     def print_language_checkers(self) -> None:
         """Logs the message that lists the names of the language checkers"""


### PR DESCRIPTION
This pull request addresses the UI nitpick raised in issue #4328 regarding the display of language checkers in the output. The changes improve the readability and conciseness of the language checker list.

## Changes
- Modified `_get_parser_name()` method to extract parser name without 'Parser' suffix
- Updated `available_language_checkers()` to use `_get_parser_name()` for cleaner output
- Removed 'cve_bin_tool.parsers.' prefix and 'Parser' suffix from checker names

## Result
The output now displays language checkers in a more user-friendly format:
INFO     cve_bin_tool.VersionScanner - Language Checkers: dart, env, go, java, javascript, perl, php, python, pythonrequirements, r, ruby, rust, swift

## Testing
- Verified that the output matches the expected format
- Ensured existing functionality remains intact

## Related Issue
Fixes #4328

## Screenshot

![image](https://github.com/user-attachments/assets/bc815a7d-7205-47d9-b4e1-758615140ff4)

Please review and let me know if any further changes are needed.

