### PR TITLE
fix: prepend justification to comments

### DIFF
--- a/cve_bin_tool/vex_manager/parse.py
+++ b/cve_bin_tool/vex_manager/parse.py
@@ -114,6 +114,11 @@ class VEXParse:
             justification = vuln.get("justification")
             response = vuln.get("remediation")
             comments = vuln.get("comment")
+
+            # If the comment doesn't already have the justification prepended, add it
+            if comments and justification and not comments.startswith(justification):
+                comments = f"{justification}: {comments}"
+
             severity = vuln.get("severity")  # Severity is not available in Lib4VEX
             # Decode the bom reference for cyclonedx and purl for csaf and openvex
             product_info = None

--- a/test/test_vex.py
+++ b/test/test_vex.py
@@ -212,7 +212,7 @@ class TestVexParse:
             },
             "CVE-1234-1005": {
                 "remarks": Remarks.NotAffected,
-                "comments": "NotAffected: Detail field populated.",
+                "comments": "code_not_reachable: NotAffected: Detail field populated.",
                 "response": "will_not_fix",
                 "justification": "code_not_reachable",
             },


### PR DESCRIPTION
* workaround for #4439

I decided it was probably better to retain the 3.3 behaviour for now; we can decide if that's the right choice for future releases later.