### PR TITLE
test: regression test for 0 cve pdf report

### DIFF
--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -4,6 +4,7 @@
 """
 CVE-bin-tool CLI tests
 """
+import importlib
 import logging
 import os
 import re
@@ -729,6 +730,42 @@ class TestCLI(TempDirTest):
             logging.INFO,
             not_installed_msg,
         ) not in caplog.record_tuples
+
+    @pytest.mark.skipif(
+        not importlib.util.find_spec("reportlab"),
+        reason="Reportlab needed for pdf test",
+    )
+    def test_0_cve_pdf_report(self, caplog):
+        """Tests to make sure --report behaves as expected when 0 cves are found.
+        We expect a short pdf file saying 0 cves were found."""
+
+        with tempfile.TemporaryDirectory() as emptytemp:
+            # Set a filename for report in tempdir, make sure it doesn't exist.
+            report_0 = Path(self.tempdir) / "0_cve_report.pdf"
+            if report_0.exists():
+                report_0.unlink()
+
+            # Call cve-bin-tool to scan empty dir and product pdf report.
+            cbt_command = [
+                "cve-bin-tool",
+                "--offline",
+                "--format",
+                "pdf",
+                "-o",
+                str(report_0),
+                "--report",
+                str(emptytemp),
+            ]
+            main(cbt_command)
+
+            # Make sure the report was created and has something in it.
+            # Testing what's in the report would increase test execution time
+            # so we're leaving that out for now
+            assert report_0.exists()
+            assert report_0.stat().st_size > 0
+
+            # get rid of generated file
+            report_0.unlink()
 
     yamls = [
         [


### PR DESCRIPTION
Adds a regression test for 0-cve pdf report behaviour.  This should help us avoid bugs that cause the report to fail in the case where 0 cves were found.

This is the last piece needed to close #4326.  Other pieces:

* #4329 fixed the check that was causing report generaiton to fail.
* #4354 changed the UI so it's more obvious when reportlab is needed.

* fixes #4326