### PR TITLE
fix: set packaging minimum version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ lib4sbom>=0.7.2
 lib4vex>=0.1.0
 python-gnupg
 packageurl-python
-packaging
+packaging>=22.0
 plotly
 pyyaml>=5.4
 requests>=2.32.2


### PR DESCRIPTION
Set packaging minimum version to 22.0 to avoid the following error with setuptools 71.x:

```
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```

Likelihood of encountering this error increased since commit e4239bd3b838b1717e295412113030ee42631fc6 which bumped minimum version of setuptools from 65.5.1 to 70.0.0

More information:
 - https://github.com/pypa/setuptools/issues/4483
 - https://github.com/pypa/setuptools/issues/4501