### PR TITLE
ci: disable csv cve scan temporarily

### DIFF
--- a/.github/workflows/cve_scan.yml
+++ b/.github/workflows/cve_scan.yml
@@ -1,8 +1,9 @@
 name: CVE scan
 
 on:
-  push:
-  pull_request:
+  #  push:
+  #  pull_request:
+  #  Temporarily disabled due to failures, will be integrated with cve-bin-tool-action
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Our csv-based CVE scan (i.e. the old scan) is failing slightly sporadically since we switched github runners.  I'm intending to get rid of it eventually (see #4294 ) but haven't done the work yet, and I don't have the time to figure out how to do that or fix it right now.

Since we have multiple cve scans going (cve-bin-tool action, snyk, dependabot, etc.) it's "safe" to disable this one so it's not getting in the way while we figure out the best solution, so this PR should make this so it only runs manually and will no longer run on pull requests and pushes to main.