### PR TITLE
fix: Help users learn about the mirrors

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -186,6 +186,7 @@ f
 faad
 facebook
 fastd
+fcix
 fde
 fedora
 fedoraproject
@@ -703,8 +704,8 @@ URI
 uri
 URIs
 url
-URLs
 urlopen
+URLs
 usecase
 username
 usr

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -21,4 +21,8 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: check-spelling/check-spelling@v0.0.22
       with:
-        post_comment: '0'
+        extra_dictionaries:
+          cspell:python/src/python/python.txt
+          cspell:public-licenses/src/generated/public-licenses.txt
+          cspell:filetypes/filetypes.txt
+          cspell:python/src/python/python-lib.txt

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -612,6 +612,7 @@ def main(argv=None):
     LOGGER.info(
         "This product uses the NVD API but is not endorsed or certified by the NVD."
     )
+    LOGGER.info("For potentially faster NVD downloads, mirrors are available using -n json-mirror")
 
     if args["nvd"] == "json":
         args["nvd"] = "json-mirror"
@@ -628,21 +629,16 @@ def main(argv=None):
     if not args["nvd_api_key"] and os.getenv("NVD_API_KEY"):
         args["nvd_api_key"] = os.getenv("NVD_API_KEY")
 
-    if args["nvd_api_key"]:
-        if nvd_type != "api2":
-            LOGGER.debug(
-                f"{nvd_type} - changing to api2. API Key {args['nvd_api_key']}"
-            )
-            nvd_type = "api2"
     # If you're not using an NVD key, let you know how to get one
-    if nvd_type == "json-nvd" and not args["nvd_api_key"] and not args["offline"]:
+    if nvd_type != "json-mirror" and not args["nvd_api_key"] and not args["offline"]:
         LOGGER.info("Not using an NVD API key. Your access may be rate limited by NVD.")
         LOGGER.info(
             "Get an NVD API key here: https://nvd.nist.gov/developers/request-an-api-key"
         )
 
     if nvd_type == "json-nvd":
-        LOGGER.warning("Using legacy JSON interface")
+        LOGGER.warning("Using legacy JSON interface.")
+        LOGGER.warning("You may want to switch to using cve-bin-tool's mirrors using -n json-mirror")
 
     if platform.system() != "Linux":
         warning_nolinux = """

--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -612,7 +612,9 @@ def main(argv=None):
     LOGGER.info(
         "This product uses the NVD API but is not endorsed or certified by the NVD."
     )
-    LOGGER.info("For potentially faster NVD downloads, mirrors are available using -n json-mirror")
+    LOGGER.info(
+        "For potentially faster NVD downloads, mirrors are available using -n json-mirror"
+    )
 
     if args["nvd"] == "json":
         args["nvd"] = "json-mirror"
@@ -638,7 +640,9 @@ def main(argv=None):
 
     if nvd_type == "json-nvd":
         LOGGER.warning("Using legacy JSON interface.")
-        LOGGER.warning("You may want to switch to using cve-bin-tool's mirrors using -n json-mirror")
+        LOGGER.warning(
+            "You may want to switch to using cve-bin-tool's mirrors using -n json-mirror"
+        )
 
     if platform.system() != "Linux":
         warning_nolinux = """

--- a/doc/MANUAL.md
+++ b/doc/MANUAL.md
@@ -612,10 +612,15 @@ This option controls the frequency of updates for the CVE data from the National
 
 ### -n {json-nvd,json-mirror,api,api2}, --nvd {json-nvd,json-mirror,api,api2}
 
-This option selects how CVE data is downloaded from the National Vulnerability Database. The `api` option previously used the NVD CVE Retrieval API version 1.0, which is now deprecated. Using `--nvd api` will automatically switch to the `--nvd api2` option. The `api2` option uses the later NVD CVE Retrieval API version 2.0. The results from this API are updated as quickly as the NVD database.
-A major benefit of using this NVD API is incremental updates which basically means you won't have to download the complete feed again in case you want the latest CVE entries from NVD. See the detailed guide on [incremental updates](how_to_guides/use_incremental_updates.md) for more details.
+This option selects how CVE data is downloaded from the National Vulnerability Database.
+
+As of cve-bin-tool 3.3, our default is to use our own mirrors of the JSON data provided by NVD. These mirrors are backed by the same <a href="https://mirror.fcix.net/">FCIX micro mirror project</a> that provides content distribution for many major open source projects and linux distributions, and they do not have rate limits or require API keys to use, making them the best choice for many casual users.  The mirrors are updated multiple times daily, and users who need brand new data released within the last hour can download the initial info from the mirror and then get incremental updates from NVD using `--nvd api2` as needed.
+
+The `api2` option uses the NVD CVE Retrieval API version 2.0. The results from this API are updated as quickly as the NVD database.  A major benefit of using this NVD API is incremental updates which basically means you won't have to download the complete feed again in case you want the latest CVE entries from NVD. See the detailed guide on [incremental updates](how_to_guides/use_incremental_updates.md) for more details.
 
 You may also choose to update the data using `json-nvd` option which uses the JSON feeds available on [this page](https://nvd.nist.gov/vuln/data-feeds). These per-year feeds are updated once per day. This mode was the default for CVE Binary Tool prior to the 3.0 release.
+
+Deprecation: The `api` option previously used the NVD CVE Retrieval API version 1.0, which is now deprecated by NVD. Using `--nvd api` will automatically switch to the `--nvd api2` option.
 
 ### --nvd-api-key NVD_API_KEY
 


### PR DESCRIPTION
- Adds log info messages about the mirrors
- Updates the manual to include more explanation of the mirror option
- Fix some logic around when we display a message about the nvd_api_key
- Switch so having an nvd_api_key doesn't automatically switch you to api2 (this turned out to be surprising in cases of people trying out the mirror)
- fixes #4037