### PR TITLE
fix: remove excessively noisy cvedb debug message

### DIFF
--- a/cve_bin_tool/cvedb.py
+++ b/cve_bin_tool/cvedb.py
@@ -643,9 +643,6 @@ class CVEDB:
             metric = list(map(lambda x: x[0], cursor.fetchall()))
             # Since the query is expected to return a single result, extract the first item from the list and store it in 'metric'
             metric = metric[0]
-            self.LOGGER.debug(
-                f'For the given cve {cve["ID"]} the cvss version found {cve["CVSS_version"]} metrics ID added into database {metric}'
-            )
         return metric
 
     def clear_cached_data(self) -> None:


### PR DESCRIPTION
This message was firing so frequently that it was making it difficult to debug another issue.  As it didn't seem useful I've removed it rather than commenting it out.  We can always add it back in later if it's needed for future debug work.