### PR TITLE
fix: match cli arguments description

### DIFF
--- a/cve_bin_tool/cli.py
+++ b/cve_bin_tool/cli.py
@@ -206,7 +206,7 @@ def main(argv=None):
     input_group.add_argument(
         "--vex-file",
         action="store",
-        help="provide vulnerability exchange (vex) filename for triage processing",
+        help="provide vulnerability exploitability exchange (vex) filename for triage processing",
         default="",
     )
 
@@ -353,7 +353,7 @@ def main(argv=None):
     vex_output_group.add_argument(
         "--vex-output",
         action="store",
-        help="Provide vulnerability exchange (vex) filename to generate",
+        help="Provide vulnerability exploitability exchange (vex) filename to generate",
         default="",
     )
     vex_output_group.add_argument(
@@ -361,7 +361,7 @@ def main(argv=None):
         action="store",
         default="",
         choices=["cyclonedx", "csaf", "openvex"],
-        help="specify type of vulnerability exchange (vex) to generate (default: cyclonedx)",
+        help="specify type of vulnerability exploitability exchange (vex) to generate (default: cyclonedx)",
     )
     vex_output_group.add_argument(
         "--product",


### PR DESCRIPTION
fixes #4455 

This PR updates the CLI arguments description changed in #4443 in the [cli.py](https://github.com/intel/cve-bin-tool/blob/main/cve_bin_tool/cli.py) file.

@terriko 