### PR TITLE
docs: add missing release notes to RELEASE.md

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -262,6 +262,7 @@ gstreamer
 gupnp
 gvfs
 gzip
+Hackathon
 Hacktoberfest
 haproxy
 harfbuzz
@@ -290,6 +291,7 @@ img
 imgur
 imsahil
 INI
+inosmeet
 iperf
 ipk
 ipmitool
@@ -309,6 +311,7 @@ javascript
 jdk
 jerinjtitus
 jhead
+joydeep
 jq
 jquery
 json
@@ -407,6 +410,7 @@ Management
 Manjaro
 mariadb
 mariuszskon
+mastersans
 mbedtls
 mcmilk
 mdadm
@@ -516,8 +520,8 @@ p
 pacman
 palletsprojects
 pango
-PASSPHRASE
 passphrase
+PASSPHRASE
 patch
 pcre
 pcsc
@@ -528,8 +532,8 @@ pdftotext
 pdxjohnny
 peb
 perl
-PGP
 pgp
+PGP
 php
 picocom
 pigz
@@ -575,6 +579,7 @@ quickstart
 qyr
 radare
 radvd
+raffifu
 Rahul
 raptor
 rauc
@@ -591,6 +596,7 @@ regex
 renv
 reportlab
 requirementstxt
+Rexbeast
 rhythmrx
 Rishabh
 Romi
@@ -663,6 +669,7 @@ systemd
 SYSV
 tagvalue
 tar
+tarfiles
 taskbar
 tcpdump
 tcpreplay
@@ -708,8 +715,8 @@ uniq
 unittest
 unixodbc
 upx
-URI
 uri
+URI
 URIs
 url
 urlopen
@@ -733,8 +740,8 @@ virtualenv
 visualstudio
 vlc
 vm
-Vorbis
 vorbis
+Vorbis
 VPkg
 vsftpd
 Vulnerability

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -45,6 +45,8 @@ The new mismatch documentation can be found here: https://cve-bin-tool.readthedo
 
 ## CVE Binary Tool 3.4rc3
 
+Pre-release for v3.4.
+
 ## CVE Binary Tool 3.4rc2
 
 Some late-breaking changes to improve backwards compatibility and fix a bug in comment propagation for triage.

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -1,5 +1,130 @@
 # CVE Binary Tool Release Notes
 
