### PR TITLE
fix: Backwards compatibility for vex triage

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -27,6 +27,7 @@ import importlib.util
 import logging
 import os
 import platform
+import shutil
 import sys
 import textwrap
 import time
@@ -64,6 +65,7 @@ from cve_bin_tool.error_handler import (
     InvalidExtensionError,
     MirrorError,
     PDFOutputUnavailable,
+    VEXError,
     excepthook,
 )
 from cve_bin_tool.input_engine import InputEngine, TriageData
@@ -545,6 +547,13 @@ def main(argv=None):
 
     deprecated_group = parser.add_argument_group("Deprecated")
     deprecated_group.add_argument(
+        "--triage-input-file",
+        action="store",
+        help="replaced by --vex-file",
+        default="",
+    )
+
+    deprecated_group.add_argument(
         "-x",
         "--extract",
         action="store_true",
@@ -657,6 +666,31 @@ def main(argv=None):
                           **********************************************
                           """
         LOGGER.warning(warning_nolinux)
+
+    # warning about deprecated "--triage-input-file" argument
+    if args["triage_input_file"]:
+        LOGGER.error(
+            " --triage-input-file has been deprecated. Please use --vex-file in future."
+        )
+        args["vex_file"] = args["triage_input_file"]
+        if args["vex_file"].endswith(".vex"):
+            # Auto-switch it to .json
+            LOGGER.error(".vex extension no longer supported, please use .json")
+
+            file_copy = Path(args["vex_file"] + ".cve-bin-tool-auto.json")
+            original_file = Path(args["vex_file"])
+            if not file_copy.exists():
+                LOGGER.error("Trying to make a copy with .json extension for this run.")
+                LOGGER.error("You will need to use this copy in future scans.")
+                shutil.copy(original_file, file_copy)
+                args["vex_file"] = str(file_copy)
+            else:
+                # abort and let the user deal with it
+                LOGGER.error(
+                    "Looks like a previous run of cve-bin-tool already made a copy."
+                )
+                LOGGER.error(f"Try re-running with --vex-file {file_copy}")
+                return ERROR_CODES[VEXError]
 
     # CSVScanner related settings
     score = 0

--- a/cve_bin_tool/error_handler.py
+++ b/cve_bin_tool/error_handler.py
@@ -149,6 +149,10 @@ class PDFOutputUnavailable(Exception):
     """Raised when reportlab is not installed and PDF output is unavailable"""
 
 
+class VEXError(Exception):
+    """Raised when VEX file provided is invalid"""
+
+
 class ErrorMode(Enum):
     Ignore = 0
     NoTrace = 1
@@ -251,4 +255,5 @@ ERROR_CODES = {
     SigningError: 43,
     NetworkConnectionError: 44,
     PDFOutputUnavailable: 45,
+    VEXError: 46,
 }


### PR DESCRIPTION
* related to #4417

This adds a little bit of backwards compatibility for vex triage
* If --triage-input-file is used, display deprecation warning and convert to --vex-file" so scan can continue.
* If file extension in .vex, the first time, make a copy and scan anyhow.  On subsequent times, print an error asking the user to use --vex-file <new file name>

It might be more elegant to edit lib4vex to handle .vex filenames more seamlessly there, but I feel like "give people one chance and then error" is probably more likely to help people switch to the new arguments so we don't have to support the old ones forever and won't break as many CI jobs.