### PR TITLE
fix: improve hostapd checker

### DIFF
--- a/cve_bin_tool/checkers/hostapd.py
+++ b/cve_bin_tool/checkers/hostapd.py
@@ -19,6 +19,6 @@ class HostapdChecker(Checker):
     FILENAME_PATTERNS = [r"hostapd"]
     VERSION_PATTERNS = [
         r"\nhostapd[_a-z]* v([0-9]+\.[0-9]+)",
-        r"([0-9]+\.[0-9]+)[a-z-]*\r?\nhostapd",
+        r"([0-9]+\.[0-9]+)[a-z-]*\r?\nhostapd[_a-z]* v",
     ]
     VENDOR_PRODUCT = [("w1.fi", "hostapd")]

--- a/test/test_data/hostapd.py
+++ b/test/test_data/hostapd.py
@@ -6,7 +6,7 @@ mapping_test_data = [
     {
         "product": "hostapd",
         "version": "2.10",
-        "version_strings": ["2.10-devel\nhostapd"],
+        "version_strings": ["2.10-devel\nhostapd v"],
     },
 ]
 package_test_data = [


### PR DESCRIPTION
Update hostapd pattern to avoid raising a wrong version of 1.100 with some proprietary binary which defines the following strings:

```
192.168.1.100
hostapd_ctrl_interface
```