### PR TITLE
fix: fix glibc patterns

### DIFF
--- a/cve_bin_tool/checkers/glibc.py
+++ b/cve_bin_tool/checkers/glibc.py
@@ -34,16 +34,5 @@ class GlibcChecker(Checker):
     VERSION_PATTERNS = [
         r"GNU C Library \([a-zA-Z0-9 \+\-\.]*\) (?:release|stable) release version ([012](\.[0-9]+){1,2})",
         r"GLIBC ([012](\.[0-9]+){1,2})[a-z0-9+\-]*\) \r?\n",
-        r"libc-([012](\.[0-9]+){1,2})\.so",  # patterns like this aren't ideal (check the end of the file)
-        r"ld-([012]\.[0-9]+)\.so",  # patterns like this aren't ideal
-        r"libanl-([012](\.[0-9]+){1,2})\.so",  # patterns like this aren't ideal
-        r"ld-([012](\.[0-9]+){1,2})\.so",  # patterns like this aren't ideal
     ]
     VENDOR_PRODUCT = [("gnu", "glibc")]
-
-
-"""
-Using filenames (containing patterns like '.so' etc.) in the binaries as VERSION_PATTERNS aren't ideal.
-The reason behind this is that these might depend on who packages the file (like it
-might work on fedora but not on ubuntu)
-"""


### PR DESCRIPTION
Drop wrong patterns to avoid the following false positive with the following lines of `/usr/lib/python3/dist-packages/psutil-5.9.8.dist-info/METADATA`:

```
    >>> p.memory_maps()
    [pmmap_grouped(path='/lib/x8664-linux-gnu/libutil-2.15.so', rss=32768, size=2125824, pss=32768, shared_clean=0, shared_dirty=0, private_clean=20480, private_dirty=12288, referenced=32768, anonymous=12288, swap=0),
     pmmap_grouped(path='/lib/x8664-linux-gnu/libc-2.15.so', rss=3821568, size=3842048, pss=3821568, shared_clean=0, shared_dirty=0, private_clean=0, private_dirty=3821568, referenced=3575808, anonymous=3821568, swap=0),
     pmmap_grouped(path='[heap]',  rss=32768, size=139264, pss=32768, shared_clean=0, shared_dirty=0, private_clean=0, private_dirty=32768, referenced=32768, anonymous=32768, swap=0),
     pmmap_grouped(path='[stack]', rss=2465792, size=2494464, pss=2465792, shared_clean=0, shared_dirty=0, private_clean=0, private_dirty=2465792, referenced=2277376, anonymous=2465792, swap=0),
     ...]
```