### PR TITLE
chore: annotate testing binaries (OSSF scorecard)

### DIFF
--- a/.github/scorecard.yml
+++ b/.github/scorecard.yml
@@ -1,0 +1,5 @@
+annotations:
+  - checks:
+      - binary-artifacts
+    reasons:
+      - reason: test-data # binary files for testing binary scanner. Most are text signatures with no code.


### PR DESCRIPTION
OpenSSF scorecard currently complains about our binary files.  This adds an annotation explaining what's in them and why we have them in case anyone's curious.