### PR TITLE
fix: halt if pdf selected but unavailable

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -63,6 +63,7 @@ from cve_bin_tool.error_handler import (
     InsufficientArgs,
     InvalidExtensionError,
     MirrorError,
+    PDFOutputUnavailable,
     excepthook,
 )
 from cve_bin_tool.input_engine import InputEngine, TriageData
@@ -893,11 +894,14 @@ def main(argv=None):
 
     # Check for PDF support
     if "pdf" in output_formats and importlib.util.find_spec("reportlab") is None:
-        LOGGER.info("PDF output not available.")
-        LOGGER.info(
+        LOGGER.error("PDF output not available.")
+        LOGGER.error(
             "If you want to produce PDF output, please install reportlab using pip install reportlab"
         )
         output_formats.remove("pdf")
+        if len(output_formats) < 1:
+            # If there's no other formats selected, exit so people actually see the error
+            return ERROR_CODES[PDFOutputUnavailable]
 
     merged_reports = None
     if args["merge"]:

--- a/cve_bin_tool/error_handler.py
+++ b/cve_bin_tool/error_handler.py
@@ -145,6 +145,10 @@ class NetworkConnectionError(Exception):
     """Raised when issue occurred with internet connection"""
 
 
+class PDFOutputUnavailable(Exception):
+    """Raised when reportlab is not installed and PDF output is unavailable"""
+
+
 class ErrorMode(Enum):
     Ignore = 0
     NoTrace = 1
@@ -246,4 +250,5 @@ ERROR_CODES = {
     InvalidExtensionError: 42,
     SigningError: 43,
     NetworkConnectionError: 44,
+    PDFOutputUnavailable: 45,
 }

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -706,7 +706,7 @@ class TestCLI(TempDirTest):
 
         assert (
             "cve_bin_tool",
-            logging.INFO,
+            logging.ERROR,
             not_installed_msg,
         ) in caplog.record_tuples
 


### PR DESCRIPTION
* Related to #4326

If pdf output is selected but isn't available, then cve-bin-tool tells you to install reportlab, but it was easy to miss that message as the scan continued and pushed it off the screen.  This changes those messages to be errors insead of info messages, and exits without doing a scan if pdf is the only output mode selected.