### PR TITLE
chore: min version of lib4vex to 0.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ importlib_resources; python_version < "3.9"
 jinja2>=2.11.3
 jsonschema>=3.0.2
 lib4sbom>=0.7.2
-lib4vex>=0.1.0
+lib4vex>=0.2.0
 python-gnupg
 packageurl-python
 packaging>=22.0


### PR DESCRIPTION
To match the test update in #4403