### PR TITLE
fix(mismatch): ignore CVE-2024-13223 for tabulate

### DIFF
--- a/mismatch_data/pypi/tabulate/mismatch_relations.yml
+++ b/mismatch_data/pypi/tabulate/mismatch_relations.yml
@@ -1,0 +1,4 @@
+purls:
+  - pkg:pypi/tabulate
+invalid_vendors:
+  - samwilson


### PR DESCRIPTION
CVE-2024-13223 is for a WordPress plugin by vendor `samwilson`, but it was incorrectly matched to the Python package `tabulate` due to name similarity.

This mismatch entry excludes the invalid vendor `samwilson` for `pkg:pypi/tabulate` to prevent a false positive.

Fixes: #5082
