### PR TITLE
fix: improve comment propagation from lib4vex

### DIFF
--- a/cve_bin_tool/vex_manager/parse.py
+++ b/cve_bin_tool/vex_manager/parse.py
@@ -113,7 +113,7 @@ class VEXParse:
             remarks = self.analysis_state[self.vextype][vuln.get("status")]
             justification = vuln.get("justification")
             response = vuln.get("remediation")
-            comments = vuln.get("comments")
+            comments = vuln.get("comment")
             severity = vuln.get("severity")  # Severity is not available in Lib4VEX
             # Decode the bom reference for cyclonedx and purl for csaf and openvex
             product_info = None

--- a/test/test_vex.py
+++ b/test/test_vex.py
@@ -173,7 +173,7 @@ class TestVexParse:
             },
             "CVE-1234-1005": {
                 "remarks": Remarks.NotAffected,
-                "comments": "",
+                "comments": "Detail field populated.",
                 "response": [],
             },
             "paths": {},
@@ -187,7 +187,7 @@ class TestVexParse:
         ): {
             "CVE-1234-1007": {
                 "remarks": Remarks.Mitigated,
-                "comments": "",
+                "comments": "Data field populated.",
                 "response": [],
             },
             "CVE-1234-1008": {
@@ -212,7 +212,7 @@ class TestVexParse:
             },
             "CVE-1234-1005": {
                 "remarks": Remarks.NotAffected,
-                "comments": "",
+                "comments": "NotAffected: Detail field populated.",
                 "response": "will_not_fix",
                 "justification": "code_not_reachable",
             },
@@ -226,7 +226,7 @@ class TestVexParse:
         ): {
             "CVE-1234-1007": {
                 "remarks": Remarks.Mitigated,
-                "comments": "",
+                "comments": "Data field populated.",
                 "response": [],
             },
             "CVE-1234-1008": {


### PR DESCRIPTION
* related to #4417 
 
We're getting a "comment" field from lib4vex and then trying to parse a "comments" one.  this is an experiment to see if any of our tests breaks if I "fix" it.  (it is not, incidentally, fixing the full issue in 4417)