### PR TITLE
ci: add verify-spdx-headers action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -57,6 +57,6 @@ jobs:
           for file in $(git diff --name-only ${{ github.event.before }} ${{ github.sha }}); do
             if [[ -f "$file" ]]; then
               echo "Checking $file"
-              python .github/workflows/verify-spdx-headers "$file"
+              python .github/workflows/verify-spdx-headers.py "$file"
             fi
           done

--- a/.github/workflows/verify-spdx-headers.py
+++ b/.github/workflows/verify-spdx-headers.py
@@ -40,6 +40,9 @@ class Language:
         Args:
             *comments (str): Variable length argument list of comment delimiters. Each comment can be a string or a tuple of strings.
             shebang (bool): Optional; If True, indicates that the file may contain a shebang line. Defaults to False.
+
+        Raises:
+            SystemExit: If the shebang argument is not a boolean.
         """
         if not isinstance(shebang, bool):
             print("The shebang argument must be a boolean value!")
@@ -275,15 +278,15 @@ def is_license_valid(license: str, valid_licenses: list[str], path: str) -> bool
         path (str): The file path being checked.
 
     Returns:
-        bool: Returns True if the license is not valid, otherwise returns False.
+        bool: Returns True if the license is valid, otherwise returns False.
     """
     if license not in valid_licenses:
         if license is None:
             print(f"NO SPDX {path}")
         else:
             print(f"{license:16} {path} not in {valid_licenses}")
-        return True
-    return False
+        return False
+    return True
 
 
 def is_copyright_valid(copyright: str, valid_holders: list[str], path: str) -> bool:
@@ -324,16 +327,15 @@ if __name__ == "__main__":
         copyright_holders = json.loads(copyright_holders)
     if ignore:
         ignore = json.loads(ignore)
-    if licenses is None:
-        licenses = sys.argv[1:]
-    else:
+    if licenses:
         licenses = json.loads(licenses)
     for license in licenses:
         if not SLUG.match(license):
             print("Invalid license '%s'!" % license)
             raise SystemExit(1)
 
-    rv = 0
+    valid = True
+    rv = 1
 
     index = Index(ignore=ignore)
     path_to_scan = "."
@@ -341,11 +343,13 @@ if __name__ == "__main__":
         path_to_scan = sys.argv[1:][-1]
     if os.path.isdir(path_to_scan):
         for path, (license, copyright) in index.scan_directory(path_to_scan):
-            rv |= is_license_valid(license, licenses, path)
-            rv |= is_copyright_valid(copyright, copyright_holders, path)
+            valid &= is_license_valid(license, licenses, path)
+            valid &= is_copyright_valid(copyright, copyright_holders, path)
     elif os.path.isfile(path_to_scan):
         license, copyright = index.scan_file(path_to_scan)
-        rv |= is_license_valid(license, licenses, path_to_scan)
-        rv |= is_copyright_valid(copyright, copyright_holders, path_to_scan)
+        valid &= is_license_valid(license, licenses, path_to_scan)
+        valid &= is_copyright_valid(copyright, copyright_holders, path_to_scan)
 
-    raise SystemExit(rv)
+    if valid:
+        rv = 0
+    exit(rv)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,3 +97,18 @@ repos:
           ]
         language: python
         types: [text]
+
+  - repo: local
+    hooks:
+      - id: verify-spdx-headers
+        name: Verify SPDX Headers
+        entry: |
+          env INPUT_LICENSES='["Apache-2.0", "GPL-3.0-or-later"]'
+          env IGNORE_DIRS='[".git", "fuzz", "test"]'
+          env COPYRIGHT_HOLDERS='["Intel Corporation"]'
+          python .github/workflows/verify-spdx-headers.py
+        language: system
+        files: \.py$
+        pass_filenames: true
+        stages: [pre-commit]
+        additional_dependencies: []


### PR DESCRIPTION
Add SPDX header verification to the CI pipeline. This action will check all changed files for SPDX headers and verify that the license and copyright holders are correct.

The original script from the [recommended repo](https://github.com/enarx/spdx/blob/master/verify-spdx-headers) did not seem to fit our needs out of the box. so we decided to bring the script into the cve-bin-tool repo and adapt it.  We could have others contribute to the original repo to fix these issues in the future. 

Some changes include: 
- Scanning files in addition to directories
- Verifying copyright holders
- Adding docstrings
- Fixing warnings
- Improving code quality and robustness
- Adding typing

Co-authored-by: Thomas, Hailee <hailee.thomas@intel.com>
Signed-off-by: Patel, Narendra <narendra.g.patel@intel.com>
Signed-off-by: Courier, Taylor <taylor.courier@intel.com>

fixes: #4219