### PR TITLE
feat: improve wording and accessibility in HTML report template

### DIFF
--- a/cve_bin_tool/output_engine/html_reports/templates/base.html
+++ b/cve_bin_tool/output_engine/html_reports/templates/base.html
@@ -206,7 +206,7 @@
                         <div class="row">
                             <div class="col-12">
                                 Let us know by creating a new issue.
-                                <p><a href="https://github.com/intel/cve-bin-tool/issues/new" class="btn btn-light btn-sm " target="_blank" rel="noopener noreferrer"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-exclamation-circle text-success" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                <p><a href="https://github.com/intel/cve-bin-tool/issues/new" class="btn btn-light btn-sm " target="_blank" rel="noopener noreferrer" role="button" aria-label="Create New Issue"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-exclamation-circle text-success" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                             <path fill-rule="evenodd" d="M8 15A7 7 0 1 0 8 1a7 7 0 0 0 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
                             <path d="M7.002 11a1 1 0 1 1 2 0 1 1 0 0 1-2 0zM7.1 4.995a.905.905 0 1 1 1.8 0l-.35 3.507a.552.552 0 0 1-1.1 0L7.1 4.995z"/>
                             </svg> New Issue</a></p>
@@ -220,8 +220,8 @@
                         <hr  \>
                         <div class="row">
                             <div class="col-12">
-                                Our community will love to hear your invaluable suggestions.
-                                <p><a href="https://gitter.im/cve-bin-tool/community" class="btn btn-light btn-sm" target="_blank" rel="noopener noreferrer"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-chat-left-text-fill text-primary" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                Our community would love to hear your invaluable suggestions.
+                                <p><a href="https://gitter.im/cve-bin-tool/community" class="btn btn-light btn-sm" target="_blank" rel="noopener noreferrer" role="button" aria-label="Navigate to Gitter"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-chat-left-text-fill text-primary" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                                 <path fill-rule="evenodd" d="M0 2a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4.414a1 1 0 0 0-.707.293L.854 15.146A.5.5 0 0 1 0 14.793V2zm3.5 1a.5.5 0 0 0 0 1h9a.5.5 0 0 0 0-1h-9zm0 2.5a.5.5 0 0 0 0 1h9a.5.5 0 0 0 0-1h-9zm0 2.5a.5.5 0 0 0 0 1h5a.5.5 0 0 0 0-1h-5z"/>
                                 </svg> Gitter</a></p> 
                             </div>
@@ -231,12 +231,12 @@
                 </div>
                 <div class="col-4">
                     <div class="container">
-                        <h4>How to Contribute?</h4>
+                        <h4>Want to Contribute?</h4>
                         <hr \>
                         <div class="row">
                             <div class="col-12">
-                                A good Open Source project always welcome contributors. We cve-bin-tool community welcome new ideas and contribution. Join us to learn about security vulnerabilities in your binaries.
-                                <p><a href="https://github.com/intel/cve-bin-tool/issues/new" class="btn btn-light btn-sm " target="_blank" rel="noopener noreferrer"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-file-earmark-binary" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                                The cve-bin-tool community always welcomes new ideas and contributors. Join us to learn about security vulnerabilities in your binaries.
+                                <p><a href="https://github.com/intel/cve-bin-tool" class="btn btn-light btn-sm " target="_blank" rel="noopener noreferrer" role="button" aria-label="Navigate to GitHub Repository"><svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-file-earmark-binary" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                                 <path d="M4 1h5v1H4a1 1 0 0 0-1 1v10a1 1 0 0 0 1 1h8a1 1 0 0 0 1-1V6h1v7a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2z"/>
                                 <path d="M9 4.5V1l5 5h-3.5A1.5 1.5 0 0 1 9 4.5zm-3.474 8.59c.976 0 1.524-.79 1.524-2.205 0-1.412-.548-2.203-1.524-2.203-.978 0-1.526.79-1.526 2.203 0 1.415.548 2.206 1.526 2.206zm-.832-2.205c0-1.05.29-1.612.832-1.612.358 0 .607.247.733.721L4.7 11.137a6.749 6.749 0 0 1-.006-.252zm.832 1.614c-.36 0-.606-.246-.732-.718l1.556-1.145c.003.079.005.164.005.249 0 1.052-.29 1.614-.829 1.614zm5.329.501v-.595H9.73V8.772h-.69l-1.19.786v.688L8.986 9.5h.05v2.906h-1.18V13h3z"/>
                                 </svg> GitHub</a></p>
@@ -248,7 +248,7 @@
             <div class="row text-center text-dark">
                 <div class="col-12 m-t-10">
                     <p>This report was generated with 
-                        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-heart-fill text-danger" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                        <svg width="1em" height="1em" viewBox="0 0 16 16" class="bi bi-heart-fill text-danger" fill="currentColor" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="Heart">
                         <path fill-rule="evenodd" d="M8 1.314C12.438-3.248 23.534 4.735 8 15-7.534 4.736 3.562-3.248 8 1.314z"></path>
                         </svg> | cve-bin-tool.
                     </p>


### PR DESCRIPTION
- Improved footer wording
- Implemented minor accessibility features to the footer buttons
- Replaced the GitHub link (previously linked to new issue), to link to the GitHub repository

Not sure if this is a fix or a feature due to adding accessibility so I'll let maintainers decide 😅 

New:
![image](https://github.com/user-attachments/assets/60e1cb94-e5b2-418b-9111-be8e99c487f6)


Old:
![image](https://github.com/user-attachments/assets/4ac1fd68-ef11-4779-b10a-ebd305a71e3a)


