### PR TITLE
fix: week error in fuzzing scripts

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -100,7 +100,7 @@ jobs:
           echo "Found Fuzzing scripts: ${fuzzing_scripts[@]}"
           current_week=($(date -u +%U))
           echo "Current week number: $current_week"
-          at_index=$((($(date -u +%U) % ${#fuzzing_scripts[@]})))
+          at_index=$(((10#$(date -u +%U)) % ${#fuzzing_scripts[@]}))
           selected_script="${fuzzing_scripts[$at_index]}"
           echo "Selected script: $selected_script"
           timeout --preserve-status --signal=SIGINT 60m python $selected_script


### PR DESCRIPTION
**Issue:**
In bash, when you use `((` for arithmetic evaluation, numbers with leading zeros are interpreted as octal numbers. Since '9' isn't a valid octal digit, you get the error: value too great for base (error token is "09").

**Fix:**
This PR updates the script to force decimal interpretation of the week number using 10# in the arithmetic expression:
`at_index=$(((10#$(date -u +%U)) % ${#fuzzing_scripts[@]}))`

![Screenshot 2025-03-04 174632](https://github.com/user-attachments/assets/de910091-29d6-40d2-95e1-a9a881baa863)

As you can see now, the correct script is being selected for week 9. I've also tested running fuzzing script on my fork in GitHub Actions.

https://github.com/its403/cve-bin-tool/actions/runs/13652954835/job/38165491473