### PR TITLE
test: re-enable some disabled tests

### DIFF
--- a/test/test_csv2cve.py
+++ b/test/test_csv2cve.py
@@ -11,7 +11,6 @@ from cve_bin_tool.error_handler import ERROR_CODES, InsufficientArgs
 
 
 class TestCSV2CVE:
-    @pytest.mark.skip(reason="Cache is broken, disabling temporarily")
     @pytest.mark.asyncio
     async def test_csv2cve_valid_file(self, caplog):
         file_path = join(dirname(__file__), "csv", "triage.csv")

--- a/test/test_exploits.py
+++ b/test/test_exploits.py
@@ -81,7 +81,6 @@ class TestExploitScanner:
             ),
         ),
     )
-    @pytest.mark.skip(reason="Cache is broken, disabling temporarily")
     def test_exploit_checker(
         self, check_exploits, exploits_list, product_info, triage_info, expected_result
     ):

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -11,7 +11,6 @@ import pytest
 from cve_bin_tool import parsers
 from cve_bin_tool.cvedb import CVEDB
 from cve_bin_tool.log import LOGGER
-from cve_bin_tool.util import ProductInfo
 from cve_bin_tool.version_scanner import VersionScanner
 
 
@@ -369,7 +368,6 @@ class TestLanguageScanner:
             assert p in found_product
         assert file_path == filename
 
-    @pytest.mark.skip(reason="Cache is broken, disabling temporarily")
     @pytest.mark.parametrize("filename", ((str(TEST_FILE_PATH / "PKG-INFO")),))
     def test_python_package(self, filename: str) -> None:
         """Test against python's PKG-INFO metadata file"""
@@ -378,7 +376,7 @@ class TestLanguageScanner:
         for product in scanner.scan_file(filename):
             if product:
                 product_info, file_path = product
-                assert product_info == ProductInfo(
-                    "facebook", "zstandard", "0.18.0", filename
-                )
+                assert product_info[1] == "zstandard"
+                assert product_info[2] == "0.18.0"
+                assert product_info[3] == filename
         assert file_path == filename


### PR DESCRIPTION
* replaces #4353
* partial fix for #4243

Re-enables the tests that are now passing consistently, fixes expectations for zstandard vendor.