### PR TITLE
test: add invalid package to test language scanner

### DIFF
--- a/test/language_data/invalid-package-lock.json
+++ b/test/language_data/invalid-package-lock.json
@@ -1,0 +1,4 @@
+{
+    "invalid": "something isn't right here",
+    "alsoInvalid": "this is not a valid package-lock.json file"
+}

--- a/test/test_language_scanner.py
+++ b/test/test_language_scanner.py
@@ -199,10 +199,25 @@ class TestLanguageScanner:
         scanner = VersionScanner()
         scanner.file_stack.append(filename)
         product = None
+
         # Not expecting any product to match with a vendor in the database
         for product in scanner.scan_file(filename):
             pass
         assert product is not None
+
+    @pytest.mark.parametrize(
+        "filename", ((str(TEST_FILE_PATH / "invalid-package-lock.json")),)
+    )
+    def test_invalid_javascript_package(self, filename: str) -> None:
+        """Test an invalid package-lock.json file
+
+        The parser should gracefully handle invalid package-lock.json files.
+        """
+        scanner = VersionScanner()
+        scanner_output = scanner.scan_file(filename)
+
+        for product in scanner_output:
+            assert product is None
 
     @pytest.mark.parametrize(
         "filename",


### PR DESCRIPTION
Add test for invalid package-lock.json handling. As mentioned in #4787, I was planning to take this on during the Intel hackathon, but forgot to submit this in time.  

Please let me know if you'd like this handled in a different way, e.g. commit to the other PR's fork, help the other contributor get their PR merged, close this for someone else to work on, etc.

fixes: #3932