### PR TITLE
ci: re-enable windows tests that previously failed

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -51,7 +51,7 @@ for i in test_data:
 
 DISABLED_TESTS_ACTIONS: list[str] = []
 DISABLED_TESTS_LOCAL: list[str] = []
-DISABLED_TESTS_WINDOWS: list[str] = ["libsrtp", "snapd"]
+DISABLED_TESTS_WINDOWS: list[str] = []
 
 
 class TestScanner:


### PR DESCRIPTION
* fixes #3923 (well, maybe)

This is a quick test to see if the snapd and libsrtp tests work on windows since we upgraded the version of python used on windows.  Previously they were both failing.

