### PR TITLE
fix: handle : in filenames better

### DIFF
--- a/test/test_scanner.py
+++ b/test/test_scanner.py
@@ -83,6 +83,10 @@ class TestScanner:
         shutil.rmtree(cls.package_test_dir)
         shutil.rmtree(cls.mapping_test_dir)
 
+    def windows_fixup(self, filename):
+        """Replace colon and backslash in filename to avoid a failure on Windows"""
+        return filename.replace(":", "_").replace("\\", "_")
+
     def test_false_positive(self):
         self.scanner.all_cves = []
         with tempfile.NamedTemporaryFile(
@@ -148,10 +152,9 @@ class TestScanner:
             f"{'.'.join(list(product))}-{version}.out",
         ]
         for filename in filenames:
-            # Replace colon and backslash in filename to avoid a failure on Windows
             with tempfile.NamedTemporaryFile(
                 "w+b",
-                suffix=filename.replace(":", "_").replace("\\", "_"),
+                suffix=self.windows_fixup(filename),
                 dir=self.mapping_test_dir,
                 delete=False,
             ) as f:
@@ -234,7 +237,7 @@ class TestScanner:
                 dirpath.mkdir()
         # Check if we've already made a condensed version of the file, if we
         # have, we're done.
-        condensed_path = condensed_dir / (package_name + ".tar.gz")
+        condensed_path = condensed_dir / (self.windows_fixup(package_name) + ".tar.gz")
         if condensed_path.is_file():
             return str(condensed_path)
         # Download the file if we don't have a condensed version of it and we


### PR DESCRIPTION
Replace colon and backslash in `filename` to avoid a failure on Windows in `condensed_filepath` function as already done in `test_version_mapping` function

Fix #4401