### PR TITLE
chore: bump version to 3.4rc0 for pre-release

### DIFF
--- a/cve_bin_tool/version.py
+++ b/cve_bin_tool/version.py
@@ -8,7 +8,7 @@ from packaging import version
 from cve_bin_tool.log import LOGGER
 from cve_bin_tool.util import make_http_requests
 
-VERSION: str = "3.3.1dev0"
+VERSION: str = "3.4rc0"
 
 HTTP_HEADERS: dict = {
     "User-Agent": f"cve-bin-tool/{VERSION} (https://github.com/intel/cve-bin-tool/)",


### PR DESCRIPTION
Decided that now that we're down to mostly test/diocs issues left, it was fair game to call this a release candidate rather than an alpha or a beta.