+## CVE Binary Tool 3.4
+
+### Release highlights
+
+This release comes with the finished products from our two Google Summer of Code 2024 contributors:
+
+- GSoC 2024 contributor [@mastersans](https://github.com/mastersans) has improved our triage workflow and VEX support.
+- GSoC 2024 contributor [@inosmeet](https://github.com/inosmeet) has added PURL identifier support and improved tooling for reducing false positives.
+
+Thank you especially to [@anthonyharrison](https://github.com/anthonyharrison), [@BenL-github](https://github.com/BenL-github) and [@terriko](https://github.com/terriko) for being Google Summer of Code mentors for us this year. For more details about these projects, see the "Improved VEX support" and "PURL and mismatch database" sections below.
+
+This release also includes
+
+- numerous new and improved binary checkers thanks to [@ffontaine](https://github.com/ffontaine)
+- improvements both to our fuzzing infrastructure and fixes for issues found (shout out to [@joydeep049](https://github.com/joydeep049) who laid a lot of groundwork here)
+- many other bug fixes and features listed below.
+
+Thanks also to the many new bug reporters who gave us feedback this release. Your feedback has been instrumental in making cve-bin-tool better, and we're so glad you've been willing to work with us as we try to find fixes for your issues. We love finding out how people use cve-bin-tool and ways we can make it more useful to you!
+
+### Breaking changes
+
+The `--triage--input-file` flag has been replaced by `--vex-input`. (See VEX section below for details.)
+
+### Improved VEX support
+
+GSoC 2024 contributor [@mastersans](https://github.com/mastersans) has improved the CVE Binary Tool by revamping the VEX workflow to integrate Lib4vex, which now handles both parsing and generating VEX files. This update aligns the sbom_manager with the vex_manager structure, enhancing overall functionality.
+
+The focus was on integrating advanced VEX triage features, which involved a thorough refactoring of the existing workflow. This includes support for various VEX formats like CSAF, OpenVEX, and CycloneDX. Key enhancements include linking Components in the File being scanned using identifiers such as bom-ref and Package URL (purl) to precisely identify Product_Info (product, version, and vendor). Specifically, bom-ref is used in CycloneDX VEX, while purl is used in CSAF and OpenVEX formats. These identifiers help in accurately pinpointing product details like vendor and release.
+
+The triage process has also been streamlined: the old --triage-input-file flag is replaced with the new --vex-file flag. This new flag automatically detects the VEX format and whether the file is standalone or paired with a companion file. Additionally, the --filter-triage flag allows you to filter out vulnerabilities marked as NotAffected and FalsePositive in the VEX document, ensuring that only relevant vulnerabilities are reported.
+
+The new triaging documentation can be found here: https://cve-bin-tool.readthedocs.io/en/latest/triaging_process.html
+
+### PURL and Mismatch database
+
+GSoC 2024 contributor [@inosmeet](https://github.com/inosmeet) has added support for PURL identifiers and the purl2cpe database to our code, as well as a new "mismatch" database to help us fine tune product name matching.
+
+Previously, our code assumed that the product name in a language dependency list would match the product name in our vulnerability data sources, and this sometimes produced false positives when product names were re-used across languages/vendors. Using PURLs to more precisely identify components from language scans and the purl2cpe database to look up human-verified matches in the vulnerability database should increase cve-bin-tool's accuracy.
+
+The mismatch database provides another way to fine-tune results by allowing us to drop name collisions that are causing false positives. For example, there may be multiple languages with a package named "xml" -- if they had entries in the vulnerability databases then purl2cpe would handle finding the right one, but if they had no matches then we fallback to a search and sometimes found an incorrect set of vulnerabilities. This allows us to explicitly define mistaken matches and exclude them from results.
+
+The new mismatch documentation can be found here: https://cve-bin-tool.readthedocs.io/en/latest/mismatch_data.html
+
+## CVE Binary Tool 3.4rc3
+
+## CVE Binary Tool 3.4rc2
+
+Some late-breaking changes to improve backwards compatibility and fix a bug in comment propagation for triage.
+
+## CVE Binary Tool 3.4rc1
+
+Final (hopefully!) pre-release for 3.4.
+
+## CVE Binary Tool 3.4rc0
+
+Pre-release for v3.4
+
+## CVE Binary Tool 3.3
+
+### Release highlights
+
+- GSoC 2023 contributor [@Rexbeast2](https://github.com/Rexbeast2) added support for EPSS scores to help users assess vulnerability risks (more info : https://cve-bin-tool.readthedocs.io/en/latest/MANUAL.html#metric)
+
+- GSoC 2023 contributor [@b31ngd3v](https://github.com/b31ngd3v) has set up a github action (available here: https://github.com/intel/cve-bin-tool-action) and did a lot of work related to using our new NVD mirror (available here: https://cveb.in/)
+
+- We now default to using our own NVD mirror unless an NVD_API_KEY is set.
+  - The data is updated multiple times per day and duplicated to mirrors in several countries across the globe. They should be significantly faster than getting data from NVD directly, especially if you need to populate a database from scratch.
+  - Mirroring infrastructure is provided by FCIX Software Mirrors, who currently provide a large portion of the global mirroring for linux distributions and other open source projects.
+  - If you have difficulties with the mirrors or wish us to activate a mirror closer to you (we're only using a fraction of the servers available), please file an issue https://github.com/intel/cve-bin-tool/issues
+  - These mirrors can be used in other tools or as part of research. We'd love to know if and how you use them!
+
+- Breaking Change: Windows users will now need to use python 3.12 if they want to scan tarfiles.
+  - Testing has been disabled on windows for python < 3.12. It's likely that older versions of python will continue to work on Windows as long as you don't need tarfile support, but our binary checker tests use tarfiles so we can no longer run the full test suite.
+
+- We now provide our own version compare function, which will not be limited to PEP 440 compliant semantic versions.
+
+- Thanks especially to [@ffontaine](https://github.com/ffontaine) we are up to 359 binary checkers!
+
+- Our fuzz testing has been improved to cover more of our language file parsers. Thanks especially to [@joydeep049](https://github.com/joydeep049), [@mastersans](https://github.com/mastersans), [@raffifu](https://github.com/raffifu) and [@inosmeet](https://github.com/inosmeet) for their work in setting these up and fixing errors found via fuzzing.
+
+We've also got a large number of new contributors, many of whom participated in Hacktoberfest 2023 or the first part of GSoC 2024, as well as users and security experts who were generous enough to share their time and expertise with us outside of these open source beginner-focused programs. Thank you!
+
+## CVE Binary Tool 3.3rc3 pre-release
+
+Assorted bugfixes, new checkers, and improvements (see details below). This may be the last pre-release before 3.3 if we don't find any additional issues.
+
+BREAKING CHANGE: Windows users will now have to use python 3.12 if they intend to scan tarfiles.
+
+## CVE Binary Tool 3.3rc2 pre-release
+
+This pre-release improved the version compare function so it can handle certain distro versions and other special version cases more smoothly. Note that it does not have any special handling for hashes because they appear infrequently in the NVD data, but you may have some unpredictable results if you have hashes listed in an SBOM or local version.
+
+## CVE Binary Tool 3.3rc1 pre-release
+
+This has some fixes for the version compare function that were reported against the previous pre-release, as well as some new checkers and bugfixes.
+
+## CVE Binary Tool pre-release 3.3a0
+
+Preview release for 3.3, which will hopefully be coming in December.
+
+There's a *lot* of changes in this release, but I'm particularly eager to have people try out the new version compare function and make sure it is sufficiently robust for arbitrary versions, as we needed to migrate away from the function provided in python packaging as it could not handle some of the versions we see in the NVD data.
+
+## CVE Binary Tool 3.2.1
+
+Due to a change in the data used for the `curl` data source, we're issuing a slightly out of band point release for users unable to use 3.2.
+
+There are a number of checker updates to address false positives, new checkers, and other bug fixes and features as described below.
+
+One commonly requested feature has made it into this release: generation of SBOMs. Please try it out and let us know where it can be improved!
+
+Thanks especially to the *many* new contributors in this release
+
+- Many of you joined us via the Google Summer of Code 2023 selection process: I wish we'd had mentors and slots available to have more of you as paid contributors this year!
+- Some of you also joined us via the Intel Open Source Hackathon: thank you so much for taking the time to work with us and it's been a delight to work with so many experienced coders during the event.
+- And some of you just stopped by on your own with great ideas and fixes. Thank you!
+
+
+## CVE Bin Tool pre-release 3.2.1rc0
+
+Due to a change in the data used for the `curl` data source, we're issuing a slightly out of band point release for users unable to use 3.2.
+
+There are a number of checker updates to address false positives, new checkers, and other bug fixes and features.
+
+One commonly requested feature has made it into this release: generation of SBOMs. Please try it out and let us know where it can be improved!
+
 ## CVE Binary Tool 3.2
 
 ### New features from our GSoC 2022 participants:


### PR DESCRIPTION
Fixes #4458. I removed the GitHub changelogs and any references to them, since the notes for the previous releases don't include them. I also added a brief release note for release 3.4rc3 which didn't have one. Please let me know if you'd like anything changed.